### PR TITLE
Bump productivity-skills version to 2.0.0

### DIFF
--- a/productivity-skills/.claude-plugin/plugin.json
+++ b/productivity-skills/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "productivity-skills",
   "description": "macOS productivity skills for managing Calendar events, Reminders, and proactive task management via EventKit CLI",
-  "version": "1.2.0"
+  "version": "2.0.0"
 }

--- a/productivity-skills/CHANGELOG.md
+++ b/productivity-skills/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## [2.0.0] - 2026-01-14
+
+### Added
+- `/gtd-inbox` command for GTD inbox management (capture, list, remove)
+- `/gtd-process` command for processing inbox into projects/actions
+- `/gtd-project` command with guided workflow and auto-review
+- Time-aware capture (relative dates converted to explicit dates)
+- Pomodoro-based context lists (@quick, @1pomo, @2pomo, @deep)
+- Project end goal tracking
+
+### Changed
+- Run Swift source directly instead of compiled binary (no build step)
+- Updated CLI usage in all skills to use `swift productivity-cli.swift`
+
+## [1.2.0] - 2025-12-28
+
+### Added
+- Personal assistant agent for proactive task management
+- Pomodoro mode support
+
+## [1.1.0] - 2025-12-27
+
+### Added
+- Calendar manager skill
+- Reminder manager skill
+
+## [1.0.0] - 2025-12-26
+
+### Added
+- Initial release
+- productivity-cli.swift for EventKit access


### PR DESCRIPTION
## Summary
- Bump version from 1.2.0 to 2.0.0 for GTD system release
- Add CHANGELOG.md

## Changes in 2.0.0
- `/gtd-inbox` command for GTD inbox management
- `/gtd-process` command for processing inbox
- `/gtd-project` command with guided workflow and auto-review
- Swift direct execution (no build step required)
- Pomodoro-based context lists (@quick, @1pomo, @2pomo, @deep)