### PR TITLE
Support Codex hook tool payloads

### DIFF
--- a/core-hooks/.claude-plugin/plugin.json
+++ b/core-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks for Claude Code",
-  "version": "1.0.6"
+  "version": "1.0.7"
 }

--- a/core-hooks/hooks/hooks.codex.json
+++ b/core-hooks/hooks/hooks.codex.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|Write|Edit|MultiEdit|Read",
+        "matcher": "Bash|Write|Edit|MultiEdit|Read|exec_command|apply_patch",
         "hooks": [
           {
             "type": "command",
@@ -11,7 +11,7 @@
         ]
       },
       {
-        "matcher": "Bash",
+        "matcher": "Bash|exec_command",
         "hooks": [
           {
             "type": "command",

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -16,6 +16,14 @@ import sys
 VALID_PREFIXES = ['feat-', 'bugfix-', 'doc-', 'refactor-', 'chore-', 'test-']
 
 
+def get_shell_command(tool_name, tool_input):
+    if tool_name == "Bash":
+        return tool_input.get("command", "")
+    if tool_name == "exec_command":
+        return tool_input.get("cmd", "")
+    return ""
+
+
 def extract_branch_name(command):
     # [^\s;|&]+ instead of \S+ to stop at shell metacharacters (; && || |)
     m = re.search(r'git checkout -b\s+([^\s;|&]+)', command)
@@ -64,8 +72,8 @@ def main():
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 
-    if tool_name == "Bash":
-        command = tool_input.get("command", "")
+    command = get_shell_command(tool_name, tool_input)
+    if command:
 
         if re.search(r'git add\s+(-A|--all|\.(?:\s|$)|\.\/(?:\s|$))', command):
             response = {

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -17,6 +17,8 @@ VALID_PREFIXES = ['feat-', 'bugfix-', 'doc-', 'refactor-', 'chore-', 'test-']
 
 
 def get_shell_command(tool_name, tool_input):
+    if not isinstance(tool_input, dict):
+        return ""
     if tool_name == "Bash":
         return tool_input.get("command", "")
     if tool_name == "exec_command":
@@ -74,7 +76,6 @@ def main():
 
     command = get_shell_command(tool_name, tool_input)
     if command:
-
         if re.search(r'git add\s+(-A|--all|\.(?:\s|$)|\.\/(?:\s|$))', command):
             response = {
                 "systemMessage": "BLOCKED: Use 'git add <filename>' with specific file names instead of 'git add .', 'git add -A', or 'git add --all' for precise change control.",

--- a/core-hooks/scripts/safety_guard.py
+++ b/core-hooks/scripts/safety_guard.py
@@ -8,6 +8,15 @@ import sys
 import re
 from pathlib import Path
 
+
+def get_shell_command(tool_name, tool_input):
+    if tool_name == 'Bash':
+        return tool_input.get('command', '')
+    if tool_name == 'exec_command':
+        return tool_input.get('cmd', '')
+    return ''
+
+
 def is_dangerous_rm_command(command):
     """
     Selective detection of dangerous rm commands.
@@ -64,15 +73,13 @@ def main():
         tool_name = input_data.get('tool_name', '')
         tool_input = input_data.get('tool_input', {})
 
-        # Check for dangerous rm -rf commands
-        if tool_name == 'Bash':
-            command = tool_input.get('command', '')
+        command = get_shell_command(tool_name, tool_input)
 
-            # Block dangerous rm commands while allowing explicit removals
-            if is_dangerous_rm_command(command):
-                print("BLOCKED: Potentially dangerous rm command detected", file=sys.stderr)
-                print("Safe explicit removals like 'rm -rf specific_folder' are allowed", file=sys.stderr)
-                sys.exit(2)  # Exit code 2 blocks tool call and shows error to Claude
+        # Block dangerous rm commands while allowing explicit removals
+        if command and is_dangerous_rm_command(command):
+            print("BLOCKED: Potentially dangerous rm command detected", file=sys.stderr)
+            print("Safe explicit removals like 'rm -rf specific_folder' are allowed", file=sys.stderr)
+            sys.exit(2)  # Exit code 2 blocks tool call and shows error to Claude/Codex
 
         # Ensure log directory exists
         log_dir = Path.cwd() / 'logs'

--- a/core-hooks/scripts/safety_guard.py
+++ b/core-hooks/scripts/safety_guard.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 
 def get_shell_command(tool_name, tool_input):
+    if not isinstance(tool_input, dict):
+        return ''
     if tool_name == 'Bash':
         return tool_input.get('command', '')
     if tool_name == 'exec_command':

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -16,8 +16,9 @@ def run_hook(payload):
         input=json.dumps(payload),
         text=True,
         capture_output=True,
-        check=True,
+        check=False,
     )
+    assert result.returncode == 0, f"Hook failed (exit {result.returncode}): {result.stderr}"
     return json.loads(result.stdout)
 
 

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -1,0 +1,53 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "pre_git_hook.py"
+CODEX_HOOKS = ROOT / "hooks" / "hooks.codex.json"
+
+
+def run_hook(payload):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+class PreGitHookTests(unittest.TestCase):
+    def test_blocks_invalid_codex_exec_command_branch_name(self):
+        response = run_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "exec_command",
+                "tool_input": {"cmd": "git switch -c codex-plugin-support"},
+            }
+        )
+
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("codex-plugin-support", response["systemMessage"])
+
+    def test_codex_hooks_match_exec_command_for_git_guard(self):
+        hooks = json.loads(CODEX_HOOKS.read_text())
+        matchers = [
+            entry["matcher"]
+            for entry in hooks["hooks"]["PreToolUse"]
+            for hook in entry["hooks"]
+            if "pre_git_hook.py" in hook["command"]
+        ]
+
+        self.assertTrue(
+            any("exec_command" in matcher for matcher in matchers),
+            f"pre_git_hook.py matcher should include exec_command, got {matchers}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core-hooks/tests/test_safety_guard.py
+++ b/core-hooks/tests/test_safety_guard.py
@@ -1,0 +1,55 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "safety_guard.py"
+CODEX_HOOKS = ROOT / "hooks" / "hooks.codex.json"
+
+
+def run_hook(payload):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            cwd=temp_dir,
+            check=False,
+        )
+
+
+class SafetyGuardTests(unittest.TestCase):
+    def test_blocks_dangerous_codex_exec_command_rm(self):
+        result = run_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "exec_command",
+                "tool_input": {"cmd": "rm -rf *"},
+            }
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("BLOCKED", result.stderr)
+
+    def test_codex_hooks_match_exec_command_for_safety_guard(self):
+        hooks = json.loads(CODEX_HOOKS.read_text())
+        matchers = [
+            entry["matcher"]
+            for entry in hooks["hooks"]["PreToolUse"]
+            for hook in entry["hooks"]
+            if "safety_guard.py" in hook["command"]
+        ]
+
+        self.assertTrue(
+            any("exec_command" in matcher for matcher in matchers),
+            f"safety_guard.py matcher should include exec_command, got {matchers}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add Codex shell tool matching to core hook configuration
- Normalize shell command extraction for Claude and Codex hook payloads
- Add regression tests for branch-name and dangerous rm guards

## Test Plan
- python3 -m unittest core-hooks/tests/test_pre_git_hook.py core-hooks/tests/test_safety_guard.py
- python3 -m py_compile core-hooks/scripts/pre_git_hook.py core-hooks/scripts/safety_guard.py core-hooks/scripts/post_tool_use.py core-hooks/scripts/system_notification.py
- jq . core-hooks/hooks/hooks.codex.json core-hooks/.codex-plugin/plugin.json