### PR TITLE
Fix overdue detection to use Apple's datetime-aware API

### DIFF
--- a/productivity-skills/.claude-plugin/plugin.json
+++ b/productivity-skills/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "productivity-skills",
   "description": "macOS productivity skills for managing Calendar events, Reminders, and proactive task management via EventKit CLI",
-  "version": "2.1.1"
+  "version": "2.1.2"
 }

--- a/productivity-skills/commands/gtd-project.md
+++ b/productivity-skills/commands/gtd-project.md
@@ -28,9 +28,9 @@ swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
 
 ## Step 1: Gather Data
 
-1. Get current date for overdue calculation:
+1. Query overdue reminders (uses Apple's datetime-aware overdue detection):
    ```bash
-   date "+%Y-%m-%d"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders overdue
    ```
 
 2. Ensure required lists exist:
@@ -68,7 +68,7 @@ swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
 7. Determine project status:
    - **Healthy** (✓): Has a pending action that is not overdue
    - **Stalled** (⚠️): No pending action linked to this project
-   - **Overdue** (⚠️): Action's due date OR project's due date is in the past
+   - **Overdue** (⚠️): Action OR project appears in the overdue query results from Step 1.1
 
 ## Step 2: Display Projects Overview
 


### PR DESCRIPTION
## Summary
- Use `reminders overdue` CLI command instead of manual date comparison
- Fixes incorrect overdue marking when comparing dates without times
- Bumps version to 2.1.2