### PR TITLE
Add productivity-skills plugin for macOS Calendar and Reminders

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -24,6 +24,10 @@
     {
       "name": "core-hooks",
       "source": "./core-hooks"
+    },
+    {
+      "name": "productivity-skills",
+      "source": "./productivity-skills"
     }
   ]
 }

--- a/productivity-skills/.claude-plugin/plugin.json
+++ b/productivity-skills/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "productivity-skills",
+  "description": "macOS productivity skills for managing Calendar events and Reminders via AppleScript",
+  "version": "1.0.0"
+}

--- a/productivity-skills/skills/calendar-manager/SKILL.md
+++ b/productivity-skills/skills/calendar-manager/SKILL.md
@@ -239,8 +239,12 @@ tell application "Calendar"
         set minutes of dayStart to 0
         set dayEnd to dayStart + (1 * days)
 
-        set evt to first event whose start date >= dayStart and start date < dayEnd
-        return {title:(summary of evt), startDate:(start date of evt), endDate:(end date of evt), location:(location of evt), notes:(description of evt)}
+        try
+            set evt to first event whose start date >= dayStart and start date < dayEnd
+            return {title:(summary of evt), startDate:(start date of evt), endDate:(end date of evt), location:(location of evt), notes:(description of evt)}
+        on error
+            return "No matching event found."
+        end try
     end tell
 end tell
 EOF

--- a/productivity-skills/skills/calendar-manager/SKILL.md
+++ b/productivity-skills/skills/calendar-manager/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: calendar-manager
+description: Manage macOS Calendar app events via AppleScript. Use this skill when the user wants to create calendar events, add meetings, schedule appointments, check calendar availability, list upcoming events, search for events by date or title, update event details, or delete calendar entries. Supports setting event details like title, start/end times, location, notes, and alarms. Requires macOS and Calendar.app automation permissions.
+---
+
+# Calendar Manager
+
+Manage macOS Calendar events using AppleScript.
+
+## Important: Always Ask for Calendar Name
+
+Before any operation, list calendars and ask the user which one to use:
+
+```bash
+osascript -e 'tell application "Calendar" to get name of calendars'
+```
+
+## Common Patterns
+
+### Permissions
+
+First run prompts for Calendar access. Grant in **System Settings > Privacy & Security > Automation**.
+
+### Date Handling
+
+```applescript
+-- Normalize date to midnight (start of day)
+set dayStart to current date  -- or: date "January 15, 2025"
+set hours of dayStart to 0
+set minutes of dayStart to 0
+set seconds of dayStart to 0
+
+-- End of day (for range queries)
+set dayEnd to dayStart + (1 * days)
+
+-- Date formats accepted:
+-- date "January 15, 2025 2:00 PM"
+-- date "1/15/2025 14:00"
+-- current date
+-- current date + (1 * days)
+-- current date + (2 * hours)
+```
+
+## Operations
+
+### List All Calendars
+
+```bash
+osascript -e 'tell application "Calendar" to get name of calendars'
+```
+
+### Create an Event
+
+**Basic event:**
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    tell calendar "CALENDAR_NAME"
+        set startDate to current date
+        set hours of startDate to 14
+        set minutes of startDate to 0
+        set seconds of startDate to 0
+        set endDate to startDate + (1 * hours)
+
+        make new event at end with properties {summary:"Meeting Title", start date:startDate, end date:endDate}
+    end tell
+end tell
+EOF
+```
+
+**Event with location and notes:**
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    tell calendar "CALENDAR_NAME"
+        set startDate to date "January 15, 2025 2:00 PM"
+        set endDate to date "January 15, 2025 3:00 PM"
+
+        make new event at end with properties {summary:"Team Meeting", start date:startDate, end date:endDate, location:"Conference Room A", description:"Weekly sync meeting"}
+    end tell
+end tell
+EOF
+```
+
+**All-day event:**
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    tell calendar "CALENDAR_NAME"
+        -- Normalize to midnight (see Common Patterns)
+        set eventDate to date "January 20, 2025"
+        set hours of eventDate to 0
+        set minutes of eventDate to 0
+        set seconds of eventDate to 0
+        set endEventDate to eventDate + (1 * days)
+
+        make new event at end with properties {summary:"Company Holiday", start date:eventDate, end date:endEventDate, allday event:true}
+    end tell
+end tell
+EOF
+```
+
+**Event with alarm:**
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    tell calendar "CALENDAR_NAME"
+        set startDate to date "January 15, 2025 2:00 PM"
+        set endDate to date "January 15, 2025 3:00 PM"
+
+        set newEvent to make new event at end with properties {summary:"Important Meeting", start date:startDate, end date:endDate}
+
+        tell newEvent
+            make new display alarm at end with properties {trigger interval:-15}
+        end tell
+    end tell
+end tell
+EOF
+```
+
+### Search Events
+
+**Events on a specific date:**
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    -- Normalize to midnight (see Common Patterns)
+    set dayStart to date "January 15, 2025"
+    set hours of dayStart to 0
+    set minutes of dayStart to 0
+    set seconds of dayStart to 0
+    set dayEnd to dayStart + (1 * days)
+
+    set matchingEvents to {}
+    repeat with cal in calendars
+        set calEvents to (every event of cal whose start date >= dayStart and start date < dayEnd)
+        repeat with evt in calEvents
+            set end of matchingEvents to {calName:(name of cal), eventName:(summary of evt), startTime:(start date of evt)}
+        end repeat
+    end repeat
+    return matchingEvents
+end tell
+EOF
+```
+
+**Events in a date range:**
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    set rangeStart to date "January 1, 2025"
+    set rangeEnd to date "January 31, 2025"
+
+    set matchingEvents to {}
+    repeat with cal in calendars
+        set calEvents to (every event of cal whose start date >= rangeStart and start date <= rangeEnd)
+        repeat with evt in calEvents
+            set end of matchingEvents to {calName:(name of cal), eventName:(summary of evt), startTime:(start date of evt)}
+        end repeat
+    end repeat
+    return matchingEvents
+end tell
+EOF
+```
+
+**Today's events:**
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    -- Normalize to midnight (see Common Patterns)
+    set today to current date
+    set hours of today to 0
+    set minutes of today to 0
+    set seconds of today to 0
+    set tomorrow to today + (1 * days)
+
+    set todayEvents to {}
+    repeat with cal in calendars
+        set calEvents to (every event of cal whose start date >= today and start date < tomorrow)
+        repeat with evt in calEvents
+            set end of todayEvents to {calendar:(name of cal), title:(summary of evt), time:(start date of evt)}
+        end repeat
+    end repeat
+    return todayEvents
+end tell
+EOF
+```
+
+**Search by title:**
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    set searchTerm to "meeting"
+    set matchingEvents to {}
+
+    repeat with cal in calendars
+        set calEvents to (every event of cal whose summary contains searchTerm)
+        repeat with evt in calEvents
+            set end of matchingEvents to {calendar:(name of cal), title:(summary of evt), time:(start date of evt)}
+        end repeat
+    end repeat
+    return matchingEvents
+end tell
+EOF
+```
+
+### Delete an Event
+
+**Delete by title on a specific date:**
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    tell calendar "CALENDAR_NAME"
+        -- Normalize to midnight (see Common Patterns)
+        set dayStart to date "January 15, 2025"
+        set hours of dayStart to 0
+        set minutes of dayStart to 0
+        set dayEnd to dayStart + (1 * days)
+
+        set eventsToDelete to (every event whose summary is "Meeting Title" and start date >= dayStart and start date < dayEnd)
+        repeat with evt in eventsToDelete
+            delete evt
+        end repeat
+    end tell
+end tell
+EOF
+```
+
+**Note:** Events from shared/subscribed calendars may not be deletable.
+
+### Get Event Details
+
+```bash
+osascript <<'EOF'
+tell application "Calendar"
+    tell calendar "CALENDAR_NAME"
+        -- Normalize to midnight (see Common Patterns)
+        set dayStart to date "January 15, 2025"
+        set hours of dayStart to 0
+        set minutes of dayStart to 0
+        set dayEnd to dayStart + (1 * days)
+
+        set evt to first event whose start date >= dayStart and start date < dayEnd
+        return {title:(summary of evt), startDate:(start date of evt), endDate:(end date of evt), location:(location of evt), notes:(description of evt)}
+    end tell
+end tell
+EOF
+```
+
+## Event Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| summary | text | Event title |
+| start date | date | When event starts |
+| end date | date | When event ends |
+| location | text | Event location |
+| description | text | Event notes |
+| allday event | boolean | All-day event flag |
+| url | text | Associated URL |
+
+## Notes
+
+- Always list calendars first and confirm with user
+- Invalid calendar names cause errors
+- Use explicit date format when in doubt: `date "Month Day, Year Hour:Minute AM/PM"`

--- a/productivity-skills/skills/reminder-manager/SKILL.md
+++ b/productivity-skills/skills/reminder-manager/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: reminder-manager
+description: Manage macOS Reminders app via AppleScript. Use this skill when the user wants to create reminders, add tasks, add todos, set due dates, check pending tasks, list reminder lists, view overdue reminders, mark tasks as complete, or delete reminders. Supports setting due dates, priorities, and notes. Requires macOS and Reminders.app automation permissions.
+---
+
+# Reminder Manager
+
+Manage macOS Reminders using AppleScript.
+
+## Important: Always Ask for Reminder List
+
+Before any operation, list reminder lists and ask the user which one to use:
+
+```bash
+osascript -e 'tell application "Reminders" to get name of lists'
+```
+
+## Common Patterns
+
+### Permissions
+
+First run prompts for Reminders access. Grant in **System Settings > Privacy & Security > Automation**.
+
+### Date Handling
+
+```applescript
+-- Normalize date to midnight (start of day)
+set dayStart to current date
+set hours of dayStart to 0
+set minutes of dayStart to 0
+set seconds of dayStart to 0
+
+-- End of day (for range queries)
+set dayEnd to dayStart + (1 * days)
+
+-- Date formats accepted:
+-- date "January 15, 2025 5:00 PM"
+-- current date
+-- current date + (1 * days)
+```
+
+### Priority Values
+
+| Value | Meaning |
+|-------|---------|
+| 0 | No priority |
+| 1 | High (!!!) |
+| 5 | Medium (!!) |
+| 9 | Low (!) |
+
+## Operations
+
+### List All Reminder Lists
+
+```bash
+osascript -e 'tell application "Reminders" to get name of lists'
+```
+
+### List Reminders
+
+**Incomplete reminders in a list:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        set incompleteReminders to (reminders whose completed is false)
+        set reminderInfo to {}
+        repeat with r in incompleteReminders
+            set end of reminderInfo to {title:(name of r), dueDate:(due date of r), priority:(priority of r)}
+        end repeat
+        return reminderInfo
+    end tell
+end tell
+EOF
+```
+
+**All reminders (including completed):**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        set allReminders to every reminder
+        set reminderInfo to {}
+        repeat with r in allReminders
+            set end of reminderInfo to {title:(name of r), completed:(completed of r), dueDate:(due date of r)}
+        end repeat
+        return reminderInfo
+    end tell
+end tell
+EOF
+```
+
+**Reminders due today:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    -- Normalize to midnight (see Common Patterns)
+    set today to current date
+    set hours of today to 0
+    set minutes of today to 0
+    set seconds of today to 0
+    set tomorrow to today + (1 * days)
+
+    set dueToday to {}
+    repeat with lst in lists
+        set lstReminders to (reminders of lst whose due date >= today and due date < tomorrow and completed is false)
+        repeat with r in lstReminders
+            set end of dueToday to {list:(name of lst), title:(name of r), dueDate:(due date of r)}
+        end repeat
+    end repeat
+    return dueToday
+end tell
+EOF
+```
+
+**Overdue reminders:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    set now to current date
+    set overdueReminders to {}
+    repeat with lst in lists
+        set lstReminders to (reminders of lst whose due date < now and completed is false)
+        repeat with r in lstReminders
+            set end of overdueReminders to {list:(name of lst), title:(name of r), dueDate:(due date of r)}
+        end repeat
+    end repeat
+    return overdueReminders
+end tell
+EOF
+```
+
+### Create a Reminder
+
+**Basic reminder:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        make new reminder with properties {name:"Buy groceries"}
+    end tell
+end tell
+EOF
+```
+
+**With due date:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        set dueDate to date "January 15, 2025 5:00 PM"
+        make new reminder with properties {name:"Submit report", due date:dueDate}
+    end tell
+end tell
+EOF
+```
+
+**With relative due date:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        set dueDate to (current date) + (1 * days)
+        make new reminder with properties {name:"Follow up on email", due date:dueDate}
+    end tell
+end tell
+EOF
+```
+
+**With priority:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        -- Priority: 0=none, 1=high, 5=medium, 9=low (see Common Patterns)
+        make new reminder with properties {name:"Urgent task", priority:1}
+    end tell
+end tell
+EOF
+```
+
+**With notes:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        make new reminder with properties {name:"Call John", body:"Discuss project timeline and budget"}
+    end tell
+end tell
+EOF
+```
+
+**Full reminder with all properties:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        set dueDate to date "January 15, 2025 9:00 AM"
+        make new reminder with properties {name:"Team meeting prep", due date:dueDate, priority:1, body:"Prepare slides and agenda"}
+    end tell
+end tell
+EOF
+```
+
+### Mark Reminder as Complete
+
+**By name:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        set targetReminder to first reminder whose name is "Buy groceries"
+        set completed of targetReminder to true
+    end tell
+end tell
+EOF
+```
+
+**Complete all in a list:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        set incompleteReminders to (reminders whose completed is false)
+        repeat with r in incompleteReminders
+            set completed of r to true
+        end repeat
+    end tell
+end tell
+EOF
+```
+
+### Mark Reminder as Incomplete
+
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        set targetReminder to first reminder whose name is "Buy groceries"
+        set completed of targetReminder to false
+    end tell
+end tell
+EOF
+```
+
+### Delete a Reminder
+
+**By name:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        delete (first reminder whose name is "Buy groceries")
+    end tell
+end tell
+EOF
+```
+
+**Delete all completed:**
+```bash
+osascript -e 'tell application "Reminders" to delete (reminders whose completed is true)'
+```
+
+**Delete completed in a specific list:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        delete (reminders whose completed is true)
+    end tell
+end tell
+EOF
+```
+
+### Create a New Reminder List
+
+```bash
+osascript -e 'tell application "Reminders" to make new list with properties {name:"New List Name"}'
+```
+
+### Get Reminder Count
+
+**Incomplete in a list:**
+```bash
+osascript <<'EOF'
+tell application "Reminders"
+    tell list "LIST_NAME"
+        count of (reminders whose completed is false)
+    end tell
+end tell
+EOF
+```
+
+**All reminders:**
+```bash
+osascript -e 'tell application "Reminders" to count of reminders'
+```
+
+## Reminder Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| name | text | Reminder title |
+| body | text | Notes/description |
+| due date | date | When reminder is due |
+| remind me date | date | When to show alert |
+| priority | integer | 0=none, 1=high, 5=medium, 9=low |
+| completed | boolean | Whether reminder is done |
+| completion date | date | When marked complete |
+| flagged | boolean | Whether flagged |
+
+## Limitations
+
+- **Tags:** Not supported via AppleScript
+- **Location-based reminders:** Cannot be created
+- **Subtasks:** Not accessible
+- **Attachments:** Cannot be added
+
+## Notes
+
+- Always list reminder lists first and confirm with user
+- Invalid list names cause errors
+- Searching by name errors if no match; use try blocks for robustness

--- a/productivity-skills/skills/reminder-manager/SKILL.md
+++ b/productivity-skills/skills/reminder-manager/SKILL.md
@@ -209,8 +209,12 @@ EOF
 osascript <<'EOF'
 tell application "Reminders"
     tell list "LIST_NAME"
-        set targetReminder to first reminder whose name is "Buy groceries"
-        set completed of targetReminder to true
+        try
+            set targetReminder to first reminder whose name is "Buy groceries"
+            set completed of targetReminder to true
+        on error
+            return "Reminder not found."
+        end try
     end tell
 end tell
 EOF
@@ -236,8 +240,12 @@ EOF
 osascript <<'EOF'
 tell application "Reminders"
     tell list "LIST_NAME"
-        set targetReminder to first reminder whose name is "Buy groceries"
-        set completed of targetReminder to false
+        try
+            set targetReminder to first reminder whose name is "Buy groceries"
+            set completed of targetReminder to false
+        on error
+            return "Reminder not found."
+        end try
     end tell
 end tell
 EOF
@@ -250,7 +258,11 @@ EOF
 osascript <<'EOF'
 tell application "Reminders"
     tell list "LIST_NAME"
-        delete (first reminder whose name is "Buy groceries")
+        try
+            delete (first reminder whose name is "Buy groceries")
+        on error
+            return "Reminder not found."
+        end try
     end tell
 end tell
 EOF


### PR DESCRIPTION
New plugin with two skills for managing macOS Calendar and Reminders via AppleScript:

- **calendar-manager**: Create, search, list, and delete calendar events
- **reminder-manager**: Create, list, complete, and delete reminders

Both skills include comprehensive AppleScript examples and always prompt user to specify which calendar/list to use.