### PR TITLE
Parse compound commands per-segment for branch-name enforcement

### DIFF
--- a/core-hooks/.claude-plugin/plugin.json
+++ b/core-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks for Claude Code",
-  "version": "1.0.8"
+  "version": "1.0.9"
 }

--- a/core-hooks/.claude-plugin/plugin.json
+++ b/core-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks for Claude Code",
-  "version": "1.0.9"
+  "version": "1.0.10"
 }

--- a/core-hooks/.codex-plugin/plugin.json
+++ b/core-hooks/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "hooks": "./hooks/hooks.codex.json"
 }

--- a/core-hooks/.codex-plugin/plugin.json
+++ b/core-hooks/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core-hooks",
   "description": "Core safety and workflow hooks",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "hooks": "./hooks/hooks.codex.json"
 }

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -69,11 +69,15 @@ def split_commands(command):
             buf.append(ch)
             escaped = False
             continue
-        if ch == '\\' and quote != "'":
+        if ch == '\\' and quote != "'" and command[i + 1:i + 2] != '\n':
             # A backslash escapes the next char everywhere except inside single
             # quotes, where bash treats it literally. Without this, an escaped
             # quote desyncs quote state and a later separator can be swallowed
             # into one segment, re-masking an invalid branch creation (#107).
+            # Exception: a line-continuation (\ + newline) is NOT escaped, so the
+            # newline still splits. Bash would join the lines, but each segment
+            # must stay one command — joining could let a creation hide behind a
+            # neighbor (check_branch_names only reads the first verb per segment).
             escaped = True
             buf.append(ch)
             continue

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -51,14 +51,32 @@ def split_commands(command):
     """Split a shell command line into its individual commands.
 
     Splits on the unquoted control operators `;`, `&`, `|` and newlines (so
-    `&&`, `||` and pipelines all break a command boundary). Quote-aware, so a
-    separator inside '...' or "..." (e.g. a commit message or PR body) does not
-    create a spurious segment. This is a heuristic, not a full shell parser.
+    `&&`, `||` and pipelines all break a command boundary). Quote- and
+    escape-aware: a separator inside '...' or "..." (e.g. a commit message or
+    PR body) does not create a spurious segment, and a backslash-escaped quote
+    does not prematurely close the surrounding string. `&` splits only as a
+    control operator, not when it is part of a redirection token such as
+    `2>&1` or `&>file`. This is a heuristic, not a full shell parser.
+
+    Returned segments are stripped of surrounding whitespace.
     """
     segments = []
     buf = []
     quote = None
-    for ch in command:
+    escaped = False
+    for i, ch in enumerate(command):
+        if escaped:
+            buf.append(ch)
+            escaped = False
+            continue
+        if ch == '\\' and quote != "'":
+            # A backslash escapes the next char everywhere except inside single
+            # quotes, where bash treats it literally. Without this, an escaped
+            # quote desyncs quote state and a later separator can be swallowed
+            # into one segment, re-masking an invalid branch creation (#107).
+            escaped = True
+            buf.append(ch)
+            continue
         if quote:
             buf.append(ch)
             if ch == quote:
@@ -66,13 +84,18 @@ def split_commands(command):
         elif ch in ("'", '"'):
             quote = ch
             buf.append(ch)
-        elif ch in (';', '&', '|', '\n'):
+        elif ch in (';', '|', '\n'):
+            segments.append(''.join(buf))
+            buf = []
+        elif ch == '&' and command[i - 1:i] != '>' and command[i + 1:i + 2] != '>':
+            # `&` is a boundary only as a control operator (`&`, `&&`). Adjacent
+            # to `>` it is part of a redirection (`2>&1`, `&>file`), not a split.
             segments.append(''.join(buf))
             buf = []
         else:
             buf.append(ch)
     segments.append(''.join(buf))
-    return [seg for seg in segments if seg.strip()]
+    return [seg.strip() for seg in segments if seg.strip()]
 
 
 def extract_branch_name(command):
@@ -181,7 +204,7 @@ def main():
                     print(json.dumps(response))
                     sys.exit(0)
 
-        invalid_branch, valid_branch = check_branch_names(command)
+        invalid_branch, saw_valid_branch = check_branch_names(command)
         if invalid_branch:
             response = {
                 "systemMessage": f"Branch name '{invalid_branch}' is invalid. Use only these prefixes: {', '.join(VALID_PREFIXES)}",
@@ -194,7 +217,7 @@ def main():
             print(json.dumps(response))
             sys.exit(0)
 
-        if valid_branch:
+        if saw_valid_branch:
             response = {
                 "systemMessage": "Branch Naming Convention: Using approved prefix - good practice!"
             }

--- a/core-hooks/scripts/pre_git_hook.py
+++ b/core-hooks/scripts/pre_git_hook.py
@@ -47,6 +47,34 @@ def get_shell_command(tool_name, tool_input):
     return ""
 
 
+def split_commands(command):
+    """Split a shell command line into its individual commands.
+
+    Splits on the unquoted control operators `;`, `&`, `|` and newlines (so
+    `&&`, `||` and pipelines all break a command boundary). Quote-aware, so a
+    separator inside '...' or "..." (e.g. a commit message or PR body) does not
+    create a spurious segment. This is a heuristic, not a full shell parser.
+    """
+    segments = []
+    buf = []
+    quote = None
+    for ch in command:
+        if quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+            buf.append(ch)
+        elif ch in (';', '&', '|', '\n'):
+            segments.append(''.join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    segments.append(''.join(buf))
+    return [seg for seg in segments if seg.strip()]
+
+
 def extract_branch_name(command):
     # [^\s;|&]+ instead of \S+ to stop at shell metacharacters (; && || |).
     # [ \t]+ (not \s+) for separators so a newline cannot pull in the next
@@ -79,16 +107,36 @@ def extract_branch_name(command):
     if m:
         return m.group(1)
 
-    # Bare creation — skip read-only/delete flags.
-    # Note: this matches the flag anywhere in the command string, so a listing/
-    # delete invocation can mask a later real creation in a compound command
-    # (e.g. "git branch -l; git branch badname"). A complete fix needs
-    # per-command parsing; tracked in issue #107.
+    # Bare creation — skip read-only/delete flags. Callers pass one command at a
+    # time (see split_commands / check_branch_names), so a listing/delete here
+    # cannot mask a real creation elsewhere in a compound command.
     if re.search(r'git branch[ \t]+(-[ladDvrV]|--list|--all|--delete|--remotes)', command):
         return None
     m = re.search(r'git branch[ \t]+(?!-)([^\s;|&]+)', command)
     if m:
         return m.group(1)
+
+
+def check_branch_names(command):
+    """Inspect every sub-command for a branch being created.
+
+    Evaluating each command separately stops an invalid creation from being
+    masked by a read-only/delete invocation or an earlier valid creation in the
+    same compound command (issue #107). Returns (invalid_name, saw_valid_name):
+    the first invalid-prefix branch found (or None) and whether any valid branch
+    name was seen.
+    """
+    invalid = None
+    saw_valid = False
+    for segment in split_commands(command):
+        name = extract_branch_name(segment)
+        if not name:
+            continue
+        if any(name.startswith(p) for p in VALID_PREFIXES):
+            saw_valid = True
+        elif invalid is None:
+            invalid = name
+    return invalid, saw_valid
 
 
 def main():
@@ -133,20 +181,20 @@ def main():
                     print(json.dumps(response))
                     sys.exit(0)
 
-        branch_name = extract_branch_name(command)
-        if branch_name:
-            if not any(branch_name.startswith(p) for p in VALID_PREFIXES):
-                response = {
-                    "systemMessage": f"Branch name '{branch_name}' is invalid. Use only these prefixes: {', '.join(VALID_PREFIXES)}",
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "deny",
-                        "permissionDecisionReason": f"Branch name must start with one of: {', '.join(VALID_PREFIXES)}"
-                    }
+        invalid_branch, valid_branch = check_branch_names(command)
+        if invalid_branch:
+            response = {
+                "systemMessage": f"Branch name '{invalid_branch}' is invalid. Use only these prefixes: {', '.join(VALID_PREFIXES)}",
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": f"Branch name must start with one of: {', '.join(VALID_PREFIXES)}"
                 }
-                print(json.dumps(response))
-                sys.exit(0)
+            }
+            print(json.dumps(response))
+            sys.exit(0)
 
+        if valid_branch:
             response = {
                 "systemMessage": "Branch Naming Convention: Using approved prefix - good practice!"
             }

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -251,6 +251,18 @@ class PreGitHookTests(unittest.TestCase):
         self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
         self.assertIn("badname", response["systemMessage"])
 
+    def test_line_continuation_does_not_mask_invalid_branch(self):
+        # A backslash-newline continuation must not join two commands into one
+        # segment, which would let a later valid creation mask the invalid one.
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git branch bad \\\ngit checkout -b feat-1-x"},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("bad", response["systemMessage"])
+
     def test_first_invalid_branch_is_reported(self):
         # When several invalid branches appear, the first is surfaced; the
         # command is denied regardless of how many follow.

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import subprocess
 import sys
@@ -8,6 +9,13 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "pre_git_hook.py"
 CODEX_HOOKS = ROOT / "hooks" / "hooks.codex.json"
+
+
+def load_hook_module():
+    spec = importlib.util.spec_from_file_location("pre_git_hook", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def run_hook_raw(payload):
@@ -180,6 +188,46 @@ class PreGitHookTests(unittest.TestCase):
             {
                 "tool_name": "Bash",
                 "tool_input": {"command": "git worktree add ../trees/feat-99-x\ngit status"},
+            }
+        )
+        self.assertNotIn("hookSpecificOutput", response)
+
+    # --- Issue #107: per-command parsing of compound commands ---
+
+    def test_split_commands_is_quote_aware(self):
+        split = load_hook_module().split_commands
+        self.assertEqual(split("git branch -l; git branch x"), ["git branch -l", " git branch x"])
+        self.assertEqual(split("a && b | c"), ["a ", " b ", " c"])
+        # A separator inside quotes must not create a new segment.
+        self.assertEqual(split('git commit -m "a; b"'), ['git commit -m "a; b"'])
+
+    def test_listing_then_invalid_creation_in_compound_is_blocked(self):
+        # The read-only listing must not mask the later invalid creation.
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git branch -l; git branch badname"},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("badname", response["systemMessage"])
+
+    def test_valid_then_invalid_creation_in_compound_is_blocked(self):
+        # An earlier valid creation must not mask a later invalid one.
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git checkout -b feat-1-a && git checkout -b badname"},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("badname", response["systemMessage"])
+
+    def test_two_valid_creations_in_compound_are_allowed(self):
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git checkout -b feat-1-a && git checkout -b feat-2-b"},
             }
         )
         self.assertNotIn("hookSpecificOutput", response)

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -196,10 +196,17 @@ class PreGitHookTests(unittest.TestCase):
 
     def test_split_commands_is_quote_aware(self):
         split = load_hook_module().split_commands
-        self.assertEqual(split("git branch -l; git branch x"), ["git branch -l", " git branch x"])
-        self.assertEqual(split("a && b | c"), ["a ", " b ", " c"])
-        # A separator inside quotes must not create a new segment.
+        # Segments are returned stripped of surrounding whitespace.
+        self.assertEqual(split("git branch -l; git branch x"), ["git branch -l", "git branch x"])
+        self.assertEqual(split("a && b | c"), ["a", "b", "c"])
+        # A separator inside double or single quotes must not create a segment.
         self.assertEqual(split('git commit -m "a; b"'), ['git commit -m "a; b"'])
+        self.assertEqual(split("git commit -m 'a; b'"), ["git commit -m 'a; b'"])
+        # A backslash-escaped quote must not desync quote state.
+        self.assertEqual(split('git commit -m "a\\"b"; ls'), ['git commit -m "a\\"b"', 'ls'])
+        # `&` inside a redirection token is not a command boundary.
+        self.assertEqual(split("git status 2>&1"), ["git status 2>&1"])
+        self.assertEqual(split("git checkout -b feat-1-x &>log"), ["git checkout -b feat-1-x &>log"])
 
     def test_listing_then_invalid_creation_in_compound_is_blocked(self):
         # The read-only listing must not mask the later invalid creation.
@@ -231,6 +238,44 @@ class PreGitHookTests(unittest.TestCase):
             }
         )
         self.assertNotIn("hookSpecificOutput", response)
+
+    def test_escaped_quote_does_not_mask_invalid_branch(self):
+        # An escaped quote in a commit message must not desync the splitter and
+        # swallow a later invalid creation into a read-only segment (#107).
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": 'git commit -m "a\\"b" ; git branch -l ; git branch badname'},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("badname", response["systemMessage"])
+
+    def test_first_invalid_branch_is_reported(self):
+        # When several invalid branches appear, the first is surfaced; the
+        # command is denied regardless of how many follow.
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git branch bad1 && git branch bad2"},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("bad1", response["systemMessage"])
+
+    def test_redirection_ampersand_does_not_mask_branch_creation(self):
+        # `&` in a redirection (2>&1, &>file) is not a command boundary, so an
+        # invalid creation with redirected output is still caught.
+        for command in [
+            "git checkout -b badname 2>&1",
+            "git checkout -b badname &>log",
+        ]:
+            with self.subTest(command=command):
+                response = run_hook(
+                    {"tool_name": "Bash", "tool_input": {"command": command}}
+                )
+                self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+                self.assertIn("badname", response["systemMessage"])
 
     def test_codex_hooks_match_exec_command_for_git_guard(self):
         hooks = json.loads(CODEX_HOOKS.read_text())

--- a/core-hooks/tests/test_pre_git_hook.py
+++ b/core-hooks/tests/test_pre_git_hook.py
@@ -275,6 +275,17 @@ class PreGitHookTests(unittest.TestCase):
         self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
         self.assertIn("bad1", response["systemMessage"])
 
+    def test_logical_or_separates_commands(self):
+        # `||` splits on each `|`, so an invalid creation after it is caught.
+        response = run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git branch -l || git branch badname"},
+            }
+        )
+        self.assertEqual(response["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("badname", response["systemMessage"])
+
     def test_redirection_ampersand_does_not_mask_branch_creation(self):
         # `&` in a redirection (2>&1, &>file) is not a command boundary, so an
         # invalid creation with redirected output is still caught.


### PR DESCRIPTION
Fixes #107 — `pre_git_hook.py` evaluated the whole command string, so a compound command could mask the branch-prefix check.

Two masking cases are now closed:
- `git branch -l; git branch badname` — the read-only listing no longer suppresses the later invalid creation.
- `git checkout -b feat-x; git checkout -b badname` — an earlier valid creation no longer masks a later invalid one (whole-string `re.search` only ever returned the first match).

**Approach:** a quote-aware `split_commands()` breaks the command on unquoted `;`, `&`, `|`, and newlines (so a separator inside a commit message or PR body doesn't create a spurious segment), and `check_branch_names()` evaluates each segment, denying if any creates an invalid-prefix branch. Branch detection is the only guard affected; the attribution and `git add` guards match anywhere and have no first-match masking, so they stay whole-string.

Added regression tests for both masking cases, two valid creations in one command (allowed), and the quote-aware splitter. Bumped `core-hooks` version.

Closes #107
