### PR TITLE
Use swift to run productivity-cli.swift directly

### DIFF
--- a/productivity-skills/commands/gtd-process.md
+++ b/productivity-skills/commands/gtd-process.md
@@ -9,7 +9,7 @@ model: opus
 Inbox file: ~/.claude/productivity-skills/inbox.md
 Projects list: "Projects" in macOS Reminders
 Context lists: @quick, @1pomo, @2pomo, @deep
-CLI tool: ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli
+CLI: swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift
 -->
 
 Process GTD inbox items based on user instructions: $ARGUMENTS
@@ -75,7 +75,7 @@ Use **AskUserQuestion**: "Is this a Project or Single Action?"
    - If custom: ask for specific date
 6. Create project in Projects list with end goal in notes:
    ```bash
-   productivity-cli reminders create \
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
      --title "ProjectName-20260112" \
      --list "Projects" \
      --priority 5 \
@@ -87,7 +87,7 @@ Use **AskUserQuestion**: "Is this a Project or Single Action?"
    - If yes: get action title, time estimate, due date (optional)
    - Create action in appropriate context list with project reference:
      ```bash
-     productivity-cli reminders create \
+     swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
        --title "Action title" \
        --list "@1pomo" \
        --notes "#{ProjectName-20260112}" \
@@ -103,7 +103,7 @@ Use **AskUserQuestion**: "Is this a Project or Single Action?"
 3. Optionally ask for due date
 4. Create reminder in appropriate context list:
    ```bash
-   productivity-cli reminders create \
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
      --title "Action title" \
      --list "@1pomo" \
      --priority 5 \

--- a/productivity-skills/commands/gtd-project.md
+++ b/productivity-skills/commands/gtd-project.md
@@ -16,7 +16,11 @@ Manage GTD projects based on user instructions: $ARGUMENTS
 
 ## CLI Tool
 
-Uses `productivity-cli` at `${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli`. See reminder-manager skill for build instructions.
+Run Swift source directly (no build step required):
+
+```bash
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
+```
 
 ## Step 1: Interpret Instructions
 
@@ -39,7 +43,7 @@ If unclear, use **AskUserQuestion** to clarify.
 
 1. Query Projects list:
    ```bash
-   productivity-cli reminders incomplete "Projects"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "Projects"
    ```
 2. Display projects with format:
    ```
@@ -55,11 +59,11 @@ If unclear, use **AskUserQuestion** to clarify.
 2. If ambiguous, use **AskUserQuestion** to select from matching projects
 3. Query all context lists for actions with `#{FullProjectName}` in notes:
    ```bash
-   productivity-cli reminders incomplete "@5min"
-   productivity-cli reminders incomplete "@15min"
-   productivity-cli reminders incomplete "@30min"
-   productivity-cli reminders incomplete "@1hr"
-   productivity-cli reminders incomplete "@Deep"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@5min"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@15min"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@30min"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@1hr"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@Deep"
    ```
 4. Filter results where notes contain `#{FullProjectName}`
 5. Display:
@@ -81,7 +85,7 @@ If unclear, use **AskUserQuestion** to clarify.
 5. Optionally ask for priority and due date
 6. Create action in appropriate context list:
    ```bash
-   productivity-cli reminders create \
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
      --title "Action title" \
      --list "@15min" \
      --notes "#{ProjectName-20260112}" \
@@ -99,7 +103,7 @@ If unclear, use **AskUserQuestion** to clarify.
    - Options: "Yes, complete project", "No, show actions first"
 5. Mark project complete:
    ```bash
-   productivity-cli reminders complete \
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders complete \
      --title "ProjectName-20260112" \
      --list "Projects"
    ```

--- a/productivity-skills/skills/calendar-manager/SKILL.md
+++ b/productivity-skills/skills/calendar-manager/SKILL.md
@@ -7,17 +7,12 @@ description: Manage macOS Calendar app events via EventKit CLI. Use this skill w
 
 Manage macOS Calendar events using the productivity-cli tool (EventKit-based).
 
-## CLI Location
+## CLI Usage
 
-The CLI tool is located at `${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli`.
-
-## Building the CLI
-
-If the binary doesn't exist, build it from source:
+Run the Swift source directly (no build step required):
 
 ```bash
-cd ${CLAUDE_PLUGIN_ROOT}/scripts
-swiftc -O -o productivity-cli productivity-cli.swift -framework EventKit
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
 ```
 
 Requires: macOS 13+ with Xcode command line tools installed.
@@ -27,7 +22,7 @@ Requires: macOS 13+ with Xcode command line tools installed.
 Before any create/delete operation, list calendars and ask the user which one to use:
 
 ```bash
-productivity-cli calendars list
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars list
 ```
 
 ## Operations
@@ -35,7 +30,7 @@ productivity-cli calendars list
 ### List All Calendars
 
 ```bash
-productivity-cli calendars list
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars list
 ```
 
 Returns JSON:
@@ -53,33 +48,33 @@ Returns JSON:
 ### Get Today's Events
 
 ```bash
-productivity-cli calendars today
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars today
 ```
 
 ### Get This Week's Events
 
 ```bash
-productivity-cli calendars week
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars week
 ```
 
 ### Get Events on a Specific Date
 
 ```bash
-productivity-cli calendars date 2025-01-15
-productivity-cli calendars date 2025-01-15 --calendar Work
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars date 2025-01-15
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars date 2025-01-15 --calendar Work
 ```
 
 ### Get Events in a Date Range
 
 ```bash
-productivity-cli calendars range 2025-01-01 2025-01-31
-productivity-cli calendars range 2025-01-01 2025-01-31 --calendar Work
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars range 2025-01-01 2025-01-31
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars range 2025-01-01 2025-01-31 --calendar Work
 ```
 
 ### Search Events by Title
 
 ```bash
-productivity-cli calendars search "meeting"
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars search "meeting"
 ```
 
 Searches events in the next 365 days matching the term.
@@ -88,7 +83,7 @@ Searches events in the next 365 days matching the term.
 
 **Basic event (1 hour duration):**
 ```bash
-productivity-cli calendars create \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars create \
   --title "Team Meeting" \
   --calendar "Work" \
   --start "2025-01-15 14:00"
@@ -96,7 +91,7 @@ productivity-cli calendars create \
 
 **Event with end time:**
 ```bash
-productivity-cli calendars create \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars create \
   --title "Team Meeting" \
   --calendar "Work" \
   --start "2025-01-15 14:00" \
@@ -105,7 +100,7 @@ productivity-cli calendars create \
 
 **Event with location and notes:**
 ```bash
-productivity-cli calendars create \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars create \
   --title "Team Meeting" \
   --calendar "Work" \
   --start "2025-01-15 14:00" \
@@ -116,7 +111,7 @@ productivity-cli calendars create \
 
 **All-day event:**
 ```bash
-productivity-cli calendars create \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars create \
   --title "Company Holiday" \
   --calendar "Work" \
   --start "2025-01-20" \
@@ -126,14 +121,14 @@ productivity-cli calendars create \
 ### Delete an Event
 
 ```bash
-productivity-cli calendars delete \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars delete \
   --title "Team Meeting" \
   --date "2025-01-15"
 ```
 
 With specific calendar:
 ```bash
-productivity-cli calendars delete \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars delete \
   --title "Team Meeting" \
   --date "2025-01-15" \
   --calendar "Work"

--- a/productivity-skills/skills/reminder-manager/SKILL.md
+++ b/productivity-skills/skills/reminder-manager/SKILL.md
@@ -7,17 +7,12 @@ description: Manage macOS Reminders app via EventKit CLI. Use this skill when th
 
 Manage macOS Reminders using the productivity-cli tool (EventKit-based).
 
-## CLI Location
+## CLI Usage
 
-The CLI tool is located at `${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli`.
-
-## Building the CLI
-
-If the binary doesn't exist, build it from source:
+Run the Swift source directly (no build step required):
 
 ```bash
-cd ${CLAUDE_PLUGIN_ROOT}/scripts
-swiftc -O -o productivity-cli productivity-cli.swift -framework EventKit
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
 ```
 
 Requires: macOS 13+ with Xcode command line tools installed.
@@ -27,7 +22,7 @@ Requires: macOS 13+ with Xcode command line tools installed.
 Before any create operation, list reminder lists and ask the user which one to use:
 
 ```bash
-productivity-cli reminders lists
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders lists
 ```
 
 ## Operations
@@ -35,7 +30,7 @@ productivity-cli reminders lists
 ### List All Reminder Lists
 
 ```bash
-productivity-cli reminders lists
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders lists
 ```
 
 Returns JSON:
@@ -56,39 +51,39 @@ The `count` field shows incomplete reminders in each list.
 ### Get Reminders Due Today
 
 ```bash
-productivity-cli reminders today
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders today
 ```
 
 ### Get Incomplete Reminders
 
 **All incomplete reminders:**
 ```bash
-productivity-cli reminders incomplete
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete
 ```
 
 **From a specific list:**
 ```bash
-productivity-cli reminders incomplete "Tasks"
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "Tasks"
 ```
 
 ### Get Overdue Reminders
 
 ```bash
-productivity-cli reminders overdue
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders overdue
 ```
 
 ### Create a Reminder
 
 **Basic reminder:**
 ```bash
-productivity-cli reminders create \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
   --title "Buy groceries" \
   --list "Tasks"
 ```
 
 **With due date:**
 ```bash
-productivity-cli reminders create \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
   --title "Submit report" \
   --list "Work" \
   --due "2025-01-15 17:00"
@@ -96,7 +91,7 @@ productivity-cli reminders create \
 
 **With priority:**
 ```bash
-productivity-cli reminders create \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
   --title "Urgent task" \
   --list "Work" \
   --priority 1
@@ -104,7 +99,7 @@ productivity-cli reminders create \
 
 **With notes:**
 ```bash
-productivity-cli reminders create \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
   --title "Call John" \
   --list "Tasks" \
   --notes "Discuss project timeline and budget"
@@ -112,7 +107,7 @@ productivity-cli reminders create \
 
 **Full reminder with all properties:**
 ```bash
-productivity-cli reminders create \
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
   --title "Team meeting prep" \
   --list "Work" \
   --due "2025-01-15 09:00" \
@@ -123,40 +118,40 @@ productivity-cli reminders create \
 ### Mark Reminder as Complete
 
 ```bash
-productivity-cli reminders complete --title "Buy groceries"
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders complete --title "Buy groceries"
 ```
 
 With specific list:
 ```bash
-productivity-cli reminders complete --title "Buy groceries" --list "Tasks"
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders complete --title "Buy groceries" --list "Tasks"
 ```
 
 ### Mark Reminder as Incomplete
 
 ```bash
-productivity-cli reminders uncomplete --title "Buy groceries"
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders uncomplete --title "Buy groceries"
 ```
 
 With specific list:
 ```bash
-productivity-cli reminders uncomplete --title "Buy groceries" --list "Tasks"
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders uncomplete --title "Buy groceries" --list "Tasks"
 ```
 
 ### Delete a Reminder
 
 ```bash
-productivity-cli reminders delete --title "Buy groceries"
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders delete --title "Buy groceries"
 ```
 
 With specific list:
 ```bash
-productivity-cli reminders delete --title "Buy groceries" --list "Tasks"
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders delete --title "Buy groceries" --list "Tasks"
 ```
 
 ### Create a New Reminder List
 
 ```bash
-productivity-cli reminders create-list "Shopping"
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create-list "Shopping"
 ```
 
 ## Response Format


### PR DESCRIPTION
Remove build step requirement by running Swift source directly instead of compiled binary.

Closes #43