### PR TITLE
Add pymol-skills plugin with MCP server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,6 +28,10 @@
     {
       "name": "productivity-skills",
       "source": "./productivity-skills"
+    },
+    {
+      "name": "pymol-skills",
+      "source": "./pymol-skills"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,22 @@ cc-toolkit/
 │   └── agents/
 │       ├── paper-reader.md
 │       └── paper-consolidator.md
+├── productivity-skills/                 # Personal productivity plugin
+│   ├── .claude-plugin/
+│   │   └── plugin.json
+│   └── skills/
+│       ├── calendar-manager/
+│       │   └── SKILL.md
+│       └── reminder-manager/
+│           └── SKILL.md
+├── pymol-skills/                        # PyMOL molecular visualization plugin
+│   ├── .claude-plugin/
+│   │   └── plugin.json
+│   ├── skills/
+│   │   └── pymol-mcp/
+│   │       └── SKILL.md
+│   └── commands/
+│       └── setup.md
 ├── logs/                                # Claude Code execution logs
 ├── trees/                               # Git worktrees for active development
 └── README.md                            # Project overview

--- a/README.md
+++ b/README.md
@@ -33,16 +33,29 @@ cc-toolkit/
 │   └── agents/
 │       ├── paper-reader.md
 │       └── paper-consolidator.md
-└── core-hooks/                     # Safety and workflow hooks plugin
+├── core-hooks/                     # Safety and workflow hooks plugin
+│   ├── .claude-plugin/
+│   │   └── plugin.json
+│   ├── hooks/
+│   │   └── hooks.json
+│   └── scripts/
+│       ├── safety_guard.py
+│       ├── pre_git_hook.py
+│       ├── post_tool_use.py
+│       └── system_notification.py
+├── productivity-skills/            # Personal productivity plugin
+│   ├── .claude-plugin/
+│   │   └── plugin.json
+│   └── skills/
+│       ├── calendar-manager/
+│       └── reminder-manager/
+└── pymol-skills/                   # PyMOL molecular visualization plugin
     ├── .claude-plugin/
     │   └── plugin.json
-    ├── hooks/
-    │   └── hooks.json
-    └── scripts/
-        ├── safety_guard.py
-        ├── pre_git_hook.py
-        ├── post_tool_use.py
-        └── system_notification.py
+    ├── skills/
+    │   └── pymol-mcp/
+    └── commands/
+        └── setup.md
 ```
 
 ## Available Plugins
@@ -81,6 +94,22 @@ Safety guards and workflow enforcement hooks.
 - **post_tool_use.py**: Logs tool executions to `logs/post_tool_use.json`
 - **system_notification.py**: Plays sound notifications on task completion
 
+### Productivity Skills (`productivity-skills`)
+Personal productivity automation using macOS Calendar and Reminders.
+
+**Skills:**
+- **calendar-manager**: Manage macOS Calendar events via EventKit CLI
+- **reminder-manager**: Manage macOS Reminders via EventKit CLI
+
+### PyMOL Skills (`pymol-skills`)
+PyMOL molecular visualization control via MCP server.
+
+**Skills:**
+- **pymol-mcp**: Control PyMOL through natural language for protein visualization and structural analysis
+
+**Commands:**
+- **/pymol-skills:setup**: Installation instructions for PyMOL socket plugin
+
 ## Plugin System Benefits
 
 1. **Modular**: Each plugin is self-contained and portable
@@ -100,3 +129,5 @@ Each plugin can be used independently by referencing its directory:
 - `./creator-skills`
 - `./doc-skills`
 - `./core-hooks`
+- `./productivity-skills`
+- `./pymol-skills`

--- a/pymol-skills/.claude-plugin/plugin.json
+++ b/pymol-skills/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "pymol-skills",
+  "description": "PyMOL molecular visualization and analysis tools integrated via MCP server",
+  "version": "1.0.0",
+  "mcpServers": "./mcp-config.json"
+}

--- a/pymol-skills/README.md
+++ b/pymol-skills/README.md
@@ -2,45 +2,20 @@
 
 PyMOL molecular visualization and analysis tools integrated via MCP server. Enables Claude to directly interact with and control PyMOL through natural language.
 
+## Quick Start
+
+Run `/pymol-skills:setup` for installation instructions.
+
+## Components
+
+- **MCP Server** (`pymol_mcp_server.py`): FastMCP server providing PyMOL tools
+- **Socket Plugin** (`pymol-mcp-socket-plugin/`): PyMOL plugin for socket communication
+- **Skill** (`skills/pymol-mcp/`): Usage guidance and workflow examples
+
 ## Prerequisites
 
 - [PyMOL](https://pymol.org/2/) installed on your system
-- [Claude Code](https://claude.ai/code) or Claude Desktop
 - [UV](https://docs.astral.sh/uv/getting-started/installation/) package manager
-
-## Installation
-
-### Step 1: Install PyMOL Socket Plugin
-
-1. Open PyMOL
-2. Go to **Plugin > Plugin Manager > Install New Plugin**
-3. Click **Choose file...** and select `pymol-mcp-socket-plugin/__init__.py`
-4. Click **OK** to install
-
-To activate: **Plugin > PyMOL MCP Socket Plugin > Start Listening**
-
-### Step 2: Enable the Plugin
-
-The MCP server is automatically available when this plugin is installed in Claude Code.
-
-## Usage
-
-1. **Start PyMOL** and activate the plugin (Plugin > PyMOL MCP Socket Plugin > Start Listening)
-2. **Open Claude Code** - PyMOL tools will be available
-3. **Use natural language** to control PyMOL:
-   - "Load PDB 1UBQ and display it as cartoon"
-   - "Color the protein by secondary structure"
-   - "Show the active site residues as sticks"
-
-## MCP Tools
-
-- `pymol_command`: Execute direct PyMOL commands (e.g., `fetch 1ubq`, `show cartoon`)
-- `pymol_python_api`: Execute PyMOL Python API commands (e.g., `cmd.fetch('1ubq')`)
-
-## Troubleshooting
-
-- **No connection**: Ensure PyMOL plugin shows "Listening on port 9876" before using Claude
-- **Tools not appearing**: Restart Claude Code after plugin installation
 
 ## Attribution
 

--- a/pymol-skills/README.md
+++ b/pymol-skills/README.md
@@ -1,0 +1,51 @@
+# PyMOL MCP Plugin
+
+PyMOL molecular visualization and analysis tools integrated via MCP server. Enables Claude to directly interact with and control PyMOL through natural language.
+
+## Prerequisites
+
+- [PyMOL](https://pymol.org/2/) installed on your system
+- [Claude Code](https://claude.ai/code) or Claude Desktop
+- [UV](https://docs.astral.sh/uv/getting-started/installation/) package manager
+
+## Installation
+
+### Step 1: Install PyMOL Socket Plugin
+
+1. Open PyMOL
+2. Go to **Plugin > Plugin Manager > Install New Plugin**
+3. Click **Choose file...** and select `pymol-mcp-socket-plugin/__init__.py`
+4. Click **OK** to install
+
+To activate: **Plugin > PyMOL MCP Socket Plugin > Start Listening**
+
+### Step 2: Enable the Plugin
+
+The MCP server is automatically available when this plugin is installed in Claude Code.
+
+## Usage
+
+1. **Start PyMOL** and activate the plugin (Plugin > PyMOL MCP Socket Plugin > Start Listening)
+2. **Open Claude Code** - PyMOL tools will be available
+3. **Use natural language** to control PyMOL:
+   - "Load PDB 1UBQ and display it as cartoon"
+   - "Color the protein by secondary structure"
+   - "Show the active site residues as sticks"
+
+## MCP Tools
+
+- `pymol_command`: Execute direct PyMOL commands (e.g., `fetch 1ubq`, `show cartoon`)
+- `pymol_python_api`: Execute PyMOL Python API commands (e.g., `cmd.fetch('1ubq')`)
+
+## Troubleshooting
+
+- **No connection**: Ensure PyMOL plugin shows "Listening on port 9876" before using Claude
+- **Tools not appearing**: Restart Claude Code after plugin installation
+
+## Attribution
+
+Based on [PyMOL-MCP](https://github.com/vrtejus/pymol-mcp) by vrtejus.
+
+## License
+
+MIT License

--- a/pymol-skills/commands/setup.md
+++ b/pymol-skills/commands/setup.md
@@ -1,0 +1,38 @@
+---
+name: setup
+description: Show PyMOL socket plugin installation instructions
+---
+
+Print the following setup instructions to the user:
+
+## PyMOL MCP Plugin Setup
+
+### Step 1: Install PyMOL Socket Plugin
+
+1. Open PyMOL
+2. Go to **Plugin > Plugin Manager > Install New Plugin**
+3. Click **Choose file...** and select:
+   ```
+   ~/.claude/plugins/pymol-skills/pymol-mcp-socket-plugin/__init__.py
+   ```
+4. Click **OK** to install
+
+### Step 2: Start the Socket Listener
+
+Each time you want to use PyMOL with Claude:
+
+1. Open PyMOL
+2. Go to **Plugin > PyMOL MCP Socket Plugin > Start Listening**
+3. You should see "Listening on port 9876" in the status
+
+### Step 3: Use PyMOL Commands
+
+Now you can use natural language to control PyMOL:
+- "Load protein 1UBQ and show as cartoon"
+- "Color chain A red and chain B blue"
+- "Align structure1 to structure2"
+
+### Troubleshooting
+
+- **Connection refused**: Make sure PyMOL plugin is listening before using Claude
+- **Plugin not found**: Reinstall the socket plugin in PyMOL

--- a/pymol-skills/mcp-config.json
+++ b/pymol-skills/mcp-config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pymol-mcp": {
+      "command": "uv",
+      "args": ["run", "${CLAUDE_PLUGIN_ROOT}/pymol_mcp_server.py"],
+      "env": {
+        "PYTHONUNBUFFERED": "1"
+      }
+    }
+  }
+}

--- a/pymol-skills/pymol-mcp-socket-plugin/__init__.py
+++ b/pymol-skills/pymol-mcp-socket-plugin/__init__.py
@@ -1,0 +1,422 @@
+'''
+PyMOL MCP Plugin
+
+A plugin that listens for socket connections and executes PyMOL commands received via socket.
+The plugin also provides a basic UI for interaction.
+
+Based on the concept of the "Rendering Plugin" from Michael Lerner.
+'''
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import socket
+import json
+import threading
+import time
+import traceback
+
+# Global variables
+dialog = None
+socket_server = None
+received_commands = []
+listening = False
+current_port = 9876  # Default port
+
+def __init_plugin__(app=None):
+    '''
+    Add an entry to the PyMOL "Plugin" menu
+    '''
+    from pymol.plugins import addmenuitemqt
+    addmenuitemqt('PyMol MCP Socket Plugin', run_plugin_gui)
+
+class SocketServer:
+    def __init__(self, host='localhost', port=9876):
+        self.host = host
+        self.port = port
+        self.socket = None
+        self.client = None
+        self.running = False
+        self.thread = None
+        self.command_callback = None
+        
+    def start(self, command_callback=None):
+        """Start the socket server on a separate thread"""
+        if self.running:
+            return False
+            
+        self.command_callback = command_callback
+        self.running = True
+        self.thread = threading.Thread(target=self._run_server)
+        self.thread.daemon = True  # Daemon thread will exit when main thread exits
+        self.thread.start()
+        return True
+        
+    def _run_server(self):
+        """Run the socket server in a separate thread"""
+        try:
+            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.socket.bind((self.host, self.port))
+            self.socket.listen(1)
+            self.socket.settimeout(1.0)  # 1 second timeout for accepting connections
+            
+            print(f"PyMOL MCP Socket server listening on {self.host}:{self.port}")
+            
+            while self.running:
+                try:
+                    # Accept connection (with timeout)
+                    self.client, address = self.socket.accept()
+                    print(f"Connected to client: {address}")
+                    self.client.settimeout(1.0)  # Set timeout for receiving data
+                    
+                    # Handle client connection
+                    buffer = b''
+                    while self.running:
+                        try:
+                            data = self.client.recv(4096)
+                            if not data:
+                                break  # Connection closed
+                                
+                            buffer += data
+                            
+                            # Try to parse JSON
+                            try:
+                                command = json.loads(buffer.decode('utf-8'))
+                                buffer = b''  # Reset buffer
+                                
+                                # Process the command and get result
+                                result = self._handle_command(command)
+                                
+                                # Send response with result
+                                response = json.dumps({
+                                    "status": "success", 
+                                    "result": result if result else {"executed": True, "output": "", "error": ""}
+                                })
+                                self.client.sendall(response.encode('utf-8'))
+                            except json.JSONDecodeError:
+                                # Incomplete JSON, continue receiving
+                                continue
+                                
+                        except socket.timeout:
+                            # Socket timeout, just continue the loop
+                            continue
+                        except Exception as e:
+                            print(f"Error receiving data: {str(e)}")
+                            break
+                    
+                    # Close client connection
+                    if self.client:
+                        self.client.close()
+                        self.client = None
+                except socket.timeout:
+                    # No connection waiting, continue
+                    continue
+                except Exception as e:
+                    print(f"Error accepting connection: {str(e)}")
+                    
+        except Exception as e:
+            print(f"Socket server error: {str(e)}")
+            traceback.print_exc()
+        finally:
+            if self.socket:
+                self.socket.close()
+            self.running = False
+            print("Socket server stopped")
+    
+    def _handle_command(self, command):
+        """Handle received command"""
+        if not command:
+            return
+            
+        cmd_type = command.get("type")
+        cmd_code = command.get("code", "")
+        
+        # Save the received command
+        global received_commands
+        received_commands.append(cmd_code)
+        
+        # Execute the PyMOL command if a callback is registered
+        if self.command_callback and cmd_code:
+            result = self.command_callback(cmd_code)
+            return result
+    
+    def stop(self):
+        """Stop the socket server"""
+        self.running = False
+        if self.thread:
+            self.thread.join(2.0)  # Wait up to 2 seconds for thread to exit
+        if self.client:
+            self.client.close()
+        if self.socket:
+            self.socket.close()
+        self.socket = None
+        self.client = None
+        self.thread = None
+        
+def run_plugin_gui():
+    '''
+    Open our custom dialog
+    '''
+    global dialog
+    
+    if dialog is None:
+        dialog = make_dialog()
+    
+    dialog.show()
+
+def make_dialog():
+    # entry point to PyMOL's API
+    from pymol import cmd
+    
+    # pymol.Qt provides the PyQt5 interface, but may support PyQt4
+    # and/or PySide as well
+    from pymol.Qt import QtWidgets
+    from pymol.Qt.utils import loadUi
+    from pymol.Qt.utils import getSaveFileNameWithExt
+    
+    # create a new Window
+    dialog = QtWidgets.QDialog()
+    
+    # populate the Window from our *.ui file which was created with the Qt Designer
+    uifile = os.path.join(os.path.dirname(__file__), 'pymol_mcp_plugin.ui')
+    form = loadUi(uifile, dialog)
+    
+    # Set up socket controls
+    form.input_port.setValue(current_port)
+    update_status_label(form, "Not listening")
+    
+    # Helper function to generate meaningful output for PyMOL commands
+    def generate_meaningful_output(pymol_cmd):
+        """Generate meaningful feedback for PyMOL commands"""
+        if pymol_cmd.startswith('set '):
+            parts = pymol_cmd.split(',')
+            if len(parts) >= 2:
+                setting_name = parts[0].replace('set ', '').strip()
+                setting_value = parts[1].strip()
+                return f"Setting: {setting_name} set to {setting_value}"
+            else:
+                return f"Setting updated: {pymol_cmd}"
+        elif pymol_cmd.startswith('fetch'):
+            structure = pymol_cmd.replace('fetch ', '').split()[0]
+            return f"Fetched structure: {structure}"
+        elif pymol_cmd.startswith('align'):
+            return f"Alignment completed: {pymol_cmd}"
+        elif pymol_cmd.startswith('super'):
+            return f"Superposition completed: {pymol_cmd}"
+        elif pymol_cmd.startswith('show') or pymol_cmd.startswith('hide'):
+            return f"Display representation updated: {pymol_cmd}"
+        elif pymol_cmd.startswith('color'):
+            return f"Coloring applied: {pymol_cmd}"
+        elif pymol_cmd.startswith('bg_color'):
+            color = pymol_cmd.replace('bg_color ', '').strip()
+            return f"Background color changed to: {color}"
+        elif pymol_cmd.startswith('load'):
+            filename = pymol_cmd.replace('load ', '').split()[0]
+            return f"Loaded file: {filename}"
+        elif pymol_cmd.startswith('save'):
+            filename = pymol_cmd.replace('save ', '').split()[0]
+            return f"Saved to file: {filename}"
+        elif pymol_cmd.startswith('select'):
+            selection_name = pymol_cmd.split()[1] if len(pymol_cmd.split()) > 1 else "selection"
+            return f"Selection '{selection_name}' created"
+        elif pymol_cmd.startswith(('distance', 'angle', 'dihedral')):
+            measurement_type = pymol_cmd.split()[0]
+            return f"{measurement_type.capitalize()} measurement created"
+        elif pymol_cmd.startswith('zoom'):
+            return f"View zoomed: {pymol_cmd}"
+        elif pymol_cmd.startswith('orient'):
+            return f"View oriented: {pymol_cmd}"
+        elif pymol_cmd.startswith('reinitialize'):
+            return "PyMOL session reinitialized"
+        elif pymol_cmd.startswith('delete'):
+            target = pymol_cmd.replace('delete ', '').strip()
+            return f"Deleted: {target}"
+        else:
+            return f"Command executed: {pymol_cmd}"
+
+    # Define a function to execute PyMOL commands and capture output
+    def execute_pymol_command(code):
+        try:
+            # Execute in PyMOL with output capture
+            print(f"Executing PyMOL command from MCP:\n{code}")
+            
+            # Prepare the execution environment
+            exec_globals = {"cmd": cmd, "__builtins__": __builtins__}
+            
+            # Capture PyMOL feedback by temporarily redirecting it
+            captured_output = []
+            
+            def capture_feedback(message, category="output"):
+                """Capture PyMOL feedback messages"""
+                captured_output.append(str(message))
+            
+            # Store original feedback function and replace with our capture function
+            original_feedback = getattr(cmd, 'feedback', None)
+            
+            try:
+                # For cmd.do() commands, try to capture PyMOL's actual output
+                if "cmd.do(" in code:
+                    # Extract the command from cmd.do('command')
+                    import re
+                    match = re.search(r"cmd\.do\(['\"](.+)['\"]\)", code)
+                    if match:
+                        pymol_cmd = match.group(1)
+                        
+                        # Try to capture output using a temporary log file
+                        import tempfile
+                        import os
+                        
+                        # Create a temporary file for logging
+                        temp_log = tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix='.pml')
+                        temp_log_path = temp_log.name
+                        temp_log.close()
+                        
+                        try:
+                            # Open logging to capture output
+                            cmd.log_open(temp_log_path)
+                            
+                            # Execute the command
+                            exec(code, exec_globals)
+                            
+                            # Close logging
+                            cmd.log_close()
+                            
+                            # Read the captured output
+                            try:
+                                with open(temp_log_path, 'r') as f:
+                                    log_content = f.read().strip()
+                                
+                                # If we captured something meaningful, use it
+                                if log_content and log_content != pymol_cmd:
+                                    output = f"PyMOL output: {log_content}"
+                                else:
+                                    # Fall back to our meaningful responses
+                                    output = generate_meaningful_output(pymol_cmd)
+                            except:
+                                output = generate_meaningful_output(pymol_cmd)
+                                
+                        finally:
+                            # Clean up temp file
+                            try:
+                                if os.path.exists(temp_log_path):
+                                    os.unlink(temp_log_path)
+                            except:
+                                pass
+                    else:
+                        exec(code, exec_globals)
+                        output = "Command executed successfully"
+                else:
+                    # Regular Python API command
+                    result = exec(code, exec_globals)
+                    if result is not None:
+                        output = str(result)
+                    else:
+                        # Try to provide meaningful feedback for common API commands
+                        if 'cmd.fetch(' in code:
+                            output = f"Structure fetched via API: {code}"
+                        elif 'cmd.align(' in code or 'cmd.super(' in code:
+                            output = f"Alignment completed via API: {code}"
+                        elif 'cmd.show(' in code or 'cmd.hide(' in code:
+                            output = f"Display updated via API: {code}"
+                        elif 'cmd.color(' in code:
+                            output = f"Coloring applied via API: {code}"
+                        elif 'cmd.set(' in code:
+                            output = f"Setting updated via API: {code}"
+                        else:
+                            output = f"Python API command executed: {code}"
+            
+            finally:
+                # Restore original feedback function if it existed
+                if original_feedback:
+                    cmd.feedback = original_feedback
+            
+            # Return captured output or our generated meaningful response
+            if captured_output:
+                final_output = " ".join(captured_output)
+            else:
+                final_output = output
+            
+            print(f"Command output: {final_output}")
+            return {"executed": True, "output": final_output, "error": ""}
+                
+        except Exception as e:
+            error_msg = f"Error executing PyMOL command: {str(e)}"
+            print(error_msg)
+            traceback.print_exc()
+            return {"executed": False, "output": "", "error": error_msg}
+    
+    # Callback for the "Start Listening" button
+    def toggle_listening():
+        global socket_server, listening, current_port
+        
+        if not listening:
+            # Start the socket server
+            port = form.input_port.value()
+            current_port = port
+            
+            socket_server = SocketServer(port=port)
+            if socket_server.start(execute_pymol_command):
+                listening = True
+                form.button_toggle_listening.setText("Stop Listening")
+                update_status_label(form, f"Listening on port {port}")
+        else:
+            # Stop the socket server
+            if socket_server:
+                socket_server.stop()
+            listening = False
+            form.button_toggle_listening.setText("Start Listening")
+            update_status_label(form, "Not listening")
+    
+    # Callback for the "Show Commands" button
+    def show_commands():
+        global received_commands
+        
+        if not received_commands:
+            cmd.feedback("No commands received yet", "output")
+            return
+            
+        # Print all received commands to the PyMOL console
+        cmd.feedback("=== Received Commands ===", "output")
+        for i, command in enumerate(received_commands):
+            cmd.feedback(f"--- Command {i+1} ---", "output")
+            cmd.feedback(command, "output")
+        cmd.feedback("=======================", "output")
+    
+    # Callback for the "Clear Commands" button
+    def clear_commands():
+        global received_commands
+        received_commands = []
+        cmd.feedback("Command history cleared", "output")
+    
+    # Callback for the "Close" button
+    def close_dialog():
+        global socket_server, listening
+        
+        # Stop the socket server if it's running
+        if socket_server and listening:
+            socket_server.stop()
+            listening = False
+        
+        dialog.close()
+    
+    # Hook up button callbacks
+    form.button_toggle_listening.clicked.connect(toggle_listening)
+    # form.button_show_commands.clicked.connect(show_commands)
+    # form.button_clear_commands.clicked.connect(clear_commands)
+    form.button_close.clicked.connect(close_dialog)
+    
+    return dialog
+
+def update_status_label(form, text):
+    """Update the status label with the given text"""
+    form.label_status.setText(text)
+    
+    # Also set a color based on the status
+    if "Not listening" in text:
+        form.label_status.setStyleSheet("color: red;")
+    elif "Listening" in text:
+        form.label_status.setStyleSheet("color: green;")
+    else:
+        form.label_status.setStyleSheet("")

--- a/pymol-skills/pymol-mcp-socket-plugin/__init__.py
+++ b/pymol-skills/pymol-mcp-socket-plugin/__init__.py
@@ -368,28 +368,7 @@ def make_dialog():
             listening = False
             form.button_toggle_listening.setText("Start Listening")
             update_status_label(form, "Not listening")
-    
-    # Callback for the "Show Commands" button
-    def show_commands():
-        global received_commands
-        
-        if not received_commands:
-            cmd.feedback("No commands received yet", "output")
-            return
-            
-        # Print all received commands to the PyMOL console
-        cmd.feedback("=== Received Commands ===", "output")
-        for i, command in enumerate(received_commands):
-            cmd.feedback(f"--- Command {i+1} ---", "output")
-            cmd.feedback(command, "output")
-        cmd.feedback("=======================", "output")
-    
-    # Callback for the "Clear Commands" button
-    def clear_commands():
-        global received_commands
-        received_commands = []
-        cmd.feedback("Command history cleared", "output")
-    
+
     # Callback for the "Close" button
     def close_dialog():
         global socket_server, listening
@@ -403,8 +382,6 @@ def make_dialog():
     
     # Hook up button callbacks
     form.button_toggle_listening.clicked.connect(toggle_listening)
-    # form.button_show_commands.clicked.connect(show_commands)
-    # form.button_clear_commands.clicked.connect(clear_commands)
     form.button_close.clicked.connect(close_dialog)
     
     return dialog

--- a/pymol-skills/pymol-mcp-socket-plugin/pymol_mcp_plugin.ui
+++ b/pymol-skills/pymol-mcp-socket-plugin/pymol_mcp_plugin.ui
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>320</width>
+    <height>320</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">PyMOL MCP Plugin</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>280</width>
+       <height>60</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: #000;color:white; padding: 20px</string>
+     </property>
+     <property name="text">
+      <string notr="true">PyMOL MCP Plugin
+Socket Server for MCP Integration</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string notr="true">Port</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="input_port">
+       <property name="minimum">
+        <number>1024</number>
+       </property>
+       <property name="maximum">
+        <number>65535</number>
+       </property>
+       <property name="value">
+        <number>9876</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string notr="true">Status:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="label_status">
+       <property name="text">
+        <string notr="true">Not listening</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">color: red;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="button_toggle_listening">
+       <property name="text">
+        <string notr="true">Start Listening</string>
+       </property>
+      </widget>
+     </item>
+     <!-- <item>
+      <widget class="QPushButton" name="button_show_commands">
+       <property name="text">
+        <string notr="true">Show Commands</string>
+       </property>
+      </widget>
+     </item> -->
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <!-- <item>
+      <widget class="QPushButton" name="button_clear_commands">
+       <property name="text">
+        <string notr="true">Clear Commands</string>
+       </property>
+      </widget>
+     </item> -->
+     <item>
+      <widget class="QPushButton" name="button_close">
+       <property name="text">
+        <string notr="true">Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pymol-skills/pymol_mcp_server.py
+++ b/pymol-skills/pymol_mcp_server.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "mcp[cli]>=1.0.0",
+# ]
+# ///
+
+import socket
+import json
+import logging
+from contextlib import asynccontextmanager
+from typing import Optional, Dict, Any, AsyncIterator
+
+from mcp.server.fastmcp import FastMCP, Context
+
+##############################################################################
+# LOGGING
+##############################################################################
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("PyMOLMCPServer")
+
+##############################################################################
+# PYMOL SOCKET CONNECTION
+##############################################################################
+
+class PyMOLConnection:
+    """Manages socket connection to PyMOL plugin."""
+
+    def __init__(self, host: str = 'localhost', port: int = 9876):
+        self.host = host
+        self.port = port
+        self.sock: Optional[socket.socket] = None
+
+    def connect(self) -> bool:
+        """Establish connection to PyMOL socket server."""
+        if self.sock:
+            return True
+        try:
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.sock.connect((self.host, self.port))
+            logger.info(f"Connected to PyMOL at {self.host}:{self.port}")
+            return True
+        except Exception as e:
+            logger.error(f"Connection error: {e}")
+            self.sock = None
+            return False
+
+    def disconnect(self) -> None:
+        """Close the socket connection."""
+        if self.sock:
+            try:
+                self.sock.close()
+            except Exception as e:
+                logger.error(f"Disconnect error: {e}")
+            finally:
+                self.sock = None
+
+    def send_command(self, code: str) -> Dict[str, Any]:
+        """
+        Sends Python code to PyMOL via the socket plugin and returns a JSON response.
+
+        Response format:
+        {
+            "status": "success" or "error",
+            "result": {
+                "executed": bool,
+                "output": str or None,
+                "error": str or None
+            },
+            "message": "error message string if any"
+        }
+        """
+        if not self.sock and not self.connect():
+            raise ConnectionError("Not connected to PyMOL")
+
+        data = {"type": "pymol_command", "code": code}
+
+        try:
+            # Send command
+            self.sock.sendall(json.dumps(data).encode('utf-8'))
+            self.sock.settimeout(10.0)
+
+            # Receive response
+            chunks = []
+            while True:
+                chunk = self.sock.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                buffer = b''.join(chunks)
+                try:
+                    response = json.loads(buffer.decode('utf-8'))
+                    return response
+                except json.JSONDecodeError:
+                    continue
+
+            if chunks:
+                buffer = b''.join(chunks)
+                return json.loads(buffer.decode('utf-8'))
+
+            raise ConnectionError("No response from PyMOL")
+
+        except socket.timeout:
+            self.sock = None
+            raise TimeoutError("PyMOL response timed out")
+        except Exception as e:
+            self.sock = None
+            raise RuntimeError(f"PyMOL command error: {e}")
+
+# Global connection instance
+_global_connection: Optional[PyMOLConnection] = None
+
+def get_pymol_connection() -> PyMOLConnection:
+    """Get or create the global PyMOL connection."""
+    global _global_connection
+
+    # Test if existing connection is alive
+    if _global_connection is not None:
+        try:
+            _global_connection.send_command("pass")
+            return _global_connection
+        except:
+            try:
+                _global_connection.disconnect()
+            except:
+                pass
+            _global_connection = None
+
+    # Create new connection
+    if _global_connection is None:
+        conn = PyMOLConnection()
+        if not conn.connect():
+            raise RuntimeError("Could not connect to PyMOL socket.")
+        _global_connection = conn
+
+    return _global_connection
+
+##############################################################################
+# MCP SERVER SETUP
+##############################################################################
+
+@asynccontextmanager
+async def server_lifespan(server: FastMCP) -> AsyncIterator[dict]:
+    """Lifecycle management for the MCP server."""
+    try:
+        logger.info("Starting PyMOL MCP server.")
+        try:
+            get_pymol_connection()
+        except Exception as e:
+            logger.warning(f"Initial PyMOL connection failure: {e}")
+        yield {}
+    finally:
+        global _global_connection
+        if _global_connection:
+            _global_connection.disconnect()
+            _global_connection = None
+        logger.info("PyMOL MCP server shut down.")
+
+mcp = FastMCP("PyMOLMCPServer", lifespan=server_lifespan)
+
+##############################################################################
+# MCP TOOLS
+##############################################################################
+
+@mcp.tool()
+def pymol_command(ctx: Context, command: str) -> str:
+    """
+    Executes a direct PyMOL command using native PyMOL syntax.
+    Returns the output from PyMOL execution.
+
+    Examples:
+      - "fetch 1ubq"
+      - "show cartoon, all"
+      - "color red, chain A"
+      - "bg_color white"
+      - "zoom all"
+    """
+    try:
+        conn = get_pymol_connection()
+
+        # Wrap command in cmd.do() for execution
+        code = f"cmd.do('{command}')"
+        response = conn.send_command(code)
+
+        status = response.get("status", "error")
+        if status == "success":
+            res = response.get("result", {})
+
+            # Handle different response formats
+            if isinstance(res, dict):
+                output = res.get("output", "")
+                error = res.get("error", "")
+
+                if error:
+                    return f"Error: {error}"
+
+                # Generate meaningful output for common commands
+                if not output or output == command:
+                    if command.startswith('fetch'):
+                        structure = command.replace('fetch ', '').split()[0]
+                        return f"Fetched structure: {structure}"
+                    elif command.startswith('show') or command.startswith('hide'):
+                        return f"Display updated: {command}"
+                    elif command.startswith('color'):
+                        return f"Coloring applied: {command}"
+                    elif command.startswith('bg_color'):
+                        color = command.replace('bg_color ', '').strip()
+                        return f"Background color changed to: {color}"
+                    else:
+                        return f"Command executed: {command}"
+
+                return output
+            else:
+                # Handle string response (legacy format)
+                return str(res) if res else f"Command executed: {command}"
+        else:
+            msg = response.get("message", "Unknown error")
+            return f"Execution failed: {msg}"
+    except Exception as e:
+        return f"Connection error: {e}"
+
+@mcp.tool()
+def pymol_python_api(ctx: Context, python_code: str) -> str:
+    """
+    Executes PyMOL Python API commands directly.
+    Returns the output from PyMOL execution.
+
+    Examples:
+      - "cmd.fetch('1ubq')"
+      - "cmd.show('cartoon', 'all')"
+      - "cmd.color('red', 'chain A')"
+      - "cmd.align('mobile', 'target')"
+      - Custom Python scripts for complex operations
+    """
+    try:
+        conn = get_pymol_connection()
+
+        # Ensure pymol.cmd is imported in the code
+        if 'from pymol import cmd' not in python_code and 'import cmd' not in python_code:
+            python_code = f"from pymol import cmd\n{python_code}"
+
+        response = conn.send_command(python_code)
+
+        status = response.get("status", "error")
+        if status == "success":
+            res = response.get("result", {})
+
+            # Handle different response formats
+            if isinstance(res, dict):
+                output = res.get("output", "")
+                error = res.get("error", "")
+
+                if error:
+                    return f"Error: {error}"
+
+                # Generate meaningful output if none provided
+                if not output:
+                    if 'cmd.fetch(' in python_code:
+                        return f"Structure fetched via Python API"
+                    elif 'cmd.align(' in python_code or 'cmd.super(' in python_code:
+                        return f"Alignment completed via Python API"
+                    elif 'cmd.show(' in python_code or 'cmd.hide(' in python_code:
+                        return f"Display updated via Python API"
+                    elif 'cmd.color(' in python_code:
+                        return f"Coloring applied via Python API"
+                    elif 'cmd.select(' in python_code:
+                        return f"Selection created via Python API"
+                    else:
+                        return f"Python API command executed"
+
+                return output
+            else:
+                # Handle string response (legacy format)
+                return str(res) if res else f"Python API executed"
+        else:
+            msg = response.get("message", "Unknown error")
+            return f"Execution failed: {msg}"
+    except Exception as e:
+        return f"Connection error: {e}"
+
+##############################################################################
+# ENTRY POINT
+##############################################################################
+
+def main():
+    mcp.run()
+
+if __name__ == "__main__":
+    main()

--- a/pymol-skills/skills/pymol-mcp/SKILL.md
+++ b/pymol-skills/skills/pymol-mcp/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: pymol-mcp
+description: Control PyMOL molecular visualization software through natural language. This skill should be used when the user wants to visualize protein structures, create molecular representations, perform structural analysis, or generate publication-quality molecular images using PyMOL.
+---
+
+# PyMOL MCP Integration
+
+## Overview
+
+Control PyMOL molecular visualization software directly from Claude using the Model Context Protocol (MCP). Execute PyMOL commands, create visualizations, and perform structural analysis through natural language.
+
+## When to Use This Skill
+
+Use this skill when the user wants to:
+- Load and visualize protein/molecular structures (PDB, CIF, etc.)
+- Create molecular representations (cartoon, surface, sticks, etc.)
+- Color molecules by chain, secondary structure, or custom selections
+- Perform structural alignments and superpositions
+- Measure distances, angles, and dihedrals
+- Generate publication-quality images
+
+## Prerequisites
+
+Before using PyMOL commands, ensure:
+1. PyMOL is running with the socket plugin active
+2. The plugin shows "Listening on port 9876"
+
+Run `/pymol-skills:setup` for installation instructions.
+
+## Available MCP Tools
+
+### pymol_command
+Execute direct PyMOL commands using native syntax.
+
+**Examples:**
+```
+fetch 1ubq              # Load structure from PDB
+show cartoon, all       # Display as cartoon
+color red, chain A      # Color chain A red
+bg_color white          # Set white background
+zoom all                # Zoom to fit all
+```
+
+### pymol_python_api
+Execute PyMOL Python API commands for complex operations.
+
+**Examples:**
+```python
+cmd.fetch('1ubq')
+cmd.show('cartoon', 'all')
+cmd.color('red', 'chain A')
+cmd.align('mobile', 'target')
+cmd.select('active_site', 'resi 50-100')
+```
+
+## Common Workflows
+
+### Load and Visualize a Protein
+1. Fetch structure: `fetch 1ubq`
+2. Set representation: `show cartoon`
+3. Color by chain: `color auto, all`
+4. Set background: `bg_color white`
+
+### Compare Two Structures
+1. Fetch both: `fetch 1ubq` and `fetch 1ubi`
+2. Align: `align 1ubi, 1ubq`
+3. Color differently: `color green, 1ubq` and `color cyan, 1ubi`
+
+### Highlight Active Site
+1. Select residues: `select active, resi 45-50`
+2. Show as sticks: `show sticks, active`
+3. Color highlight: `color yellow, active`
+
+## Troubleshooting
+
+- **Connection refused**: Start PyMOL socket plugin before using commands
+- **Command not recognized**: Check PyMOL command syntax
+- **No output**: Some commands don't produce visible output


### PR DESCRIPTION
## Summary
- Add PyMOL MCP server for molecular visualization control via Claude
- Include PyMOL socket plugin for communication with PyMOL
- Add `/pymol-skills:setup` command for installation instructions
- Register plugin in marketplace