### PR TITLE
Bump productivity-skills plugin version to 5.0.0

### DIFF
--- a/productivity-skills/.claude-plugin/plugin.json
+++ b/productivity-skills/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "productivity-skills",
   "description": "macOS productivity skills for managing Calendar events, Reminders, and proactive task management via EventKit CLI",
-  "version": "4.3.0"
+  "version": "5.0.0"
 }


### PR DESCRIPTION
## Summary

- Bump plugin version from 4.3.0 to 5.0.0 to invalidate cache after #95 added @agent context list to GTD skills
- Without this bump, `/reload-plugins` serves stale cached skills missing the @agent support