### PR TITLE
Generalize attribution detection pattern

### DIFF
--- a/core-hooks/.claude-plugin/plugin.json
+++ b/core-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks for Claude Code",
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -109,7 +109,7 @@ def main():
             claude_patterns = [
                 r'Generated with \[Claude Code\]',
                 r'claude\.ai/code',
-                r'Co-Authored-By: Claude <noreply@anthropic\.com>',
+                r'noreply@anthropic\.com',
                 r'Generated with',
                 r'Claude Code'
             ]


### PR DESCRIPTION
## Summary
- Match any noreply@anthropic.com email instead of specific model name
- Bump core-hooks to 1.0.3