### PR TITLE
Fix Co-Authored-By pattern to catch model name variants

### DIFF
--- a/core-hooks/.claude-plugin/plugin.json
+++ b/core-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks for Claude Code",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -102,7 +102,7 @@ def main():
             claude_patterns = [
                 r'Generated with \[Claude Code\]',
                 r'claude\.ai/code',
-                r'Co-Authored-By: Claude <noreply@anthropic\.com>',
+                r'Co-Authored-By:.*(?:claude|anthropic)',
                 r'Generated with',
                 r'Claude Code'
             ]


### PR DESCRIPTION
## Summary
- Broaden `Co-Authored-By` regex from exact match to `Co-Authored-By:.*(?:claude|anthropic)` so it catches variants like `claude Opus 4.6`
- Bump core-hooks version to 1.0.1