### PR TITLE
Add agent-centric task category to GTD skills

### DIFF
--- a/docs/superpowers/specs/2026-04-27-gtd-agent-tasks-design.md
+++ b/docs/superpowers/specs/2026-04-27-gtd-agent-tasks-design.md
@@ -1,0 +1,157 @@
+# GTD Agent-Assisted Tasks Design
+
+## Problem
+
+The current GTD system categorizes all tasks by pomodoro duration (`@quick`, `@1pomo`, `@2pomo`, `@deep`). AI agents are now deeply involved in workflows, and many tasks are delegated to agents — dispatched asynchronously and monitored for results. These agent-centric tasks don't fit the pomodoro model: their duration is unpredictable, and multiple can run concurrently.
+
+## Decision
+
+Binary task classification: every task is either **human-centric** (sequential, pomodoro-timed) or **agent-centric** (parallel, async, due-date only). A new `@agent` list in macOS Reminders holds all agent-centric tasks.
+
+Scheduling model: `gtd-next` assigns 1 human task that fits the time slot + up to 3 agent tasks ranked by priority/due date. Agent tasks require monitoring but not continuous engagement.
+
+## Data Model
+
+### New `@agent` context list
+
+| List | Type | Duration |
+|------|------|----------|
+| @quick | Human | ~15 min |
+| @1pomo | Human | ~25 min |
+| @2pomo | Human | ~50 min |
+| @deep | Human | ~90 min |
+| @agent | Agent | N/A |
+
+### Agent task properties
+
+- Title
+- Priority (1=High, 5=Medium, 9=Low, 0=None)
+- Due date (required, defaults to one week from today)
+- Notes: `#{ProjectName}` for project linking
+- No duration / no time estimate
+
+### Agent-centric inference heuristics
+
+Classify as agent-centric when action text suggests delegatable work:
+- Keywords: "generate", "draft", "analyze", "research", "summarize", "review code", "run tests", "scan", "convert", "process"
+- Pattern: tasks that produce an artifact the user checks later
+- Default to human-centric when ambiguous
+
+All skills use infer-and-confirm: the agent guesses human vs agent from text, user confirms or overrides.
+
+## Skill Changes
+
+### gtd-next
+
+**Current:** Fill time slot with human tasks ranked by priority.
+
+**New:** Two parallel selections.
+
+Human track (unchanged):
+- Rank from `@quick`, `@1pomo`, `@2pomo`, `@deep`
+- Fit into available time slot using pomodoro blocks
+
+Agent track (new):
+- Query `@agent` list
+- Rank by: overdue first, high priority, soonest due date
+- Select top 3 (or fewer if less available)
+- No time-fitting
+
+**Agenda output — with time constraint:**
+
+```
+## Your Agenda (until [Event] at [Time])
+
+### Focus Task
+[Start] - [End]  [Task A] (@1pomo) #[Project]
+[Start] - [End]  Break
+[Start] - [End]  Buffer before [Event]
+
+### Agent Tasks (dispatch and monitor)
+1. [Task B] #[Project] [High] — due 2026-05-01
+2. [Task C] — due 2026-05-03
+3. [Task D] #[Project] [Medium] — due 2026-05-10
+```
+
+**Agenda output — without time constraint:**
+
+```
+## Recommended Next Tasks
+
+### Human Tasks
+1. [Action] #[Project] [High] @quick (~15 min) - OVERDUE
+2. [Action] @1pomo (~25 min) - due 2026-05-01
+...
+
+### Agent Tasks (dispatch up to 3, monitor progress)
+1. [Action] #[Project] [High] — due 2026-05-01
+2. [Action] [Medium] — due 2026-05-05
+3. [Action] — due 2026-05-10
+```
+
+Rules:
+- Agent tasks shown below human task section
+- Max 3 agent tasks per agenda
+- Agent tasks show priority and due date, no duration
+- Overdue agent tasks get warning prefix same as human tasks
+
+### gtd-process
+
+**Step 2:** Add `@agent` to required list creation checks.
+
+**Step 3 (Analyze and Propose):** New inference before time estimation:
+1. Infer task type (human or agent) from text
+2. If human: infer time estimate, assign context list (existing logic)
+3. If agent: skip time estimate, assign `@agent`
+
+**Confirmation prompt — human-centric (unchanged):**
+```
+Item: "Call dentist to schedule appointment"
+Proposed:
+  Type: Human
+  Action: "Call dentist to schedule appointment"
+  List: @quick (~15 min)
+  Priority: Medium
+  Due: 2026-05-04
+```
+
+**Confirmation prompt — agent-centric:**
+```
+Item: "Analyze Q1 sales data and generate summary report"
+Proposed:
+  Type: Agent
+  Action: "Analyze Q1 sales data and generate summary report"
+  List: @agent
+  Priority: Medium
+  Due: 2026-05-04
+```
+
+**Step 4 (Execute):** Same CLI commands, targeting `@agent` list for agent tasks.
+
+### gtd-project
+
+**Step 1 (Gather Data):** Add `@agent` to context list queries and list creation checks.
+
+**Step 2 (Display):** Show `(@agent)` tag with due date instead of time estimate:
+```
+- Actions (3):
+  • "Review pipeline output" (@1pomo)
+  • "Run ETL on Q1 dataset" (@agent) — due 2026-05-01
+  • "Generate dashboard charts" (@agent) — due 2026-05-03
+```
+
+**Step 4a (Add Action):** Infer human vs agent from title text. Include task type in confirmation. "Modify" options include "Task type".
+
+**Step 4c (Edit Action):** "What to edit?" options add "Task type". Switching type moves the task between `@agent` and a time-based list.
+
+**Reference table:** Updated to include `@agent` row.
+
+### gtd-inbox
+
+No changes. Inbox is for raw capture — classification happens during processing.
+
+## Files to Modify
+
+1. `productivity-skills/skills/gtd-next/SKILL.md` — add `@agent` queries, two-track selection, updated agenda format
+2. `productivity-skills/skills/gtd-process/SKILL.md` — add agent inference, `@agent` list creation, updated confirmation prompts
+3. `productivity-skills/skills/gtd-project/SKILL.md` — add `@agent` queries, updated display, task type in add/edit flows

--- a/docs/superpowers/specs/2026-04-27-gtd-agent-tasks-design.md
+++ b/docs/superpowers/specs/2026-04-27-gtd-agent-tasks-design.md
@@ -62,7 +62,7 @@ Agent track (new):
 ```
 ## Your Agenda (until [Event] at [Time])
 
-### Focus Task
+### Focus Tasks
 [Start] - [End]  [Task A] (@1pomo) #[Project]
 [Start] - [End]  Break
 [Start] - [End]  Buffer before [Event]
@@ -126,7 +126,7 @@ Proposed:
   Due: 2026-05-04
 ```
 
-**Step 4 (Execute):** Same CLI commands, targeting `@agent` list for agent tasks.
+**Step 4 (Execute):** CLI templates use `<inferred list>` placeholder — use `@agent` for agent-centric tasks, otherwise the inferred time-based list (@quick, @1pomo, @2pomo, @deep).
 
 ### gtd-project
 

--- a/productivity-skills/skills/gtd-next/SKILL.md
+++ b/productivity-skills/skills/gtd-next/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gtd-next
 version: 3.0.0
-description: This skill should be used when the user asks "what should I work on next?", "plan my next block", "generate an agenda", "what's next?", or wants calendar-aware task selection and time-blocked agenda generation for the GTD Engage step.
+description: This skill should be used when the user asks "what should I work on next?", "plan my next block", "generate an agenda", "what's next?", "dispatch agent tasks", or wants calendar-aware task selection, time-blocked agenda generation, and parallel agent task dispatch for the GTD Engage step.
 ---
 
 <!--
@@ -120,7 +120,7 @@ Select up to 3 agent tasks from the top of the ranked `@agent` list. No time-fit
 ```
 ## Your Agenda (until [Event] at [Time])
 
-### Focus Task
+### Focus Tasks
 [Start Time] - [End Time]  [Task A] (@quick) #[ProjectName]
 [Start Time] - [End Time]  [Task B] (@1pomo)
 [Start Time] - [End Time]  Break

--- a/productivity-skills/skills/gtd-next/SKILL.md
+++ b/productivity-skills/skills/gtd-next/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: gtd-next
-version: 2.1.0
+version: 3.0.0
 description: This skill should be used when the user asks "what should I work on next?", "plan my next block", "generate an agenda", "what's next?", or wants calendar-aware task selection and time-blocked agenda generation for the GTD Engage step.
 ---
 
 <!--
 CLI: swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift
-Context lists: @quick, @1pomo, @2pomo, @deep
+Human context lists: @quick, @1pomo, @2pomo, @deep
+Agent context list: @agent (no duration, async)
 Projects list: "Projects" in macOS Reminders
 Action reference: #{ProjectName} in notes field
 
 Task durations: @quick=15min, @1pomo=25min, @2pomo=50min, @deep=90min
+Agent tasks: no duration, ranked by priority/due date
+Scheduling: 1 human task (fits time slot) + up to 3 agent tasks (parallel)
 Buffer: ~10 min per hour (available_minutes / 6, min 5, max 20)
 Pomodoro: 25 min work + 5 min break
 -->
@@ -49,6 +52,7 @@ swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@1pomo"
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@2pomo"
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@deep"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "@agent"
    ```
 
 2. Query overdue reminders:
@@ -56,31 +60,42 @@ swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders overdue
    ```
 
-3. Parse and combine results, noting for each action:
-   - Context list (@quick, @1pomo, @2pomo, @deep)
-   - Project reference from notes field (#{ProjectName})
-   - Priority value
-   - Due date
-   - Whether overdue
+3. Parse and combine results, separating into two pools:
 
-If no actionable tasks found, report "No actionable tasks found. Add tasks to @quick, @1pomo, @2pomo, or @deep lists." and exit.
+   **Human tasks** (from @quick, @1pomo, @2pomo, @deep):
+   - Context list and duration
+   - Project reference from notes field (#{ProjectName})
+   - Priority value, due date, whether overdue
+
+   **Agent tasks** (from @agent):
+   - Project reference from notes field (#{ProjectName})
+   - Priority value, due date, whether overdue
+   - No duration
+
+If no actionable tasks found in either pool, report "No actionable tasks found. Add tasks to @quick, @1pomo, @2pomo, @deep, or @agent lists." and exit.
 
 ## Step 3: Rank and Select Tasks
 
-**Rank all tasks by priority order:**
+**Ranking order (same for both pools):**
 1. Overdue items first
 2. High priority (priority=1)
 3. Due date approaching (soonest first)
 4. Medium priority (priority=5)
 5. Remaining items
 
+### Human task selection
+
 **If there is a time constraint** (next event found in Step 1):
 
-Select tasks from the top of the ranked list that fit within the available time. Use task durations based on context (@quick=15min, @1pomo=25min, @2pomo=50min, @deep=90min). Account for buffer time and pomodoro breaks when calculating fit. Skip tasks that exceed remaining time and try the next one.
+Select human tasks from the top of the ranked list that fit within the available time. Use task durations based on context (@quick=15min, @1pomo=25min, @2pomo=50min, @deep=90min). Account for buffer time and pomodoro breaks when calculating fit. Skip tasks that exceed remaining time and try the next one.
 
 **If there is no time constraint:**
 
-Select the top 10 actionable tasks from the ranked list.
+Select the top 10 human tasks from the ranked list.
+
+### Agent task selection
+
+Select up to 3 agent tasks from the top of the ranked `@agent` list. No time-fitting — agent tasks run asynchronously in the background. If fewer than 3 agent tasks are available, show all of them.
 
 ## Step 4: Generate Agenda
 
@@ -93,53 +108,67 @@ Select the top 10 actionable tasks from the ranked list.
 
 2. Usable work time = Available time - Buffer time
 
-3. Arrange selected tasks into pomodoro blocks:
+3. Arrange selected human tasks into pomodoro blocks:
    - Each pomodoro = 25 min work + 5 min break
    - Multiple short tasks within 25 min: group without breaks
    - After each 25 min of work, schedule a 5 min break
    - No break needed before the final buffer
    - Longer tasks (@2pomo, @deep): treat as single focused blocks, break after completing
 
-4. Present a time-blocked agenda:
+4. Present a time-blocked agenda with agent tasks listed separately:
 
 ```
 ## Your Agenda (until [Event] at [Time])
 
+### Focus Task
 [Start Time] - [End Time]  [Task A] (@quick) #[ProjectName]
 [Start Time] - [End Time]  [Task B] (@1pomo)
 [Start Time] - [End Time]  Break
 [Start Time] - [End Time]  [Task C] (@2pomo) #[ProjectName]
 [Start Time] - [End Time]  Buffer before [Event]
+
+### Agent Tasks (dispatch and monitor)
+1. [Task D] #[ProjectName] [High] — due [date]
+2. [Task E] — due [date]
+3. [Task F] #[ProjectName] [Medium] — due [date]
 ```
 
 **If there is no time constraint:**
 
-Present the top 10 tasks as a ranked recommendation list:
+Present human tasks as a ranked list, agent tasks separately:
 
 ```
 ## Recommended Next Tasks
 
+### Human Tasks
 1. ⚠️ [Action Title] #[ProjectName] [High] @quick (~15 min) - OVERDUE
 2. [Action Title] #[ProjectName] [High] @1pomo (~25 min) - due [date]
 3. [Action Title] [Medium] @2pomo (~50 min)
 ...
-10. [Action Title] @1pomo (~25 min)
 
 Total estimated time: ~X hours Y min
+
+### Agent Tasks (dispatch up to 3, monitor progress)
+1. [Action Title] #[ProjectName] [High] — due [date]
+2. [Action Title] [Medium] — due [date]
+3. [Action Title] — due [date]
 ```
 
 **Display formatting:**
-- ⚠️ prefix for overdue items
+- ⚠️ prefix for overdue items (both human and agent)
 - Show project name if linked (from notes field)
 - Map priority values: 1=[High], 5=[Medium], 9=[Low], 0=omit
-- Show context list: @quick, @1pomo, @2pomo, @deep
-- Show estimated duration based on context
+- Human tasks: show context list (@quick, @1pomo, @2pomo, @deep) and estimated duration
+- Agent tasks: show priority and due date only, no duration
 - Show due date if set, with "OVERDUE" if past
 
 ## Guidelines
 
-- Prioritize overdue items — they always appear first
+- Prioritize overdue items — they always appear first (both human and agent)
 - Link actions to projects when #{ProjectName} is found in notes
 - Show all matching actions even if multiple belong to the same project
 - Handle CLI errors gracefully and report to user
 - The agent decides what to work on — present the result, do not ask for selection
+- Human tasks are sequential — only 1 active focus task at a time
+- Agent tasks are parallel — up to 3 dispatched concurrently, no time-fitting needed
+- If only human tasks exist, show agenda without agent section (and vice versa)

--- a/productivity-skills/skills/gtd-process/SKILL.md
+++ b/productivity-skills/skills/gtd-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gtd-process
 version: 3.0.0
-description: This skill should be used when the user asks to "process inbox", "process items", "organize inbox", "categorize tasks", or wants to process GTD inbox items into projects or actions following the GTD clarify/organize workflow.
+description: This skill should be used when the user asks to "process inbox", "process items", "triage inbox", "clarify inbox", "organize inbox", "categorize tasks", or wants to process GTD inbox items into projects or actions following the GTD clarify/organize workflow.
 ---
 
 Process GTD inbox items into projects or actions. The agent infers categorization, project assignment, priority, time estimate, and due date for each item — then presents a single confirmation for the user to approve or modify.
@@ -133,30 +133,31 @@ Based on the confirmed or modified proposal:
      --notes "Goal: [end goal]" \
      --due "YYYY-MM-DD 17:00"
    ```
-2. Create first action in the appropriate context list:
+2. Create first action in the appropriate context list (use the inferred list from Step 3):
    ```bash
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
      --title "Action title" \
-     --list "@1pomo" \
+     --list "<inferred list>" \
      --notes "#{ProjectName-YYYYMMDD}" \
      --priority 5
    ```
+   Use `@agent` if the first action is agent-centric, otherwise use the inferred time-based list (@quick, @1pomo, @2pomo, @deep).
 
-**For project actions:**
+**For project actions (use the inferred list from Step 3):**
 ```bash
 swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
   --title "Action title" \
-  --list "@1pomo" \
+  --list "<inferred list>" \
   --notes "#{ProjectName-YYYYMMDD}" \
   --priority 5 \
   --due "YYYY-MM-DD 17:00"
 ```
 
-**For single actions (human-centric):**
+**For single actions (human-centric — use the inferred time-based list):**
 ```bash
 swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
   --title "Action title" \
-  --list "@1pomo" \
+  --list "<inferred list>" \
   --priority 5 \
   --due "YYYY-MM-DD 17:00"
 ```

--- a/productivity-skills/skills/gtd-process/SKILL.md
+++ b/productivity-skills/skills/gtd-process/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gtd-process
-version: 2.1.0
+version: 3.0.0
 description: This skill should be used when the user asks to "process inbox", "process items", "organize inbox", "categorize tasks", or wants to process GTD inbox items into projects or actions following the GTD clarify/organize workflow.
 ---
 
@@ -39,6 +39,7 @@ Determine the processing mode from the user's message:
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create-list "@1pomo"
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create-list "@2pomo"
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create-list "@deep"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create-list "@agent"
    ```
 6. Fetch existing projects for context:
    ```bash
@@ -53,9 +54,13 @@ For each inbox item, analyze the text and infer:
    - If existing projects were fetched, check if the item relates to any of them
 2. **Project assignment**: If it's a project action, which project does it belong to?
 3. **Action title**: Clean up the inbox text into a clear action title
-4. **Time estimate**: Infer from complexity — @quick (< 25 min), @1pomo (25 min), @2pomo (50 min), @deep (90+ min)
-5. **Priority**: Infer from urgency cues in the text (default: Medium)
-6. **Due date**: Infer from any time references in the text (default: one week from today)
+4. **Task type**: Is this human-centric or agent-centric?
+   - **Agent-centric indicators**: "generate", "draft", "analyze", "research", "summarize", "review code", "run tests", "scan", "convert", "process" — tasks that produce an artifact the user monitors and checks later
+   - **Human-centric indicators**: phone calls, meetings, physical tasks, decisions requiring real-time judgment
+   - Default to human-centric when ambiguous
+5. **Time estimate** (human-centric only): Infer from complexity — @quick (< 25 min), @1pomo (25 min), @2pomo (50 min), @deep (90+ min). Skip for agent-centric tasks.
+6. **Priority**: Infer from urgency cues in the text (default: Medium)
+7. **Due date**: Infer from any time references in the text (default: one week from today)
 
 **For new projects**, also infer:
 - Project name: `{CamelCaseSummary}-{YYYYMMDD}`
@@ -63,6 +68,37 @@ For each inbox item, analyze the text and infer:
 
 Present the proposal to the user with a single **AskUserQuestion**: "Confirm or modify this processing:"
 
+**Human-centric example:**
+```
+Item: "Call dentist to schedule appointment"
+
+Proposed:
+  Type: Single Action
+  Task type: Human
+  Action: "Call dentist to schedule appointment"
+  List: @quick (~15 min)
+  Priority: Medium
+  Due: 2026-05-04
+
+Confirm or modify?
+```
+
+**Agent-centric example:**
+```
+Item: "Analyze Q1 sales data and generate summary report"
+
+Proposed:
+  Type: Single Action
+  Task type: Agent
+  Action: "Analyze Q1 sales data and generate summary report"
+  List: @agent
+  Priority: Medium
+  Due: 2026-05-04
+
+Confirm or modify?
+```
+
+**New project example:**
 ```
 Item: "Research vacation flights by end of month"
 
@@ -72,7 +108,7 @@ Proposed:
   Goal: Flights researched and booked
   Priority: Medium
   Due: 2026-03-31
-  First action: "Search flight comparison sites" (@1pomo)
+  First action: "Search flight comparison sites" (@1pomo, Human)
 
 Confirm or modify?
 ```
@@ -116,11 +152,20 @@ swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
   --due "YYYY-MM-DD 17:00"
 ```
 
-**For single actions:**
+**For single actions (human-centric):**
 ```bash
 swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
   --title "Action title" \
   --list "@1pomo" \
+  --priority 5 \
+  --due "YYYY-MM-DD 17:00"
+```
+
+**For single actions (agent-centric):**
+```bash
+swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create \
+  --title "Action title" \
+  --list "@agent" \
   --priority 5 \
   --due "YYYY-MM-DD 17:00"
 ```
@@ -139,7 +184,9 @@ Use Edit tool to remove the processed item from inbox.md.
 
 ## Reference
 
-**Context lists:** @quick (< 25 min), @1pomo (25 min), @2pomo (50 min), @deep (90+ min)
+**Context lists (human):** @quick (< 25 min), @1pomo (25 min), @2pomo (50 min), @deep (90+ min)
+
+**Context list (agent):** @agent (no duration — async, monitor progress)
 
 **Priority values:** 1=High, 5=Medium, 9=Low, 0=None
 

--- a/productivity-skills/skills/gtd-project/SKILL.md
+++ b/productivity-skills/skills/gtd-project/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gtd-project
 version: 3.0.0
-description: This skill should be used when the user asks to "review projects", "manage projects", "check project status", "add action to project", "complete project", or wants to review and manage GTD projects with a guided workflow including status tracking and action management.
+description: This skill should be used when the user asks to "review projects", "manage projects", "check project status", "add action to project", "add agent task", "complete project", or wants to review and manage GTD projects with a guided workflow including status tracking, action management, and agent-centric task assignment.
 ---
 
 <!--
@@ -246,6 +246,7 @@ In all cases, the user can override the suggestion by saying "complete project" 
      --priority 5 \
      --due "2026-01-15 17:00"
    ```
+   If the create command fails after deletion, immediately retry with the same parameters. Report the original action details to the user so they can manually recover if needed.
 
 5. Report: "Updated action '[title]'"
 

--- a/productivity-skills/skills/gtd-project/SKILL.md
+++ b/productivity-skills/skills/gtd-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gtd-project
-version: 2.0.0
+version: 3.0.0
 description: This skill should be used when the user asks to "review projects", "manage projects", "check project status", "add action to project", "complete project", or wants to review and manage GTD projects with a guided workflow including status tracking and action management.
 ---
 
@@ -9,10 +9,11 @@ Projects list: "Projects" in macOS Reminders
 Project naming: {CamelCaseSummary}-{YYYYMMDD} (e.g., VacationResearch-20260112)
 Action reference: #{FullProjectName} in notes field
 Project notes: "Goal: [end goal description]"
-Context lists: @quick, @1pomo, @2pomo, @deep
+Human context lists: @quick, @1pomo, @2pomo, @deep
+Agent context list: @agent (no duration, async)
 CLI: swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift
 
-Key principle: Projects can have multiple parallel actions. Track all actionable tasks that can be worked on independently.
+Key principle: Projects can have multiple parallel actions. Track all actionable tasks that can be worked on independently. Actions are either human-centric (pomodoro-timed) or agent-centric (async, no duration).
 -->
 
 Review and manage GTD projects with infer-and-confirm workflow. The agent analyzes project state, proposes actions, and the user confirms or overrides — minimizing back-and-forth.
@@ -43,6 +44,7 @@ swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create-list "@1pomo"
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create-list "@2pomo"
    swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create-list "@deep"
+   swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders create-list "@agent"
    ```
 
 3. Query all open projects:
@@ -52,7 +54,7 @@ swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift <command>
 
 4. Query all context lists for actions:
    ```bash
-   for context in "@quick" "@1pomo" "@2pomo" "@deep"; do
+   for context in "@quick" "@1pomo" "@2pomo" "@deep" "@agent"; do
      swift ${CLAUDE_PLUGIN_ROOT}/scripts/productivity-cli.swift reminders incomplete "$context"
    done
    ```
@@ -91,9 +93,10 @@ Present all projects sorted by urgency (overdue first, then stalled, then health
 
 3. ✓ VacationResearch-20260112 [High]
    - Goal: Flights and hotel booked for Hawaii trip
-   - Actions (2):
+   - Actions (3):
      • "Research flights to Hawaii" (@1pomo)
      • "Email hotel for rates" (@quick)
+     • "Analyze flight price trends" (@agent) — due 2026-01-20
 
 Which project to work on? [1/2/3/Done]
 ```
@@ -133,14 +136,17 @@ In all cases, the user can override the suggestion by saying "complete project" 
    - User provides action title
 
 2. **Infer all properties from the title text** (same pattern as gtd-process):
-   - **Time estimate**: Infer from complexity. "Email..." → @quick, "Research..." → @1pomo, "Write report..." → @2pomo, "Redesign..." → @deep
+   - **Task type**: Infer human vs agent from text. Agent-centric indicators: "generate", "draft", "analyze", "research", "summarize", "review code", "run tests", "scan", "convert", "process". Default to human-centric when ambiguous.
+   - **Time estimate** (human only): Infer from complexity. "Email..." → @quick, "Research..." → @1pomo, "Write report..." → @2pomo, "Redesign..." → @deep. Skip for agent-centric tasks.
    - **Priority**: Inherit from project priority by default
-   - **Due date**: No due date unless the title implies urgency ("today", "by Friday", "urgent")
+   - **Due date**: No due date unless the title implies urgency ("today", "by Friday", "urgent"). For agent-centric tasks, default to one week from today if no date implied.
 
 3. Present a single proposal for confirmation:
 
+   **Human-centric example:**
    ```
    Action: "Email hotel for rates"
+   → Type: Human
    → List: @quick (~15 min)
    → Priority: High (inherited from project)
    → Due: No due date
@@ -148,9 +154,20 @@ In all cases, the user can override the suggestion by saying "complete project" 
    Confirm? [Yes / Modify / Skip]
    ```
 
+   **Agent-centric example:**
+   ```
+   Action: "Analyze flight price trends"
+   → Type: Agent
+   → List: @agent
+   → Priority: High (inherited from project)
+   → Due: 2026-01-20
+
+   Confirm? [Yes / Modify / Skip]
+   ```
+
    Use **AskUserQuestion**: "Confirm this action?"
    - Options: "Yes", "Modify", "Skip"
-   - If "Modify": ask which property to change, then re-confirm
+   - If "Modify": ask which property to change (includes "Task type"), then re-confirm
    - If "Yes": create the action
    - If "Skip": return to Step 2
 
@@ -208,10 +225,11 @@ In all cases, the user can override the suggestion by saying "complete project" 
 3. **For general edit** (user selected "Edit action"):
    - Show current properties
    - Use **AskUserQuestion**: "What to edit?" with multiSelect
-     - Options: "Title", "Time estimate", "Priority", "Due date", "Done editing"
+     - Options: "Title", "Task type", "Time estimate", "Priority", "Due date", "Done editing"
    - For each selected property, gather the new value:
      - Title: ask for new title text
-     - Time estimate: options "Quick", "1 Pomodoro", "2 Pomodoros", "Deep" (maps to @quick, @1pomo, @2pomo, @deep)
+     - Task type: options "Human", "Agent". Switching to agent moves task to @agent and removes time estimate. Switching to human requires selecting a time estimate.
+     - Time estimate (human only): options "Quick", "1 Pomodoro", "2 Pomodoros", "Deep" (maps to @quick, @1pomo, @2pomo, @deep)
      - Priority: options "High", "Medium", "Low", "None" (maps to 1, 5, 9, 0)
      - Due date: options "No due date", "Today", "Tomorrow", "This week", "Custom date"
 
@@ -280,12 +298,13 @@ Projects completed: 1
 
 ## Reference: Context Lists
 
-| List | Time Estimate |
-|------|---------------|
-| @quick | Quick tasks (< 25 min) |
-| @1pomo | 1 Pomodoro (25 min) |
-| @2pomo | 2 Pomodoros (50 min) |
-| @deep | Deep focus (3+ pomodoros) |
+| List | Type | Time Estimate |
+|------|------|---------------|
+| @quick | Human | Quick tasks (< 25 min) |
+| @1pomo | Human | 1 Pomodoro (25 min) |
+| @2pomo | Human | 2 Pomodoros (50 min) |
+| @deep | Human | Deep focus (3+ pomodoros) |
+| @agent | Agent | N/A (async, monitor progress) |
 
 ## Reference: Priority Values
 


### PR DESCRIPTION
## Summary

- Adds `@agent` context list for async, delegatable tasks alongside existing pomodoro-based lists
- `gtd-next` now schedules 1 human task + up to 3 agent tasks per agenda
- `gtd-process` and `gtd-project` infer human vs agent from action text with confirm-and-override
- All three skills bumped to v3.0.0