### PR TITLE
Redesign pr-feedback Step 2 wait mechanism

### DIFF
--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-skills",
   "description": "Collection of development workflow skills including systematic problem-solving cycle from brainstorming to PR merge",
-  "version": "3.4.0"
+  "version": "3.5.0"
 }

--- a/dev-skills/skills/pr-feedback/SKILL.md
+++ b/dev-skills/skills/pr-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-feedback
-version: 3.1.0
+version: 3.2.0
 description: This skill should be used when the user asks to "gather PR feedback", "review and fix PR issues", "run pr-feedback", "address reviewer comments", or wants to run a structured review-fix-push cycle on the current pull request. Orchestrates self-review, external review collection, issue investigation, and iterative fixing until clean.
 ---
 
@@ -34,13 +34,15 @@ Save the full list for consolidation in Step 3.
 
 External reviewers (e.g., GitHub Actions bots, Claude Code Review) are typically triggered when the PR is pushed and run in parallel with the self-review. They often take longer to complete than the self-review.
 
-**Wait for external reviewers to finish:**
+**Wait via a background-scheduled delay, then read comments:**
 
-1. After self-review completes, wait **2 minutes** before checking GitHub. This gives automated reviewers time to post their results.
-2. After waiting, read all reviewer comments on the PR — including review comments, inline comments, and general PR comments. Extract actionable feedback items.
-3. If no external reviews exist after waiting, proceed to Step 3 with self-review issues only.
+1. After self-review completes, fire a 2-minute background wait. Use the Bash tool with `run_in_background: true` and the command `sleep 120`. The harness will notify when it completes — do not poll, do not run a foreground `sleep`, do not invoke any other tool while waiting.
 
-**Never ask the user for input during this step** — do not prompt to add reviewers, wait longer, or confirm before proceeding. This step is fully autonomous.
+2. After the notification, read all reviewer comments on the PR — review summaries, inline review comments, and general PR comments. Extract actionable feedback items.
+
+3. **If no external reviews exist after the wait, proceed to Step 3 with self-review issues only.** Do not extend the wait. Do not ask the user. The Step 6 loop will catch any late-arriving comments in a subsequent cycle — that's by design.
+
+**Never ask the user for input during this step.** Not to wait longer, not to confirm, not to add reviewers. The full step is autonomous.
 
 ## Step 3: Consolidate Issues
 

--- a/dev-skills/skills/pr-feedback/SKILL.md
+++ b/dev-skills/skills/pr-feedback/SKILL.md
@@ -36,7 +36,7 @@ External reviewers (e.g., GitHub Actions bots, Claude Code Review) are typically
 
 **Wait via a background-scheduled delay, then read comments:**
 
-1. After self-review completes, fire a 2-minute background wait. Use the Bash tool with `run_in_background: true` and the command `sleep 120`. The harness will notify when it completes — do not poll, do not run a foreground `sleep`, do not invoke any other tool while waiting.
+1. After self-review completes, schedule a 2-minute background wait. Use the Bash tool with `run_in_background: true` and the command `sleep 120`. End your turn after firing — the harness will notify when the wait completes and resume you at step 2. Do not poll, do not run a foreground `sleep`, do not chain other tool calls in the same turn to check on the wait.
 
 2. After the notification, read all reviewer comments on the PR — review summaries, inline review comments, and general PR comments. Extract actionable feedback items.
 

--- a/dev-skills/skills/pr-feedback/SKILL.md
+++ b/dev-skills/skills/pr-feedback/SKILL.md
@@ -36,7 +36,7 @@ External reviewers (e.g., GitHub Actions bots, Claude Code Review) are typically
 
 **Wait via a background-scheduled delay, then read comments:**
 
-1. After self-review completes, schedule a 2-minute background wait. Use the Bash tool with `run_in_background: true` and the command `sleep 120`. End your turn after firing — the harness will notify when the wait completes and resume you at step 2. Do not poll, do not run a foreground `sleep`, do not chain other tool calls in the same turn to check on the wait.
+1. After self-review completes, schedule a 2-minute background wait. Use the Bash tool with `run_in_background: true` and the command `sleep 120`. End your turn after firing — the harness will notify when the wait completes. Do not poll, do not run a foreground `sleep`, do not chain other tool calls in the same turn to check on the wait.
 
 2. After the notification, read all reviewer comments on the PR — review summaries, inline review comments, and general PR comments. Extract actionable feedback items.
 

--- a/docs/superpowers/plans/2026-05-14-pr-feedback-step2.md
+++ b/docs/superpowers/plans/2026-05-14-pr-feedback-step2.md
@@ -29,7 +29,7 @@ External reviewers (e.g., GitHub Actions bots, Claude Code Review) are typically
 
 **Wait via a background-scheduled delay, then read comments:**
 
-1. After self-review completes, fire a 2-minute background wait. Use the Bash tool with `run_in_background: true` and the command `sleep 120`. The harness will notify when it completes — do not poll, do not run a foreground `sleep`, do not invoke any other tool while waiting.
+1. After self-review completes, schedule a 2-minute background wait. Use the Bash tool with `run_in_background: true` and the command `sleep 120`. End your turn after firing — the harness will notify when the wait completes. Do not poll, do not run a foreground `sleep`, do not chain other tool calls in the same turn to check on the wait.
 
 2. After the notification, read all reviewer comments on the PR — review summaries, inline review comments, and general PR comments. Extract actionable feedback items.
 

--- a/docs/superpowers/plans/2026-05-14-pr-feedback-step2.md
+++ b/docs/superpowers/plans/2026-05-14-pr-feedback-step2.md
@@ -18,7 +18,7 @@
 - Modify: `dev-skills/skills/pr-feedback/SKILL.md` (frontmatter line 3; Step 2 body lines 33–43)
 - Modify: `dev-skills/.claude-plugin/plugin.json` (version field line 4)
 
-- [ ] **Step 1: Replace the Step 2 body in SKILL.md**
+- [x] **Step 1: Replace the Step 2 body in SKILL.md**
 
 Open `dev-skills/skills/pr-feedback/SKILL.md`. Replace the existing Step 2 block (the section header `## Step 2: Gather External Reviews` and the lines up to but not including `## Step 3: Consolidate Issues`) with this exact text:
 
@@ -41,7 +41,7 @@ External reviewers (e.g., GitHub Actions bots, Claude Code Review) are typically
 
 Preserve the blank line between this section and `## Step 3: Consolidate Issues`.
 
-- [ ] **Step 2: Bump the skill frontmatter version**
+- [x] **Step 2: Bump the skill frontmatter version**
 
 In the same file `dev-skills/skills/pr-feedback/SKILL.md`, change frontmatter line 3:
 
@@ -55,7 +55,7 @@ to:
 version: 3.2.0
 ```
 
-- [ ] **Step 3: Bump the plugin manifest version**
+- [x] **Step 3: Bump the plugin manifest version**
 
 Edit `dev-skills/.claude-plugin/plugin.json`. Change:
 
@@ -69,7 +69,7 @@ to:
 "version": "3.5.0"
 ```
 
-- [ ] **Step 4: Verify the diff**
+- [x] **Step 4: Verify the diff**
 
 Run:
 
@@ -84,7 +84,7 @@ Expected output:
 
 If anything outside the intended scope changed, fix before committing.
 
-- [ ] **Step 5: Sanity-check against the failure modes**
+- [x] **Step 5: Sanity-check against the failure modes**
 
 Re-read the rewritten Step 2 and answer each question; all three must be "yes":
 - Does it prescribe a specific mechanism (Bash + `run_in_background: true` + `sleep 120`)? — defeats "hangs / skips".
@@ -93,7 +93,7 @@ Re-read the rewritten Step 2 and answer each question; all three must be "yes":
 
 If any answer is no, return to Step 1 of this task and revise.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add dev-skills/skills/pr-feedback/SKILL.md dev-skills/.claude-plugin/plugin.json
@@ -106,15 +106,15 @@ git commit -m "Redesign pr-feedback Step 2 wait mechanism"
 
 **Files:** None (git/gh operations only)
 
-- [ ] **Step 1: Push the branch**
+- [x] **Step 1: Push the branch**
 
 ```bash
 git push -u origin bugfix-pr-feedback-step2
 ```
 
-The project's branch-naming hook requires a `bugfix-` prefix, which this branch already satisfies.
+The project's branch-naming hook requires one of the approved prefixes (`feat-`, `bugfix-`, `doc-`, `refactor-`, `chore-`, `test-`); this branch already satisfies that with `bugfix-`.
 
-- [ ] **Step 2: Open the PR**
+- [x] **Step 2: Open the PR**
 
 ```bash
 gh pr create --title "Redesign pr-feedback Step 2 wait mechanism" --body "$(cat <<'EOF'
@@ -131,7 +131,7 @@ EOF
 )"
 ```
 
-- [ ] **Step 3: Confirm PR URL**
+- [x] **Step 3: Confirm PR URL**
 
 The `gh pr create` command prints the PR URL on success. Note it for the next phase (pr-feedback cycle).
 

--- a/docs/superpowers/plans/2026-05-14-pr-feedback-step2.md
+++ b/docs/superpowers/plans/2026-05-14-pr-feedback-step2.md
@@ -1,0 +1,144 @@
+# pr-feedback Step 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite Step 2 of the `pr-feedback` skill to prescribe a deterministic background wait mechanism, make empty-external behavior explicit, and reinforce autonomy.
+
+**Architecture:** Single Markdown skill file edit plus two semver version bumps. No code, no tests — skill behavior is verified qualitatively by re-reading the rewritten Step 2.
+
+**Tech Stack:** Markdown (skill doc), JSON (plugin manifest), Git.
+
+**Spec:** `docs/superpowers/specs/2026-05-14-pr-feedback-step2-design.md`
+
+---
+
+### Task 1: Apply Step 2 redesign and bump versions
+
+**Files:**
+- Modify: `dev-skills/skills/pr-feedback/SKILL.md` (frontmatter line 3; Step 2 body lines 33–43)
+- Modify: `dev-skills/.claude-plugin/plugin.json` (version field line 4)
+
+- [ ] **Step 1: Replace the Step 2 body in SKILL.md**
+
+Open `dev-skills/skills/pr-feedback/SKILL.md`. Replace the existing Step 2 block (the section header `## Step 2: Gather External Reviews` and the lines up to but not including `## Step 3: Consolidate Issues`) with this exact text:
+
+```markdown
+## Step 2: Gather External Reviews
+
+External reviewers (e.g., GitHub Actions bots, Claude Code Review) are typically triggered when the PR is pushed and run in parallel with the self-review. They often take longer to complete than the self-review.
+
+**Wait via a background-scheduled delay, then read comments:**
+
+1. After self-review completes, fire a 2-minute background wait. Use the Bash tool with `run_in_background: true` and the command `sleep 120`. The harness will notify when it completes — do not poll, do not run a foreground `sleep`, do not invoke any other tool while waiting.
+
+2. After the notification, read all reviewer comments on the PR — review summaries, inline review comments, and general PR comments. Extract actionable feedback items.
+
+3. **If no external reviews exist after the wait, proceed to Step 3 with self-review issues only.** Do not extend the wait. Do not ask the user. The Step 6 loop will catch any late-arriving comments in a subsequent cycle — that's by design.
+
+**Never ask the user for input during this step.** Not to wait longer, not to confirm, not to add reviewers. The full step is autonomous.
+
+```
+
+Preserve the blank line between this section and `## Step 3: Consolidate Issues`.
+
+- [ ] **Step 2: Bump the skill frontmatter version**
+
+In the same file `dev-skills/skills/pr-feedback/SKILL.md`, change frontmatter line 3:
+
+```yaml
+version: 3.1.0
+```
+
+to:
+
+```yaml
+version: 3.2.0
+```
+
+- [ ] **Step 3: Bump the plugin manifest version**
+
+Edit `dev-skills/.claude-plugin/plugin.json`. Change:
+
+```json
+"version": "3.4.0"
+```
+
+to:
+
+```json
+"version": "3.5.0"
+```
+
+- [ ] **Step 4: Verify the diff**
+
+Run:
+
+```bash
+git diff dev-skills/skills/pr-feedback/SKILL.md dev-skills/.claude-plugin/plugin.json
+```
+
+Expected output:
+- `SKILL.md`: version bump on line 3, Step 2 block replaced with the new prose. No other changes.
+- `plugin.json`: single version field change from `3.4.0` to `3.5.0`.
+- Confirm: no whitespace-only edits to surrounding sections; Step 1, Step 3, and other steps untouched.
+
+If anything outside the intended scope changed, fix before committing.
+
+- [ ] **Step 5: Sanity-check against the failure modes**
+
+Re-read the rewritten Step 2 and answer each question; all three must be "yes":
+- Does it prescribe a specific mechanism (Bash + `run_in_background: true` + `sleep 120`)? — defeats "hangs / skips".
+- Does it explicitly say to proceed to Step 3 if external is empty after the wait? — defeats "asks user / waits forever".
+- Does it forbid asking the user for input? — defeats "asks user mid-step".
+
+If any answer is no, return to Step 1 of this task and revise.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dev-skills/skills/pr-feedback/SKILL.md dev-skills/.claude-plugin/plugin.json
+git commit -m "Redesign pr-feedback Step 2 wait mechanism"
+```
+
+---
+
+### Task 2: Push branch and open PR
+
+**Files:** None (git/gh operations only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin bugfix-pr-feedback-step2
+```
+
+The project's branch-naming hook requires a `bugfix-` prefix, which this branch already satisfies.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "Redesign pr-feedback Step 2 wait mechanism" --body "$(cat <<'EOF'
+## Summary
+
+- Prescribe an exact background-scheduled wait mechanism (`run_in_background: true` + `sleep 120`) instead of the vague "wait 2 minutes" instruction.
+- Make the empty-external-reviews case explicit: proceed to Step 3 with self-review issues only; the Step 6 loop catches late-arriving comments.
+- Reinforce the autonomy clause with specific anti-patterns to prevent agents from prompting the user mid-step.
+
+Closes the "agent gets stuck on Step 2" failure modes observed in practice: never waits, waits forever, or asks the user mid-step.
+
+Spec: `docs/superpowers/specs/2026-05-14-pr-feedback-step2-design.md`
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirm PR URL**
+
+The `gh pr create` command prints the PR URL on success. Note it for the next phase (pr-feedback cycle).
+
+---
+
+## Post-Plan Workflow
+
+After both tasks complete, the user will typically run `/pr-feedback` to exercise the self-review → external-review → fix-and-push cycle on this very PR. That cycle will be the first real test of the redesigned Step 2.
+
+Cleanup after merge: `gh pr merge --squash --delete-branch` followed by `git fetch --prune` from the main repo (not the worktree). The worktree itself can be removed via ExitWorktree.

--- a/docs/superpowers/specs/2026-05-14-pr-feedback-step2-design.md
+++ b/docs/superpowers/specs/2026-05-14-pr-feedback-step2-design.md
@@ -47,10 +47,11 @@ self-review. They often take longer to complete than the self-review.
 
 **Wait via a background-scheduled delay, then read comments:**
 
-1. After self-review completes, fire a 2-minute background wait. Use the
-   Bash tool with `run_in_background: true` and the command `sleep 120`.
-   The harness will notify when it completes — do not poll, do not run a
-   foreground `sleep`, do not invoke any other tool while waiting.
+1. After self-review completes, schedule a 2-minute background wait. Use
+   the Bash tool with `run_in_background: true` and the command `sleep 120`.
+   End your turn after firing — the harness will notify when the wait
+   completes. Do not poll, do not run a foreground `sleep`, do not chain
+   other tool calls in the same turn to check on the wait.
 
 2. After the notification, read all reviewer comments on the PR — review
    summaries, inline review comments, and general PR comments. Extract
@@ -64,6 +65,8 @@ self-review. They often take longer to complete than the self-review.
 **Never ask the user for input during this step.** Not to wait longer,
 not to confirm, not to add reviewers. The full step is autonomous.
 ```
+
+The bullet 1 wording was refined during code review (see commit `aa43798`) for control-flow clarity: explicit "end your turn after firing" and narrower "do not chain other tool calls in the same turn to check on the wait" replace the original "do not invoke any other tool while waiting" (which over-restricted adjacent tools and implied an active waiting state inconsistent with the harness's notification model).
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-05-14-pr-feedback-step2-design.md
+++ b/docs/superpowers/specs/2026-05-14-pr-feedback-step2-design.md
@@ -1,0 +1,86 @@
+# pr-feedback Step 2 — Wait Mechanism Redesign
+
+## Goal
+
+Rewrite Step 2 of `dev-skills/skills/pr-feedback/SKILL.md` so the "wait for external reviewers" phase is deterministic, bounded, and autonomous. Eliminate the three failure modes observed in practice: agents skipping the wait, hanging on the wait, or asking the user mid-step.
+
+## Problem
+
+The current Step 2 instruction is "wait 2 minutes" with no prescribed mechanism. Three distinct misinterpretations have been observed:
+
+1. **Never waits at all** — agent moves to Step 3 immediately with self-review issues only.
+2. **Waits forever / hangs** — agent tries a foreground `sleep 120`, which the harness blocks as a long leading sleep, and the agent gets stuck.
+3. **Asks user mid-Step 2** — agent breaks the autonomy clause and prompts for confirmation.
+
+Root cause: the skill specifies an outcome ("wait 2 minutes") but no concrete mechanism. Different agent interpretations diverge.
+
+## Design Decisions
+
+### Wait mechanism: background scheduled wait
+
+Use the Bash tool with `run_in_background: true` running `sleep 120`. This is the harness's native pattern for one-shot waits: the agent fires the command, returns control, and is auto-notified when the timer elapses. Foreground long sleeps are blocked by the harness, so they're explicitly forbidden in the new text.
+
+Considered alternatives:
+- **Foreground `sleep 120`** — rejected: harness blocks long leading sleeps.
+- **Until-loop with short sleeps** — rejected: verbose, harder to teach in skill prose, no functional advantage over background sleep.
+- **`ScheduleWakeup`** — not available outside `/loop` dynamic mode.
+- **`CronCreate`** — designed for recurring tasks; runs independently of the conversation.
+
+### Empty-external behavior: proceed, trust cycle 2
+
+If the wait completes and no external comments are present, the agent proceeds to Step 3 with self-review issues only. It does not extend the wait, does not ask the user. Step 6's loop catches any late-arriving comments in cycle 2 — this is the existing safety net, now made explicit.
+
+This is the load-bearing decision: once the skill says "proceed if external is empty," the 2-min wait stops being safety-critical. It's a courtesy delay to reduce cycles, not a correctness guarantee. The simplest wait mechanism becomes sufficient.
+
+### Autonomy reinforcement
+
+The existing "never ask the user" clause is preserved and reinforced. The new text spells out each tempting branch (don't ask to wait longer, don't ask to confirm, don't ask to add reviewers) to prevent agents rationalizing around it.
+
+## Proposed Step 2 Text
+
+```markdown
+## Step 2: Gather External Reviews
+
+External reviewers (e.g., GitHub Actions bots, Claude Code Review) are
+typically triggered when the PR is pushed and run in parallel with the
+self-review. They often take longer to complete than the self-review.
+
+**Wait via a background-scheduled delay, then read comments:**
+
+1. After self-review completes, fire a 2-minute background wait. Use the
+   Bash tool with `run_in_background: true` and the command `sleep 120`.
+   The harness will notify when it completes — do not poll, do not run a
+   foreground `sleep`, do not invoke any other tool while waiting.
+
+2. After the notification, read all reviewer comments on the PR — review
+   summaries, inline review comments, and general PR comments. Extract
+   actionable feedback items.
+
+3. **If no external reviews exist after the wait, proceed to Step 3 with
+   self-review issues only.** Do not extend the wait. Do not ask the user.
+   The Step 6 loop will catch any late-arriving comments in a subsequent
+   cycle — that's by design.
+
+**Never ask the user for input during this step.** Not to wait longer,
+not to confirm, not to add reviewers. The full step is autonomous.
+```
+
+## Out of Scope
+
+- Enumerating exact `gh` commands for each comment surface (Step 2 already lists the categories conceptually; "wrong surface" failure was not observed).
+- Check-based conditional wait (`gh pr checks` polling).
+- Restructuring Steps 1, 3–7.
+
+## Version Bumps
+
+- `dev-skills/skills/pr-feedback/SKILL.md` frontmatter: `version: 3.1.0` → `3.2.0`
+- `dev-skills/.claude-plugin/plugin.json` version: `3.4.0` → `3.5.0`
+
+Minor (not patch) because the empty-external behavior is a newly explicit specification, not a bug fix to existing prose.
+
+## Validation
+
+This is a documentation/spec change, not code. Validation is qualitative:
+- Re-read the rewritten Step 2 and confirm each of the three failure modes is addressed.
+- Confirm no contradictions with Steps 1, 3, 6.
+- Future cycle of pr-feedback on a real PR will exercise the new instructions.

--- a/docs/superpowers/specs/2026-05-14-pr-feedback-step2-design.md
+++ b/docs/superpowers/specs/2026-05-14-pr-feedback-step2-design.md
@@ -66,7 +66,7 @@ self-review. They often take longer to complete than the self-review.
 not to confirm, not to add reviewers. The full step is autonomous.
 ```
 
-The bullet 1 wording was refined during code review (see commit `aa43798`) for control-flow clarity: explicit "end your turn after firing" and narrower "do not chain other tool calls in the same turn to check on the wait" replace the original "do not invoke any other tool while waiting" (which over-restricted adjacent tools and implied an active waiting state inconsistent with the harness's notification model).
+The bullet 1 wording was refined during code review for control-flow clarity: explicit "end your turn after firing" and narrower "do not chain other tool calls in the same turn to check on the wait" replace the original "do not invoke any other tool while waiting", which over-restricted adjacent tools and implied an active waiting state inconsistent with the harness's notification model.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- Prescribe an exact background-scheduled wait (`run_in_background: true` + `sleep 120`) instead of the vague "wait 2 minutes" instruction.
- Make the empty-external-reviews case explicit: proceed to Step 3 with self-review issues only; Step 6 loop catches late-arriving comments.
- Reinforce the autonomy clause with specific anti-patterns to prevent agents from prompting mid-step.

Addresses the three observed failure modes in Step 2: agent never waits, agent hangs on wait, or agent asks the user mid-step.

Spec: `docs/superpowers/specs/2026-05-14-pr-feedback-step2-design.md`
Plan: `docs/superpowers/plans/2026-05-14-pr-feedback-step2.md`