### PR TITLE
Fix pre_git_hook branch false positive and PR attribution gap

### DIFF
--- a/core-hooks/.claude-plugin/plugin.json
+++ b/core-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks for Claude Code",
-  "version": "1.0.7"
+  "version": "1.0.8"
 }

--- a/core-hooks/.codex-plugin/plugin.json
+++ b/core-hooks/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "hooks": "./hooks/hooks.codex.json"
 }

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -27,12 +27,14 @@ def get_shell_command(tool_name, tool_input):
 
 
 def extract_branch_name(command):
-    # [^\s;|&]+ instead of \S+ to stop at shell metacharacters (; && || |)
-    m = re.search(r'git checkout -b\s+([^\s;|&]+)', command)
+    # [^\s;|&]+ instead of \S+ to stop at shell metacharacters (; && || |).
+    # [ \t]+ (not \s+) for separators so a newline cannot pull in the next
+    # command's first token as a false branch name (see issues #104/#105).
+    m = re.search(r'git checkout -b[ \t]+([^\s;|&]+)', command)
     if m:
         return m.group(1)
 
-    m = re.search(r'git switch -c\s+([^\s;|&]+)', command)
+    m = re.search(r'git switch -c[ \t]+([^\s;|&]+)', command)
     if m:
         return m.group(1)
 
@@ -49,17 +51,17 @@ def extract_branch_name(command):
         return None
 
     # Rename/copy: short flags (-m/-M/-c/-C) and long flags (--move/--copy)
-    m = re.search(r'git branch\s+(?:-[mMcC]|--move|--copy)\s+[^\s;|&]+\s+([^\s;|&]+)', command)
+    m = re.search(r'git branch[ \t]+(?:-[mMcC]|--move|--copy)[ \t]+[^\s;|&]+[ \t]+([^\s;|&]+)', command)
     if m:
         return m.group(1)
-    m = re.search(r'git branch\s+(?:-[mMcC]|--move|--copy)\s+([^\s;|&]+)', command)
+    m = re.search(r'git branch[ \t]+(?:-[mMcC]|--move|--copy)[ \t]+([^\s;|&]+)', command)
     if m:
         return m.group(1)
 
     # Bare creation — skip read-only/delete flags
     if re.search(r'git branch\s+(-[ladDvrV]|--list|--all|--delete|--remotes)', command):
         return None
-    m = re.search(r'git branch\s+(?!-)([^\s;|&]+)', command)
+    m = re.search(r'git branch[ \t]+(?!-)([^\s;|&]+)', command)
     if m:
         return m.group(1)
 
@@ -115,7 +117,7 @@ def main():
             print(json.dumps(response))
             sys.exit(0)
 
-        elif "git commit" in command or "gh pr create" in command:
+        elif "git commit" in command or re.search(r'\bgh pr (?:create|edit|comment)\b', command):
             attribution_patterns = [
                 # Claude Code
                 r'Generated (?:with|by) \[?Claude Code\]?',
@@ -143,7 +145,7 @@ def main():
                     sys.exit(0)
 
             response = {
-                "systemMessage": "Commit Guidelines: Keep messages concise and accurate. Avoid AI attribution in commit messages or PR descriptions."
+                "systemMessage": "Contribution Guidelines: Keep messages concise and accurate. Avoid AI attribution in commit messages or PR descriptions/comments."
             }
             print(json.dumps(response))
             sys.exit(0)

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -15,6 +15,27 @@ import sys
 
 VALID_PREFIXES = ['feat-', 'bugfix-', 'doc-', 'refactor-', 'chore-', 'test-']
 
+# AI tool attribution that must not appear in commit messages or PR
+# descriptions/comments.
+ATTRIBUTION_PATTERNS = [
+    # Claude Code
+    r'Generated (?:with|by) \[?Claude Code\]?',
+    r'claude\.ai/code',
+    r'noreply@anthropic\.com',
+    r'Claude Code',
+    # Codex / OpenAI
+    r'Generated (?:with|by) Codex',
+    r'noreply@openai\.com',
+    r'openai\.com/codex',
+    r'Codex CLI',
+]
+
+# gh subcommands that introduce a PR body/comment where attribution can appear.
+# [^;&|\n]* tolerates global flags (e.g. `gh -R owner/repo pr edit`) and extra
+# spaces between tokens, while the excluded chars stop it from matching across
+# chained (; && ||), piped, or newline-separated commands.
+PR_CONTRIBUTION_RE = re.compile(r'\bgh\b[^;&|\n]*\bpr[ \t]+(?:create|edit|comment|review)\b')
+
 
 def get_shell_command(tool_name, tool_input):
     if not isinstance(tool_input, dict):
@@ -29,7 +50,7 @@ def get_shell_command(tool_name, tool_input):
 def extract_branch_name(command):
     # [^\s;|&]+ instead of \S+ to stop at shell metacharacters (; && || |).
     # [ \t]+ (not \s+) for separators so a newline cannot pull in the next
-    # command's first token as a false branch name (see issues #104/#105).
+    # command's first token as a false branch name (see issue #104).
     m = re.search(r'git checkout -b[ \t]+([^\s;|&]+)', command)
     if m:
         return m.group(1)
@@ -39,13 +60,13 @@ def extract_branch_name(command):
         return m.group(1)
 
     if 'git worktree add' in command:
-        m = re.search(r'git worktree add\s+[^\s;|&]+\s+(?:-b|--branch)\s+([^\s;|&]+)', command)
+        m = re.search(r'git worktree add[ \t]+[^\s;|&]+[ \t]+(?:-b|--branch)[ \t]+([^\s;|&]+)', command)
         if m:
             return m.group(1)
-        m = re.search(r'git worktree add\s+[^\s;|&]+\s+([a-zA-Z][\w-]*)', command)
+        m = re.search(r'git worktree add[ \t]+[^\s;|&]+[ \t]+([a-zA-Z][\w-]*)', command)
         if m:
             return m.group(1)
-        m = re.search(r'git worktree add\s+([^\s;|&]+)', command)
+        m = re.search(r'git worktree add[ \t]+([^\s;|&]+)', command)
         if m:
             return os.path.basename(m.group(1))
         return None
@@ -58,8 +79,12 @@ def extract_branch_name(command):
     if m:
         return m.group(1)
 
-    # Bare creation — skip read-only/delete flags
-    if re.search(r'git branch\s+(-[ladDvrV]|--list|--all|--delete|--remotes)', command):
+    # Bare creation — skip read-only/delete flags.
+    # Note: this matches the flag anywhere in the command string, so a listing/
+    # delete invocation can mask a later real creation in a compound command
+    # (e.g. "git branch -l; git branch badname"). A complete fix needs
+    # per-command parsing; tracked as a follow-up.
+    if re.search(r'git branch[ \t]+(-[ladDvrV]|--list|--all|--delete|--remotes)', command):
         return None
     m = re.search(r'git branch[ \t]+(?!-)([^\s;|&]+)', command)
     if m:
@@ -90,6 +115,24 @@ def main():
             print(json.dumps(response))
             sys.exit(0)
 
+        # AI attribution is a hard block. Check it before the advisory handlers
+        # below so a compound command (e.g. `gh pr edit ... && gh pr merge`)
+        # cannot short-circuit the deny via an earlier advisory exit.
+        is_contribution_cmd = "git commit" in command or PR_CONTRIBUTION_RE.search(command)
+        if is_contribution_cmd:
+            for pattern in ATTRIBUTION_PATTERNS:
+                if re.search(pattern, command, re.IGNORECASE):
+                    response = {
+                        "systemMessage": "BLOCKED: Git operation contains AI tool attribution. Remove AI contribution messages from commit messages and PR descriptions/comments.",
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": "AI tool attribution detected in git operation"
+                        }
+                    }
+                    print(json.dumps(response))
+                    sys.exit(0)
+
         branch_name = extract_branch_name(command)
         if branch_name:
             if not any(branch_name.startswith(p) for p in VALID_PREFIXES):
@@ -117,33 +160,7 @@ def main():
             print(json.dumps(response))
             sys.exit(0)
 
-        elif "git commit" in command or re.search(r'\bgh pr (?:create|edit|comment)\b', command):
-            attribution_patterns = [
-                # Claude Code
-                r'Generated (?:with|by) \[?Claude Code\]?',
-                r'claude\.ai/code',
-                r'noreply@anthropic\.com',
-                r'Claude Code',
-                # Codex / OpenAI
-                r'Generated (?:with|by) Codex',
-                r'noreply@openai\.com',
-                r'openai\.com/codex',
-                r'Codex CLI',
-            ]
-
-            for pattern in attribution_patterns:
-                if re.search(pattern, command, re.IGNORECASE):
-                    response = {
-                        "systemMessage": "BLOCKED: Git operation contains AI tool attribution. Remove AI contribution messages from commit messages and PR descriptions.",
-                        "hookSpecificOutput": {
-                            "hookEventName": "PreToolUse",
-                            "permissionDecision": "deny",
-                            "permissionDecisionReason": "AI tool attribution detected in git operation"
-                        }
-                    }
-                    print(json.dumps(response))
-                    sys.exit(0)
-
+        if is_contribution_cmd:
             response = {
                 "systemMessage": "Contribution Guidelines: Keep messages concise and accurate. Avoid AI attribution in commit messages or PR descriptions/comments."
             }

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -83,7 +83,7 @@ def extract_branch_name(command):
     # Note: this matches the flag anywhere in the command string, so a listing/
     # delete invocation can mask a later real creation in a compound command
     # (e.g. "git branch -l; git branch badname"). A complete fix needs
-    # per-command parsing; tracked as a follow-up.
+    # per-command parsing; tracked in issue #107.
     if re.search(r'git branch[ \t]+(-[ladDvrV]|--list|--all|--delete|--remotes)', command):
         return None
     m = re.search(r'git branch[ \t]+(?!-)([^\s;|&]+)', command)

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -118,7 +118,7 @@ def main():
         # AI attribution is a hard block. Check it before the advisory handlers
         # below so a compound command (e.g. `gh pr edit ... && gh pr merge`)
         # cannot short-circuit the deny via an earlier advisory exit.
-        is_contribution_cmd = "git commit" in command or PR_CONTRIBUTION_RE.search(command)
+        is_contribution_cmd = bool("git commit" in command or PR_CONTRIBUTION_RE.search(command))
         if is_contribution_cmd:
             for pattern in ATTRIBUTION_PATTERNS:
                 if re.search(pattern, command, re.IGNORECASE):

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -107,6 +107,18 @@ class PreGitHookTests(unittest.TestCase):
                 )
                 self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
 
+    def test_clean_git_commit_gets_advisory(self):
+        # The other half of is_contribution_cmd: a clean commit is allowed with
+        # the advisory, not denied or silently passed.
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": 'git commit -m "Fix typo in README"'},
+            }
+        )
+        self.assertNotIn("hookSpecificOutput", response)
+        self.assertIn("Contribution Guidelines", response.get("systemMessage", ""))
+
     def test_blocks_attribution_in_gh_pr_review(self):
         response = run_hook(
             {

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -90,6 +90,82 @@ class PreGitHookTests(unittest.TestCase):
                 "tool_input": {"command": 'gh pr edit 1 --body "Fix typo in README"'},
             }
         )
+        # Advisory message fires, but the operation is not denied.
+        self.assertNotIn("hookSpecificOutput", response)
+        self.assertIn("Contribution Guidelines", response.get("systemMessage", ""))
+
+    def test_blocks_attribution_despite_spaces_and_global_flags(self):
+        # The guard must survive extra whitespace and gh global flags placed
+        # before the `pr` subcommand (e.g. `gh -R owner/repo pr edit`).
+        for command in [
+            'gh  pr  edit 1 --body "Generated with Claude Code"',
+            'gh -R owner/repo pr edit 1 --body "Generated with Claude Code"',
+        ]:
+            with self.subTest(command=command):
+                response = run_hook(
+                    {"tool_name": "Bash", "tool_input": {"command": command}}
+                )
+                self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    def test_blocks_attribution_in_gh_pr_review(self):
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": 'gh pr review 1 --comment --body "Generated with Claude Code"'},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    def test_blocks_attribution_in_compound_edit_then_merge(self):
+        # A merge advisory must not short-circuit the attribution deny when both
+        # appear in one compound command.
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": 'gh pr edit 1 --body "Generated with Claude Code" && gh pr merge 1'},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    # --- #104 regressions: rename, tabs, worktree in compound commands ---
+
+    def test_rename_to_invalid_branch_is_blocked(self):
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git branch -m old-name badname"},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    def test_rename_to_valid_branch_is_allowed(self):
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git branch -m old-name feat-42-new"},
+            }
+        )
+        self.assertNotIn("hookSpecificOutput", response)
+
+    def test_tab_separator_is_still_detected(self):
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git switch -c\tbadname"},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    def test_worktree_add_in_compound_uses_path_not_next_token(self):
+        # Before the fix, the separator before the branch group matched the
+        # newline and captured "git" from the next command. Now the worktree's
+        # own path basename is used, so a valid prefix is allowed.
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git worktree add ../trees/feat-99-x\ngit status"},
+            }
+        )
         self.assertNotIn("hookSpecificOutput", response)
 
     def test_codex_hooks_match_exec_command_for_git_guard(self):

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -10,7 +10,7 @@ SCRIPT = ROOT / "scripts" / "pre_git_hook.py"
 CODEX_HOOKS = ROOT / "hooks" / "hooks.codex.json"
 
 
-def run_hook(payload):
+def run_hook_raw(payload):
     result = subprocess.run(
         [sys.executable, str(SCRIPT)],
         input=json.dumps(payload),
@@ -19,7 +19,12 @@ def run_hook(payload):
         check=False,
     )
     assert result.returncode == 0, f"Hook failed (exit {result.returncode}): {result.stderr}"
-    return json.loads(result.stdout)
+    return result
+
+
+def run_hook(payload):
+    # Commands the hook ignores produce no stdout; use run_hook_raw for those.
+    return json.loads(run_hook_raw(payload).stdout)
 
 
 class PreGitHookTests(unittest.TestCase):
@@ -34,6 +39,58 @@ class PreGitHookTests(unittest.TestCase):
 
         self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
         self.assertIn("codex-plugin-support", response["systemMessage"])
+
+    # --- Issue #104: bare branch listing in a compound command ---
+
+    def test_bare_branch_listing_in_compound_command_is_allowed(self):
+        # `git branch` (no args) followed by another command must not be
+        # misread as creating a branch named after the next command's token.
+        result = run_hook_raw(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git branch\ngit status -sb"},
+            }
+        )
+        self.assertEqual(result.stdout.strip(), "")
+
+    def test_invalid_branch_on_same_line_still_blocked(self):
+        # The cross-line fix must not weaken real same-line detection.
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git branch badname"},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    # --- Issue #105: AI attribution in gh pr edit / comment ---
+
+    def test_blocks_attribution_in_gh_pr_edit(self):
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": 'gh pr edit 1 --body "Generated with Claude Code"'},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    def test_blocks_attribution_in_gh_pr_comment(self):
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": 'gh pr comment 1 --body "noreply@anthropic.com"'},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    def test_clean_gh_pr_edit_is_allowed(self):
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": 'gh pr edit 1 --body "Fix typo in README"'},
+            }
+        )
+        self.assertNotIn("hookSpecificOutput", response)
 
     def test_codex_hooks_match_exec_command_for_git_guard(self):
         hooks = json.loads(CODEX_HOOKS.read_text())

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -151,6 +151,8 @@ class PreGitHookTests(unittest.TestCase):
         self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
 
     def test_rename_to_valid_branch_is_allowed(self):
+        # A valid branch name emits the "good practice" advisory (non-empty
+        # JSON, no deny), so run_hook is safe here — the path is not silent.
         response = run_hook(
             {
                 "tool_name": "Bash",
@@ -171,7 +173,9 @@ class PreGitHookTests(unittest.TestCase):
     def test_worktree_add_in_compound_uses_path_not_next_token(self):
         # Before the fix, the separator before the branch group matched the
         # newline and captured "git" from the next command. Now the worktree's
-        # own path basename is used, so a valid prefix is allowed.
+        # own path basename is used, so a valid prefix is allowed. The basename
+        # is valid, so the hook emits the advisory (non-empty JSON) — run_hook
+        # is safe here.
         response = run_hook(
             {
                 "tool_name": "Bash",


### PR DESCRIPTION
Fixes two detection gaps in `core-hooks/scripts/pre_git_hook.py`.

**#104 — bare branch listing misdetected as branch creation**
`git branch` (no args) inside a compound command captured the next command's first token as a "branch name" because `\s+` matched across newlines. Branch-detection separators (`checkout -b`, `switch -c`, rename/copy, bare creation, `worktree add`, and the read-only skip-list) now use `[ \t]+`, so a branch name must be on the same line as its subcommand.

**#105 — AI attribution not blocked on PR-mutating subcommands**
The attribution guard only fired for `git commit` and `gh pr create`, so attribution could be added after the fact via `gh pr edit`/`comment`/`review`. The guard now matches `gh pr create|edit|comment|review` (tolerating global flags such as `gh -R owner/repo pr edit` and extra whitespace), and the deny now runs before the advisory handlers so a compound command can't short-circuit it.

Added regression tests for both. Bumped `core-hooks` version. Compound-command masking of the branch-prefix check is a known limitation tracked in #107.

Closes #104
Closes #105
