### PR TITLE
Bump dev-skills version to 3.3.0

### DIFF
--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-skills",
   "description": "Collection of development workflow skills including systematic problem-solving cycle from brainstorming to PR merge",
-  "version": "3.2.0"
+  "version": "3.3.0"
 }


### PR DESCRIPTION
## Summary
- Bump dev-skills plugin version to 3.3.0 for new eval-critic capabilities (Chrome browser tools, WebSearch)