### PR TITLE
Fix branch naming hook bypass for git branch and git branch -m

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ git push -u origin <branch-name>
 gh pr create --title "Brief title" --body "Description and closes #<issue>"
 
 # Merge PR after review
-gh pr merge <pr-number> --merge
+gh pr merge <pr-number> --squash
 ```
 
 ### Managing the Plugin Marketplace
@@ -300,7 +300,7 @@ The core skill defines a complete development workflow with 8 phases:
 - Re-run tests after updates
 
 **Phase 7: Merge & Close**
-- Merge via `gh pr merge --merge` (not squash)
+- Merge via `gh pr merge --squash` to keep history clean
 - Issue auto-closes if PR description references it
 
 **Phase 8: Cleanup**

--- a/cc-customize/.claude-plugin/plugin.json
+++ b/cc-customize/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "cc-customize",
   "description": "Claude Code customization skills for configuring model, effort level, auto-compact threshold, and statusline",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/core-hooks/.claude-plugin/plugin.json
+++ b/core-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks for Claude Code",
-  "version": "1.0.5"
+  "version": "1.0.6"
 }

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -9,10 +9,52 @@ Adds context reminders before git commits and PR creation.
 
 import json
 import os
+import re
 import sys
 
+
+VALID_PREFIXES = ['feat-', 'bugfix-', 'doc-', 'refactor-', 'chore-', 'test-']
+
+
+def extract_branch_name(command):
+    # [^\s;|&]+ instead of \S+ to stop at shell metacharacters (; && || |)
+    m = re.search(r'git checkout -b\s+([^\s;|&]+)', command)
+    if m:
+        return m.group(1)
+
+    m = re.search(r'git switch -c\s+([^\s;|&]+)', command)
+    if m:
+        return m.group(1)
+
+    if 'git worktree add' in command:
+        m = re.search(r'git worktree add\s+[^\s;|&]+\s+(?:-b|--branch)\s+([^\s;|&]+)', command)
+        if m:
+            return m.group(1)
+        m = re.search(r'git worktree add\s+[^\s;|&]+\s+([a-zA-Z][\w-]*)', command)
+        if m:
+            return m.group(1)
+        m = re.search(r'git worktree add\s+([^\s;|&]+)', command)
+        if m:
+            return os.path.basename(m.group(1))
+        return None
+
+    # Rename/copy: short flags (-m/-M/-c/-C) and long flags (--move/--copy)
+    m = re.search(r'git branch\s+(?:-[mMcC]|--move|--copy)\s+[^\s;|&]+\s+([^\s;|&]+)', command)
+    if m:
+        return m.group(1)
+    m = re.search(r'git branch\s+(?:-[mMcC]|--move|--copy)\s+([^\s;|&]+)', command)
+    if m:
+        return m.group(1)
+
+    # Bare creation — skip read-only/delete flags
+    if re.search(r'git branch\s+(-[ladDvrV]|--list|--all|--delete|--remotes)', command):
+        return None
+    m = re.search(r'git branch\s+(?!-)([^\s;|&]+)', command)
+    if m:
+        return m.group(1)
+
+
 def main():
-    # Read input from stdin
     try:
         input_data = json.loads(sys.stdin.read())
     except json.JSONDecodeError:
@@ -22,13 +64,10 @@ def main():
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 
-    # Check if this is a git operation
     if tool_name == "Bash":
         command = tool_input.get("command", "")
-        import re
-        # Block git add . and git add -A operations (but allow dotfile paths like .claude-plugin/)
+
         if re.search(r'git add\s+(-A|--all|\.(?:\s|$)|\.\/(?:\s|$))', command):
-            # Block bulk git add operations
             response = {
                 "systemMessage": "BLOCKED: Use 'git add <filename>' with specific file names instead of 'git add .', 'git add -A', or 'git add --all' for precise change control.",
                 "hookSpecificOutput": {
@@ -39,69 +78,35 @@ def main():
             }
             print(json.dumps(response))
             sys.exit(0)
-        elif "git checkout -b" in command or "git switch -c" in command or "git worktree add" in command:
-            # Extract branch name and validate naming convention
-            import re
 
-            # Extract branch name from command
-            branch_name = None
-            if "git checkout -b" in command:
-                match = re.search(r'git checkout -b\s+(\S+)', command)
-                if match:
-                    branch_name = match.group(1)
-            elif "git switch -c" in command:
-                match = re.search(r'git switch -c\s+(\S+)', command)
-                if match:
-                    branch_name = match.group(1)
-            elif "git worktree add" in command:
-                # Match git worktree add with -b or --branch flag
-                match = re.search(r'git worktree add\s+\S+\s+(?:-b|--branch)\s+(\S+)', command)
-                if match:
-                    branch_name = match.group(1)
-                else:
-                    # Check for positional branch name: git worktree add <path> <branch>
-                    match = re.search(r'git worktree add\s+\S+\s+([a-zA-Z][\w-]*)', command)
-                    if match:
-                        branch_name = match.group(1)
-                    else:
-                        # No explicit branch — git derives branch name from last path component
-                        # e.g. git worktree add trees/my-feature -> branch "my-feature"
-                        match = re.search(r'git worktree add\s+(\S+)', command)
-                        if match:
-                            branch_name = os.path.basename(match.group(1))
-
-            if branch_name:
-                valid_prefixes = ['feat-', 'bugfix-', 'doc-', 'refactor-', 'chore-', 'test-']
-
-                if not any(branch_name.startswith(prefix) for prefix in valid_prefixes):
-                    # Block invalid branch name
-                    response = {
-                        "systemMessage": f"Branch name '{branch_name}' is invalid. Use only these prefixes: feat-, bugfix-, doc-, refactor-, chore-, test-",
-                        "hookSpecificOutput": {
-                            "hookEventName": "PreToolUse",
-                            "permissionDecision": "deny",
-                            "permissionDecisionReason": f"Branch name must start with one of: {', '.join(valid_prefixes)}"
-                        }
+        branch_name = extract_branch_name(command)
+        if branch_name:
+            if not any(branch_name.startswith(p) for p in VALID_PREFIXES):
+                response = {
+                    "systemMessage": f"Branch name '{branch_name}' is invalid. Use only these prefixes: {', '.join(VALID_PREFIXES)}",
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": f"Branch name must start with one of: {', '.join(VALID_PREFIXES)}"
                     }
-                    print(json.dumps(response))
-                    sys.exit(0)
+                }
+                print(json.dumps(response))
+                sys.exit(0)
 
-            # Valid branch name, just show reminder
             response = {
                 "systemMessage": "Branch Naming Convention: Using approved prefix - good practice!"
             }
             print(json.dumps(response))
             sys.exit(0)
-        elif "gh pr merge" in command and "--squash" not in command:
-            # Encourage squash merge
+
+        if "gh pr merge" in command and "--squash" not in command:
             response = {
                 "systemMessage": "Merge Strategy: Prefer --squash when merging PRs to keep history clean."
             }
             print(json.dumps(response))
             sys.exit(0)
+
         elif "git commit" in command or "gh pr create" in command:
-            # Check for Claude Code attribution patterns
-            import re
             claude_patterns = [
                 r'Generated with \[Claude Code\]',
                 r'claude\.ai/code',
@@ -110,10 +115,8 @@ def main():
                 r'Claude Code'
             ]
 
-            # Check the command content for Claude attribution
             for pattern in claude_patterns:
                 if re.search(pattern, command, re.IGNORECASE):
-                    # Block the operation
                     response = {
                         "systemMessage": "BLOCKED: Git operation contains Claude Code attribution. Remove AI contribution messages from commit messages and PR descriptions.",
                         "hookSpecificOutput": {
@@ -125,15 +128,14 @@ def main():
                     print(json.dumps(response))
                     sys.exit(0)
 
-            # Output JSON with systemMessage to show reminder to user
             response = {
                 "systemMessage": "Commit Guidelines: Keep messages concise and accurate. Avoid AI attribution in commit messages or PR descriptions."
             }
             print(json.dumps(response))
             sys.exit(0)
 
-    # Allow the operation to continue (no git operation detected)
     sys.exit(0)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Fix branch naming validation for bare `git branch`, `-m/-M/--move`, `-c/-C/--copy` commands
- Handle shell metacharacters (`;`, `&&`, `||`, `|`) in regex patterns
- Update CLAUDE.md merge strategy from `--merge` to `--squash`
- Bump cc-customize to 1.1.0, core-hooks to 1.0.6

Closes #90