### PR TITLE
Fix statusline token breakdown and show effort level

### DIFF
--- a/cc-customize/.claude-plugin/plugin.json
+++ b/cc-customize/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "cc-customize",
   "description": "Claude Code customization skills for configuring model, effort level, auto-compact threshold, and statusline",
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/cc-customize/skills/statusline-setup/SKILL.md
+++ b/cc-customize/skills/statusline-setup/SKILL.md
@@ -10,9 +10,9 @@ Install and configure a custom Claude Code statusline that shows model info, git
 
 The statusline displays 3 lines:
 
-1. **Model + Project + Git** — `[Opus 4.6] │ my-project git:(main*)`
+1. **Model[·Effort] + Project + Git** — `[Opus 4.7 · high] │ my-project git:(main*)` (effort level shown when the model supports it)
 2. **Usage bars** — Context, 5-hour rate limit, and 7-day rate limit with color-coded progress bars and reset countdowns
-3. **Token breakdown + cost** — Input, cache-write, cache-read, output tokens with session cost from Claude Code
+3. **Token breakdown + cost** — Fresh input, cache-write, cache-read, output tokens (non-overlapping components of the current context window) with session cost from Claude Code
 
 ## Prerequisites
 

--- a/cc-customize/skills/statusline-setup/SKILL.md
+++ b/cc-customize/skills/statusline-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: statusline-setup
-version: 1.1.0
+version: 1.2.0
 description: This skill should be used when the user asks to "set up statusline", "configure statusline", "install statusline", "set up status bar", or wants to configure the Claude Code statusline with model info, git status, context/rate-limit bars, and token cost tracking.
 ---
 
@@ -10,7 +10,7 @@ Install and configure a custom Claude Code statusline that shows model info, git
 
 The statusline displays 3 lines:
 
-1. **Model[·Effort] + Project + Git** — `[Opus 4.7 · high] │ my-project git:(main*)` (effort level shown when the model supports it)
+1. **Model[·Effort] + Project + Git** — `[Opus 4.7 · high] │ my-project git:(main*)`. Effort is omitted when the model doesn't expose it: `[Opus 4.7] │ my-project git:(main*)`.
 2. **Usage bars** — Context, 5-hour rate limit, and 7-day rate limit with color-coded progress bars and reset countdowns
 3. **Token breakdown + cost** — Fresh input, cache-write, cache-read, output tokens (non-overlapping components of the current context window) with session cost from Claude Code
 

--- a/cc-customize/skills/statusline-setup/SKILL.md
+++ b/cc-customize/skills/statusline-setup/SKILL.md
@@ -48,6 +48,10 @@ Read `~/.claude/settings.json`, then set the `statusLine` field to the following
 
 Inform the user that the statusline is configured. Changes take effect on the next Claude Code session (restart required).
 
+## Updating
+
+To install changes from a new plugin version, re-run Step 1 above.
+
 ## Uninstall
 
 To remove the statusline, delete the `statusLine` field from `~/.claude/settings.json` and remove `~/.claude/statusline-command.sh`.

--- a/cc-customize/skills/statusline-setup/scripts/statusline-command.sh
+++ b/cc-customize/skills/statusline-setup/scripts/statusline-command.sh
@@ -144,8 +144,8 @@ fi
 printf "\n"
 
 # Line 3: Token breakdown + cost
-# in/cw/cr/out are non-overlapping components of the current context window
-# (in = fresh input only; total_input_tokens = in + cw + cr per Claude Code docs)
+# in/cw/cr/out are non-overlapping components from current_usage.
+# Per Claude Code docs: total_input_tokens = in + cw + cr; total_output_tokens = out.
 if [ "$CW" != "null" ] && [ -n "$CW" ]; then
   IN_TOKENS=$(echo "$CW" | jq -r '.current_usage.input_tokens // 0')
   OUT_TOKENS=$(echo "$CW" | jq -r '.current_usage.output_tokens // 0')

--- a/cc-customize/skills/statusline-setup/scripts/statusline-command.sh
+++ b/cc-customize/skills/statusline-setup/scripts/statusline-command.sh
@@ -144,8 +144,8 @@ fi
 printf "\n"
 
 # Line 3: Token breakdown + cost
-# in/cw/cr/out are non-overlapping components from current_usage.
-# Per Claude Code docs: total_input_tokens = in + cw + cr; total_output_tokens = out.
+# All four counts (in/cw/cr/out) are sourced from current_usage — non-overlapping.
+# Docs equivalence: total_input_tokens = in+cw+cr; total_output_tokens = out.
 if [ "$CW" != "null" ] && [ -n "$CW" ]; then
   IN_TOKENS=$(echo "$CW" | jq -r '.current_usage.input_tokens // 0')
   OUT_TOKENS=$(echo "$CW" | jq -r '.current_usage.output_tokens // 0')

--- a/cc-customize/skills/statusline-setup/scripts/statusline-command.sh
+++ b/cc-customize/skills/statusline-setup/scripts/statusline-command.sh
@@ -5,6 +5,7 @@ INPUT=$(cat)
 
 # Parse JSON once
 MODEL=$(echo "$INPUT" | jq -r '.model.display_name // .model.id // "Claude"')
+EFFORT=$(echo "$INPUT" | jq -r '.effort.level // empty')
 CW=$(echo "$INPUT" | jq -c '.context_window // null')
 CWD=$(echo "$INPUT" | jq -r '.cwd // ""')
 
@@ -66,8 +67,12 @@ if [ "$CW" != "null" ] && [ -n "$CW" ]; then
   PERCENT=$(echo "$CW" | jq -r '.used_percentage // 0' | awk '{printf "%d", $1}')
 fi
 
-# Line 1: Model | Project git:(branch*)
-LINE1="${DIM}[${RST}${MODEL}${DIM}]${RST}"
+# Line 1: Model[· effort] | Project git:(branch*)
+if [ -n "$EFFORT" ]; then
+  LINE1="${DIM}[${RST}${MODEL}${DIM} · ${RST}${EFFORT}${DIM}]${RST}"
+else
+  LINE1="${DIM}[${RST}${MODEL}${DIM}]${RST}"
+fi
 if [ -n "$PROJECT" ]; then
   LINE1+=" ${DIM}│${RST} ${PROJECT}"
 fi
@@ -139,19 +144,21 @@ fi
 printf "\n"
 
 # Line 3: Token breakdown + cost
+# in/cw/cr/out are non-overlapping components of the current context window
+# (in = fresh input only; total_input_tokens = in + cw + cr per Claude Code docs)
 if [ "$CW" != "null" ] && [ -n "$CW" ]; then
-  TOTAL_INPUT=$(echo "$CW" | jq -r '.total_input_tokens // 0')
-  TOTAL_OUTPUT=$(echo "$CW" | jq -r '.total_output_tokens // 0')
+  IN_TOKENS=$(echo "$CW" | jq -r '.current_usage.input_tokens // 0')
+  OUT_TOKENS=$(echo "$CW" | jq -r '.current_usage.output_tokens // 0')
   CACHE_WRITE=$(echo "$CW" | jq -r '.current_usage.cache_creation_input_tokens // 0')
   CACHE_READ=$(echo "$CW" | jq -r '.current_usage.cache_read_input_tokens // 0')
 
-  if [ "$TOTAL_INPUT" -gt 0 ] || [ "$TOTAL_OUTPUT" -gt 0 ]; then
-    IN_FMT=$(format_k "$TOTAL_INPUT")
-    OUT_FMT=$(format_k "$TOTAL_OUTPUT")
+  if [ "$IN_TOKENS" -gt 0 ] || [ "$OUT_TOKENS" -gt 0 ]; then
+    IN_FMT=$(format_k "$IN_TOKENS")
+    OUT_FMT=$(format_k "$OUT_TOKENS")
     CW_FMT=$(format_k "$CACHE_WRITE")
     CR_FMT=$(format_k "$CACHE_READ")
 
-    # Cost from Claude Code's built-in calculation
+    # Cost from Claude Code's built-in client-side estimate
     COST=$(echo "$INPUT" | jq -r '.cost.total_cost_usd // 0' | awk '{printf "%.2f", $1}')
 
     printf "  ${DIM}in:${RST}%s ${DIM}cw:${RST}%s ${DIM}cr:${RST}%s ${DIM}out:${RST}%s ${DIM}│${RST} \$%s\n" \

--- a/cc-customize/skills/statusline-setup/scripts/statusline-command.sh
+++ b/cc-customize/skills/statusline-setup/scripts/statusline-command.sh
@@ -152,7 +152,7 @@ if [ "$CW" != "null" ] && [ -n "$CW" ]; then
   CACHE_WRITE=$(echo "$CW" | jq -r '.current_usage.cache_creation_input_tokens // 0')
   CACHE_READ=$(echo "$CW" | jq -r '.current_usage.cache_read_input_tokens // 0')
 
-  if [ "$IN_TOKENS" -gt 0 ] || [ "$OUT_TOKENS" -gt 0 ]; then
+  if [ "$IN_TOKENS" -gt 0 ] || [ "$OUT_TOKENS" -gt 0 ] || [ "$CACHE_WRITE" -gt 0 ] || [ "$CACHE_READ" -gt 0 ]; then
     IN_FMT=$(format_k "$IN_TOKENS")
     OUT_FMT=$(format_k "$OUT_TOKENS")
     CW_FMT=$(format_k "$CACHE_WRITE")


### PR DESCRIPTION
## Summary
- Switch `in:` to `current_usage.input_tokens` so `in + cw + cr` no longer double-counts (per Claude Code statusline docs, `total_input_tokens` already equals `input_tokens + cache_creation + cache_read`)
- Add `.effort.level` to line 1 — renders as `[Opus 4.7 · high]`, gracefully omitted when the model doesn't expose effort