### PR TITLE
Add /gtd-next command for calendar-aware task selection

### DIFF
--- a/productivity-skills/commands/gtd-next.md
+++ b/productivity-skills/commands/gtd-next.md
@@ -1,0 +1,271 @@
+---
+description: Calendar-aware task selection for GTD Engage step
+argument-hint: []
+allowed-tools: Read, Bash, AskUserQuestion
+model: opus
+---
+
+<!--
+CLI: swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift
+Context lists: @quick, @1pomo, @2pomo, @deep
+Projects list: "Projects" in macOS Reminders
+Action reference: #{ProjectName} in notes field
+
+Time to context mapping:
+- < 25 min → @quick only
+- 25-50 min → @quick, @1pomo
+- 50-90 min → @quick, @1pomo, @2pomo
+- 90+ min → all contexts including @deep
+-->
+
+Help user pick the best task based on available time until their next fixed event (GTD "Engage" step).
+
+## CLI Tool
+
+Run Swift source directly (no build step required):
+
+```bash
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
+```
+
+## Step 1: Check Calendar
+
+1. Get current date and time:
+   ```bash
+   date "+%Y-%m-%d %H:%M"
+   ```
+
+2. Query today's remaining events:
+   ```bash
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift calendars today
+   ```
+
+3. Parse the JSON response and find the next event (after current time)
+   - Skip all-day events
+   - Find the earliest event with a start time after now
+
+4. If no remaining events today:
+   - Use **AskUserQuestion**: "No more calendar events today. Any other time constraints?"
+   - Options: "I'm free for the rest of the day", "I have about 1 hour", "I have about 2 hours", "I have 30 minutes or less"
+   - Map response to available time and skip to Step 3
+
+## Step 2: Confirm with User
+
+Present the next event and ask for confirmation:
+
+Use **AskUserQuestion**:
+```
+Your next event: "[Event Title]" at [Time]
+
+Any other commitments before then?
+```
+- Options: "No, that's correct", "I have something else sooner"
+
+If user has an unlisted commitment:
+- Use **AskUserQuestion**: "When is your commitment?"
+- Options: "In about 30 minutes", "In about 1 hour", "In about 2 hours", "Let me add it to calendar"
+- If "Let me add it to calendar": inform user to add the event and re-run /gtd-next
+
+## Step 3: Calculate Available Time
+
+Calculate minutes until next commitment:
+```
+Available time = Next event start time - Current time
+```
+
+Map to suitable contexts:
+
+| Available Time | Suitable Contexts |
+|----------------|-------------------|
+| < 15 min | None - suggest taking a break |
+| 15-25 min | @quick only |
+| 25-50 min | @quick, @1pomo |
+| 50-90 min | @quick, @1pomo, @2pomo |
+| 90+ min | @quick, @1pomo, @2pomo, @deep |
+
+If available time < 15 minutes:
+- Display: "Only [X] minutes until [Event]. Consider taking a break or reviewing notes for your upcoming event."
+- Exit the workflow
+
+## Step 4: Query Matching Actions
+
+1. Ensure required lists exist:
+   ```bash
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders lists
+   ```
+
+2. Query actions from suitable context lists:
+   ```bash
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@quick"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@1pomo"
+   # etc. based on available time
+   ```
+
+3. Also query overdue reminders:
+   ```bash
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders overdue
+   ```
+
+4. Parse and combine results, noting:
+   - Which context list each action belongs to
+   - Project reference from notes field (#{ProjectName})
+   - Priority value
+   - Due date
+   - Whether overdue
+
+## Step 5: Prioritize and Display Suggestions
+
+Sort actions by:
+1. Overdue items first
+2. High priority (priority=1)
+3. Due date approaching (soonest first)
+4. Medium priority (priority=5)
+5. Remaining items
+
+Display format:
+
+```
+# Available Time: [X hours/minutes] until [Event] ([Time])
+
+Suggested actions:
+
+1. ⚠️ [Action Title] #[ProjectName] [Priority] @[context] - OVERDUE
+2. [Action Title] #[ProjectName] [Priority] @[context] - due [date]
+3. [Action Title] [Priority] @[context]
+
+Recommended: Start with #1 (overdue), then #2
+```
+
+Format notes:
+- ⚠️ prefix for overdue items
+- Show project name if linked (from notes field)
+- Show priority: [High], [Medium], [Low], or omit for None
+- Show context list: @quick, @1pomo, @2pomo, @deep
+- Show due date if set, with "OVERDUE" if past
+
+If no actions match available contexts:
+- Display: "No actions found matching your available time. Consider adding actions to @quick or @1pomo lists."
+- Exit the workflow
+
+Use **AskUserQuestion**: "Which task to start?"
+- Options: Numbered list (up to 4 items) + "Show more" + "Skip for now"
+- If "Show more": display next batch of suggestions
+- If "Skip for now": exit workflow
+
+## Step 6: Start Selected Task
+
+1. Display task details:
+   ```
+   Starting: "[Action Title]"
+   Context: @[context]
+   ```
+
+2. If task is linked to a project (has #{ProjectName} in notes):
+   - Query the project to get its goal:
+     ```bash
+     swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "Projects"
+     ```
+   - Parse to find matching project and extract goal from notes
+   - Display: "Project: [ProjectName]\nGoal: [Goal description]"
+
+3. Display: "Let me know when you're done with this task."
+
+## Step 7: Task Completion
+
+Use **AskUserQuestion**: "How did it go?"
+- Options: "Completed", "Partially done, need more time", "Couldn't start, will do later"
+
+**If "Completed":**
+1. Mark the action complete:
+   ```bash
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders complete \
+     --title "[Action title]" \
+     --list "@[context]"
+   ```
+2. Report: "Marked complete: '[Action title]'"
+3. Go to Step 8
+
+**If "Partially done":**
+1. Keep action incomplete
+2. Report: "Keeping '[Action title]' on your list for later."
+3. Go to Step 8
+
+**If "Couldn't start":**
+1. Keep action incomplete
+2. Go to Step 8
+
+## Step 8: Recalculate and Continue
+
+1. Get current time:
+   ```bash
+   date "+%Y-%m-%d %H:%M"
+   ```
+
+2. Recalculate remaining time until the original next event
+
+3. If remaining time < 15 minutes:
+   - Display: "Only [X] minutes left before [Event]. Take a break and prepare for your meeting."
+   - Exit workflow
+
+4. Otherwise, display updated time and next suggestion:
+   ```
+   Remaining time: [X hours/minutes] until [Event] ([Time])
+
+   Next suggestion:
+   1. [Action Title] [Priority] @[context]
+   ```
+
+Use **AskUserQuestion**: "Continue?"
+- Options: "Yes, start this task", "Pick a different task", "Done for now"
+- If "Yes": Go to Step 6
+- If "Pick a different task": Go to Step 4 (re-query and display options)
+- If "Done for now": Exit workflow
+
+---
+
+## Reference: Context Lists
+
+| List | Time Estimate | Suitable When |
+|------|---------------|---------------|
+| @quick | < 25 min | Any short window |
+| @1pomo | 25 min | 25+ min available |
+| @2pomo | 50 min | 50+ min available |
+| @deep | 90+ min | Long uninterrupted time |
+
+## Reference: Priority Display
+
+| Value | Display |
+|-------|---------|
+| 1 | [High] |
+| 5 | [Medium] |
+| 9 | [Low] |
+| 0 | (omit) |
+
+## Reference: Time Calculations
+
+To calculate available minutes:
+1. Parse event start time from calendar JSON (format: "2026-01-15 14:00:00")
+2. Parse current time (format: "2026-01-15 13:30")
+3. Calculate difference in minutes
+4. Subtract 5-10 minutes buffer for transition
+
+---
+
+## Guidelines
+
+- Always show context (@quick, @1pomo, etc.) with each action
+- Prioritize overdue items - they should always appear first
+- Link actions to projects when #{ProjectName} is found in notes
+- Provide time-appropriate suggestions (don't suggest @deep tasks for 30-minute windows)
+- After each completed task, immediately recalculate and suggest next
+- Respect the user's time by exiting gracefully when time is short
+- Handle CLI errors gracefully and report to user
+
+## Note: Sequential Questions
+
+Questions in this command are asked sequentially (not batched) because each answer affects subsequent behavior:
+- Step 2: "Other commitments?" → only ask "When?" if user says yes
+- Step 7: "How did it go?" → determines whether to mark complete
+- Step 8: "Continue?" → depends on remaining time after completion
+
+Use batched questions only when answers are independent (e.g., time estimate + priority + due date in /gtd-process).

--- a/productivity-skills/commands/gtd-process.md
+++ b/productivity-skills/commands/gtd-process.md
@@ -60,20 +60,21 @@ Use **AskUserQuestion**: "Is this a Project or Single Action?"
 
 1. Generate project name: `{CamelCaseSummary}-{YYYYMMDD}`
    - Examples: "Research vacation" → `VacationResearch-20260112`
+
 2. Use **AskUserQuestion** to confirm/edit name
+
 3. Use **AskUserQuestion** for end goal: "What does 'done' look like for this project?"
    - This is critical for GTD - every project needs a clear outcome
    - User provides a concrete, achievable end state
    - Examples: "Flights and hotel booked for Hawaii trip", "Documentation updated and reviewed"
    - Record this end goal in the project's notes field
-4. Use **AskUserQuestion** for priority:
-   - Options: "High", "Medium", "Low", "None"
-   - Values: High=1, Medium=5, Low=9, None=0
-5. Use **AskUserQuestion** for due date (optional):
-   - "When should this project be completed?"
-   - Options: "No deadline", "This week", "Next week", "Custom date"
-   - If custom: ask for specific date
-6. Create project in Projects list with end goal in notes:
+
+4. Use **AskUserQuestion** to gather priority and due date together (2 questions in one call):
+   - Question 1 - "Priority?": Options "High", "Medium", "Low", "None"
+   - Question 2 - "Due date?": Options "No deadline", "This week", "Next week", "Custom date"
+   - If custom date selected: follow up to ask for specific date
+
+5. Create project in Projects list with end goal in notes:
    ```bash
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
      --title "ProjectName-20260112" \
@@ -96,12 +97,13 @@ Use **AskUserQuestion**: "Is this a Project or Single Action?"
 
 ## Step 5b: Process as Single Action
 
-1. Use **AskUserQuestion** for time estimate:
-   - Options: "Quick (< 25 min)", "1 Pomodoro (25 min)", "2 Pomodoros (50 min)", "Deep (3+ pomodoros)"
-2. Use **AskUserQuestion** for priority:
-   - Options: "High", "Medium", "Low", "None"
-3. Optionally ask for due date
-4. Create reminder in appropriate context list:
+1. Use **AskUserQuestion** to gather all action properties together (3 questions in one call):
+   - Question 1 - "Time estimate?": Options "Quick (< 25 min)", "1 Pomodoro (25 min)", "2 Pomodoros (50 min)", "Deep (3+ pomodoros)"
+   - Question 2 - "Priority?": Options "High", "Medium", "Low", "None"
+   - Question 3 - "Due date?": Options "No due date", "Today", "Tomorrow", "This week", "Custom date"
+   - If custom date selected: follow up to ask for specific date
+
+2. Create reminder in appropriate context list:
    ```bash
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
      --title "Action title" \
@@ -158,3 +160,13 @@ Use Edit tool to remove the processed item from inbox.md.
 - Project notes contain the end goal: "Goal: [description]"
 - Date format for due dates: `yyyy-MM-dd HH:mm`
 - Handle CLI errors gracefully and report to user
+
+## Note: Batched vs Sequential Questions
+
+**Batched (independent answers):**
+- Time estimate + Priority + Due date → ask in single AskUserQuestion call with 3 questions
+
+**Sequential (dependent answers):**
+- "Project or Single Action?" → must ask first, determines which properties to gather
+- "Confirm project name" → must confirm before asking for end goal
+- "Add first action?" → must ask after project is created

--- a/productivity-skills/commands/gtd-project.md
+++ b/productivity-skills/commands/gtd-project.md
@@ -121,7 +121,11 @@ Options presented based on project state:
 1. Use **AskUserQuestion**: "What's the next action for this project?"
    - User provides action title
 
-2. Gather action properties using **Action Property Questions** (see reference section below)
+2. Use **AskUserQuestion** to gather all action properties together (3 questions in one call):
+   - Question 1 - "Time estimate?": Options "Quick (< 25 min)", "1 Pomodoro (25 min)", "2 Pomodoros (50 min)", "Deep (3+ pomodoros)"
+   - Question 2 - "Priority?": Options "High", "Medium", "Low", "None"
+   - Question 3 - "Due date?": Options "No due date", "Today", "Tomorrow", "This week", "Custom date"
+   - If custom date selected: follow up to ask for specific date
 
 3. Create the action:
    ```bash
@@ -228,24 +232,26 @@ When user selects "Done reviewing" in Step 2:
 
 ---
 
-## Reference: Action Property Questions
+## Reference: Batched Action Property Questions
 
-Use these standardized prompts when gathering action properties in Steps 4a and 4c:
+When gathering action properties, use a single **AskUserQuestion** call with multiple questions:
 
-**Time estimate:**
-- Use **AskUserQuestion**: "Time estimate?"
-- Options: "Quick (< 25 min)", "1 Pomodoro (25 min)", "2 Pomodoros (50 min)", "Deep (3+ pomodoros)"
-- Maps to lists: @quick, @1pomo, @2pomo, @deep
+```
+AskUserQuestion with 3 questions:
+  Question 1 (header: "Time"): "Time estimate?"
+    Options: "Quick (< 25 min)", "1 Pomodoro (25 min)", "2 Pomodoros (50 min)", "Deep (3+ pomodoros)"
+    Maps to lists: @quick, @1pomo, @2pomo, @deep
 
-**Priority:**
-- Use **AskUserQuestion**: "Priority?"
-- Options: "High", "Medium", "Low", "None"
-- Values: High=1, Medium=5, Low=9, None=0
+  Question 2 (header: "Priority"): "Priority?"
+    Options: "High", "Medium", "Low", "None"
+    Values: High=1, Medium=5, Low=9, None=0
 
-**Due date:**
-- Use **AskUserQuestion**: "Due date?"
-- Options: "No due date", "Today", "Tomorrow", "This week", "Custom date"
-- If custom: ask for specific date
+  Question 3 (header: "Due"): "Due date?"
+    Options: "No due date", "Today", "Tomorrow", "This week", "Custom date"
+    If custom selected: follow up to ask for specific date
+```
+
+This reduces back-and-forth interactions from 3 separate questions to 1 batched question.
 
 ---
 
@@ -281,3 +287,14 @@ Use `yyyy-MM-dd HH:mm` for due dates. Default time is 17:00 if only date provide
 - Create missing reminder lists automatically before creating reminders
 - Handle CLI errors gracefully and report to user
 - Match project names case-insensitively
+
+## Note: Batched vs Sequential Questions
+
+**Batched (independent answers):**
+- Time estimate + Priority + Due date → ask in single AskUserQuestion call with 3 questions (Step 4a)
+
+**Sequential (dependent answers):**
+- "Which project?" → must select before showing options
+- "What to do?" → options depend on project state (stalled vs healthy)
+- "Action title" → must get title before asking for properties
+- "What to edit?" → must know which properties before gathering new values


### PR DESCRIPTION
## Summary

- Add `/gtd-next` command for calendar-aware task selection (GTD Engage step)
- Refactor GTD commands to batch independent AskUserQuestion calls
- Add documentation for batched vs sequential question patterns

Closes #47