### PR TITLE
Fix duplicate hooks file error in core-hooks plugin

### DIFF
--- a/core-hooks/.claude-plugin/plugin.json
+++ b/core-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks for Claude Code",
-  "version": "1.0.0",
-  "hooks": "./hooks/hooks.json"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Remove explicit hooks field from plugin.json since hooks/hooks.json at the standard location is auto-discovered by the plugin system.

This fixes the "Duplicate hooks file detected" error when installing the core-hooks plugin.