### PR TITLE
Encourage squash merge in core-hooks

### DIFF
--- a/core-hooks/.claude-plugin/plugin.json
+++ b/core-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks for Claude Code",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -89,10 +89,10 @@ def main():
             }
             print(json.dumps(response))
             sys.exit(0)
-        elif "gh pr merge" in command and "--squash" in command:
-            # Warn about squash merge
+        elif "gh pr merge" in command and "--squash" not in command:
+            # Encourage squash merge
             response = {
-                "systemMessage": "Merge Strategy: Use regular merge instead of squash to preserve commit history and authorship."
+                "systemMessage": "Merge Strategy: Prefer --squash when merging PRs to keep history clean."
             }
             print(json.dumps(response))
             sys.exit(0)


### PR DESCRIPTION
## Summary
- Flip PR merge hook to encourage `--squash` instead of warning against it
- Bump core-hooks version to 1.0.1