### PR TITLE
Add discuss-with-codex skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Development workflow automation and systematic problem-solving.
 **Skills:**
 - **problem-solving-cycle**: Systematic development workflow from brainstorming to PR merge, including issue creation, branch management, and cleanup
 - **step-workflow**: Step-based file naming and folder organization using numbered prefixes (01_, 02_, 03_) for clear workflow order
+- **discuss-with-codex**: Autonomous turn-by-turn adversarial discussion with the Codex CLI that converges on a saved written conclusion
 
 ### Creator Skills (`creator-skills`)
 Scientific content creation for figures and presentations.

--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-skills",
   "description": "Collection of development workflow skills including systematic problem-solving cycle from brainstorming to PR merge",
-  "version": "3.6.0"
+  "version": "3.7.0"
 }

--- a/dev-skills/skills/discuss-with-codex/SKILL.md
+++ b/dev-skills/skills/discuss-with-codex/SKILL.md
@@ -153,9 +153,18 @@ cat "$DIR/msg.txt"
 
 ## Stop conditions
 
-- **Converged** — Codex's reply contains `NO FURTHER OBJECTIONS`, or it only
-  restates points you have already addressed (no new substantive objection).
-  Judge this against Codex's actual words, not your preference.
+- **Converged** — any of:
+  - Codex replies `NO FURTHER OBJECTIONS`, or only restates points you have
+    already addressed (no new substantive objection); or
+  - **Goal convergence** — the original goal question now has a stable answer and
+    Codex's new objections have drifted to out-of-scope refinements (deeper
+    implementation details, adjacent APIs, edge cases that don't change the
+    answer to the goal). An always-adversarial critic will keep finding *some*
+    new edge case forever, so do not wait for it to run dry on a tangent.
+  Judge against Codex's actual words, not your preference — only call goal
+  convergence when the goal is genuinely settled (often Codex itself signals it,
+  e.g. "the core question is solid"), not merely because you want to stop. Record
+  the accepted out-of-scope refinements in the conclusion.
 - **Round cap** — 6 rounds reached. Carry any live disagreements into the
   conclusion as explicitly unresolved.
 - **Error** — a codex call exits non-zero or times out (exit code 124 = timed

--- a/dev-skills/skills/discuss-with-codex/SKILL.md
+++ b/dev-skills/skills/discuss-with-codex/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: discuss-with-codex
+description: This skill should be used when the user asks to "discuss with codex", "debate this with codex", "get codex's take", "deliberate with codex", or wants Claude and the Codex CLI to reach a reasoned conclusion on a question or design through autonomous turn-by-turn adversarial discussion. Claude holds a genuine position while Codex acts as an always-adversarial read-only critic; the loop runs to convergence or a round cap, then a conclusion is saved and presented.
+---
+
+# Discuss with Codex
+
+## Overview
+
+Given a goal — a question, decision, or design — run an autonomous, turn-by-turn
+deliberation between **you (Claude)** and the **Codex CLI**, converging on a
+written conclusion. You harness the turns. Codex is an adversarial critic running
+read-only. The deliverable is a reasoned conclusion, not code changes.
+
+**Core asymmetry (the whole point):**
+- **Codex always attacks** — every turn it finds the weakest point, pushes back,
+  and proposes a better alternative.
+- **You are truth-seeking** — hold your genuine best position and update it
+  honestly, conceding or rebutting each objection.
+
+The conclusion is your position *after* it survives adversarial pressure, plus
+any objections that could not be dissolved (flagged as unresolved with your
+chosen resolution and reasoning).
+
+You drive the loop by running the bash commands below turn by turn — reading
+Codex's reply, then composing the next prompt with your own reasoning. It is NOT
+a single shell script: composing each rebuttal is your job.
+
+## When to use / not use
+
+- **Use** for: design decisions, architecture debates, "should we X or Y", pros/cons
+  questions, pressure-testing a plan.
+- **Do not use** when the user wants files changed or code written — this skill
+  only deliberates. Suggest a normal workflow instead.
+
+## Defaults
+
+- `ROUND_CAP=6` (one round = one Claude↔Codex exchange)
+- `CALL_TIMEOUT=180` seconds per codex call; `SMOKE_TIMEOUT=60` for preflight
+- Codex sandbox: `read-only`, repo as working dir
+- Conclusion: always saved AND presented
+
+## Setup (run once at start)
+
+```bash
+DIR="$(mktemp -d)"                      # transcript + working files
+REPO="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+echo "workdir: $DIR"; echo "repo: $REPO"
+
+# Portable per-call timeout. macOS has no `timeout`; perl ships at /usr/bin/perl.
+# Also forces child stdin to /dev/null — codex blocks on stdin otherwise.
+codex_to() {                            # usage: codex_to <seconds> <cmd...>
+  local s="$1"; shift
+  if command -v timeout  >/dev/null 2>&1; then timeout  "$s" "$@" </dev/null
+  elif command -v gtimeout >/dev/null 2>&1; then gtimeout "$s" "$@" </dev/null
+  else perl -e 'my $t=shift; my $p=fork; if(!$p){open(STDIN,"<","/dev/null");exec @ARGV;exit 127} eval{local $SIG{ALRM}=sub{die};alarm $t;waitpid($p,0);alarm 0}; if($@){kill "TERM",$p;exit 124} exit($?>>8)' "$s" "$@"
+  fi
+}
+```
+
+## Step 0 — Preflight (mandatory)
+
+A real smoke call catches broken Codex environments that `command -v` cannot
+(failed/missing Codex hooks, auth problems, sandbox refusals).
+
+```bash
+command -v codex >/dev/null || { echo "codex CLI not found — install it first"; exit 1; }
+codex_to 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \
+  "Reply with exactly: ok" > "$DIR/smoke.jsonl" 2> "$DIR/smoke.err"
+echo "exit=$?"
+grep -qi "ok" "$DIR/smoke.txt" 2>/dev/null && echo "SMOKE OK" || { echo "SMOKE FAILED"; tail -5 "$DIR/smoke.err"; }
+```
+
+If the smoke call times out, exits non-zero, or `smoke.txt` lacks the reply,
+**STOP**. Report a one-line diagnosis from `$DIR/smoke.err` (e.g. "Codex hooks
+are failing — check the `~/.codex` plugin cache" or "Codex not authenticated").
+Do not fall back to a Claude-only discussion — this skill is pointless without Codex.
+
+## Step 1 — Kickoff
+
+1. Form your **honest initial position** on the goal (claim + reasoning). Show it
+   to the user.
+2. Build the kickoff prompt: the goal, your position, and the critic block.
+3. Send it (first call sets sandbox + cwd):
+
+```bash
+PROMPT="GOAL:
+<the goal>
+
+CLAUDE'S CURRENT POSITION:
+<your position + reasoning>
+
+$(cat <<'CRITIC'
+You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is NOT to agree.
+- Find the single weakest point in the position above and attack it concretely.
+- Push back hard; surface hidden assumptions, edge cases, and failure modes.
+- If a better alternative exists, propose it specifically.
+- Ground objections in this repo when relevant (you have read-only access).
+- Keep it tight: a few concrete objections, strongest first.
+- If, and only if, you genuinely have no substantive objection left, reply with the single line: NO FURTHER OBJECTIONS, then one sentence on why the position holds.
+CRITIC
+)"
+
+codex_to 180 codex exec --json -s read-only -C "$REPO" \
+  -o "$DIR/msg.txt" "$PROMPT" \
+  > "$DIR/events.jsonl" 2> "$DIR/err.log"
+echo "exit=$?"
+
+THREAD_ID=$(grep -m1 '"type":"thread.started"' "$DIR/events.jsonl" \
+  | sed -E 's/.*"thread_id":"([^"]+)".*/\1/')
+echo "thread_id=$THREAD_ID"
+cat "$DIR/msg.txt"
+```
+
+If `THREAD_ID` is empty, use `codex exec resume --last` in later turns instead.
+
+## Step 2 — Discussion loop (repeat until a stop condition)
+
+Each round:
+1. Read Codex's objections from `$DIR/msg.txt`.
+2. For **each** objection, decide: **concede & revise** or **rebut with reasoning**.
+   Update your position accordingly.
+3. Print the round block (see Progress format).
+4. Check stop conditions (below). If stopping, go to Step 3.
+5. Otherwise send your revised position back:
+
+```bash
+PROMPT="I have revised my position in response to your objections.
+
+HOW I HANDLED YOUR LAST OBJECTIONS:
+<per-objection: conceded & revised, or rebutted with reasoning>
+
+CLAUDE'S REVISED POSITION:
+<updated position>
+
+$(cat <<'CRITIC'
+You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is NOT to agree.
+- Find the single weakest point in the position above and attack it concretely.
+- Push back hard; surface hidden assumptions, edge cases, and failure modes.
+- If a better alternative exists, propose it specifically.
+- Ground objections in this repo when relevant (you have read-only access).
+- Keep it tight: a few concrete objections, strongest first.
+- If, and only if, you genuinely have no substantive objection left, reply with the single line: NO FURTHER OBJECTIONS, then one sentence on why the position holds.
+CRITIC
+)"
+
+codex_to 180 codex exec resume "$THREAD_ID" --json \
+  -o "$DIR/msg.txt" "$PROMPT" \
+  > "$DIR/events.jsonl" 2> "$DIR/err.log"
+echo "exit=$?"
+cat "$DIR/msg.txt"
+```
+
+## Stop conditions
+
+- **Converged** — Codex's reply contains `NO FURTHER OBJECTIONS`, or it only
+  restates points you have already addressed (no new substantive objection).
+  Judge this against Codex's actual words, not your preference.
+- **Round cap** — 6 rounds reached. Carry any live disagreements into the
+  conclusion as explicitly unresolved.
+- **Error** — a codex call exits non-zero or times out (exit code 124 = timed
+  out) → retry the same call once → if it still fails, conclude with what exists
+  and state the discussion was cut short.
+
+## Progress format (print one block per round, as it happens)
+
+```
+─── Round N ───
+Codex ▸ <faithful 2-4 bullet objections — no softening>
+Claude ▸ <concede/rebut per objection, condensed>
+```
+
+Show objections faithfully. Raw exchanges persist in `$DIR/msg.txt`. End with:
+`Converged after N rounds.` or `Round cap reached — K tension(s) unresolved.`
+
+## Step 3 — Conclusion (always)
+
+Write the conclusion to a dated file AND present it in chat.
+
+```bash
+OUT="docs/superpowers/specs/$(date +%F)-<topic-slug>-conclusion.md"
+```
+
+Conclusion contents:
+- The settled position.
+- Key decisions made.
+- The strongest objections Codex raised and how each resolved.
+- Any unresolved tensions, with your chosen resolution and why.
+- How it ended (converged after N rounds / round cap / cut short).
+
+Then tell the user the path and show the conclusion.

--- a/docs/superpowers/plans/2026-05-30-discuss-with-codex.md
+++ b/docs/superpowers/plans/2026-05-30-discuss-with-codex.md
@@ -6,7 +6,9 @@
 
 **Architecture:** Single-file procedural skill (`SKILL.md`). Claude is one debater and the harness; it shells out to `codex exec` / `codex exec resume` for an always-adversarial, read-only critic. Conversational state lives in each model's own session (Codex via `thread_id` resume), so the "harness" is a simple loop, not a phase machine. Every codex call is wrapped in `timeout`.
 
-**Tech Stack:** Markdown skill (`SKILL.md` with YAML frontmatter), Codex CLI (`codex exec`, v0.135.0), bash, `jq`-free JSONL parsing via `grep`/`sed`.
+**Tech Stack:** Markdown skill (`SKILL.md` with YAML frontmatter), Codex CLI (`codex exec`, v0.135.0), bash, `jq`-free JSONL parsing via `grep`/`sed`, portable timeout (`timeout`/`gtimeout`/`perl` fallback), stdin pinned to `/dev/null`.
+
+**Verified on real CLI (2026-05-30):** kickoff (clean `ok`, exit 0), `thread_id` capture from the `thread.started` event, and `resume` retaining context. Three live-testing findings are baked into the SKILL.md below: (a) macOS has no `timeout`; (b) `codex exec` blocks on stdin unless given `</dev/null`; (c) the one-time hook-loop was a transient `1.0.7→1.0.10` upgrade race that self-healed.
 
 **Spec:** `docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md`
 
@@ -80,6 +82,16 @@ a single shell script: composing each rebuttal is your job.
 DIR="$(mktemp -d)"                      # transcript + working files
 REPO="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 echo "workdir: $DIR"; echo "repo: $REPO"
+
+# Portable per-call timeout. macOS has no `timeout`; perl ships at /usr/bin/perl.
+# Also forces child stdin to /dev/null — codex blocks on stdin otherwise.
+codex_to() {                            # usage: codex_to <seconds> <cmd...>
+  local s="$1"; shift
+  if command -v timeout  >/dev/null 2>&1; then timeout  "$s" "$@" </dev/null
+  elif command -v gtimeout >/dev/null 2>&1; then gtimeout "$s" "$@" </dev/null
+  else perl -e 'my $t=shift; my $p=fork; if(!$p){open(STDIN,"<","/dev/null");exec @ARGV;exit 127} eval{local $SIG{ALRM}=sub{die};alarm $t;waitpid($p,0);alarm 0}; if($@){kill "TERM",$p;exit 124} exit($?>>8)' "$s" "$@"
+  fi
+}
 ```
 
 ## Step 0 — Preflight (mandatory)
@@ -89,7 +101,7 @@ A real smoke call catches broken Codex environments that `command -v` cannot
 
 ```bash
 command -v codex >/dev/null || { echo "codex CLI not found — install it first"; exit 1; }
-timeout 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \
+codex_to 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \
   "Reply with exactly: ok" > "$DIR/smoke.jsonl" 2> "$DIR/smoke.err"
 echo "exit=$?"
 grep -qi "ok" "$DIR/smoke.txt" 2>/dev/null && echo "SMOKE OK" || { echo "SMOKE FAILED"; tail -5 "$DIR/smoke.err"; }
@@ -125,7 +137,7 @@ You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is 
 CRITIC
 )"
 
-timeout 180 codex exec --json -s read-only -C "$REPO" \
+codex_to 180 codex exec --json -s read-only -C "$REPO" \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"
 echo "exit=$?"
@@ -168,7 +180,7 @@ You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is 
 CRITIC
 )"
 
-timeout 180 codex exec resume "$THREAD_ID" --json \
+codex_to 180 codex exec resume "$THREAD_ID" --json \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"
 echo "exit=$?"
@@ -241,13 +253,16 @@ Expected: all six lines print `OK`.
 Run:
 ```bash
 F=dev-skills/skills/discuss-with-codex/SKILL.md
-grep -qF 'timeout 180 codex exec --json -s read-only -C "$REPO" \' "$F" && echo "OK kickoff call"
-grep -qF 'timeout 180 codex exec resume "$THREAD_ID" --json \' "$F" && echo "OK resume call"
+grep -qF 'codex_to()' "$F" && echo "OK timeout helper defined"
+grep -qF 'open(STDIN,"<","/dev/null")' "$F" && echo "OK stdin redirect in helper"
+grep -qF 'codex_to 180 codex exec --json -s read-only -C "$REPO" \' "$F" && echo "OK kickoff call"
+grep -qF 'codex_to 180 codex exec resume "$THREAD_ID" --json \' "$F" && echo "OK resume call"
 grep -qF "grep -m1 '\"type\":\"thread.started\"'" "$F" && echo "OK thread_id capture"
-grep -qF 'timeout 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \' "$F" && echo "OK smoke call"
+grep -qF 'codex_to 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \' "$F" && echo "OK smoke call"
 ```
-Expected: all four `OK ...` lines print. This confirms the exact command templates
-(timeout wrappers, read-only sandbox, thread_id capture) survived authoring intact.
+Expected: all six `OK ...` lines print. This confirms the command templates
+(portable timeout helper, stdin redirect, read-only sandbox, thread_id capture)
+survived authoring intact.
 
 - [ ] **Step 5: Commit**
 
@@ -332,10 +347,11 @@ git commit -m "Document discuss-with-codex in README"
 
 ## Task 4: Live end-to-end verification
 
-**Precondition:** the user's Codex environment must be healthy. The known blocker
-(2026-05-30) is a core-hooks plugin version mismatch in `~/.codex` that sent
-`codex exec` into an emit loop. Confirm the preflight smoke call passes before
-running this task.
+**Precondition:** the user's Codex environment must be healthy. A one-time
+hook-loop on 2026-05-30 was traced to a transient `core-hooks` `1.0.7→1.0.10`
+upgrade race in `~/.codex` and has since self-healed (verified: clean smoke +
+resume). Still, always confirm the preflight smoke call passes before running
+this task — it is the cheap guard against any future environment breakage.
 
 **Files:** none modified (manual run).
 
@@ -344,8 +360,10 @@ running this task.
 Run:
 ```bash
 DIR="$(mktemp -d)"; REPO="$(git rev-parse --show-toplevel)"
-timeout 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \
-  "Reply with exactly: ok" > "$DIR/smoke.jsonl" 2> "$DIR/smoke.err"
+# Portable timeout + stdin /dev/null (macOS has no `timeout`; codex blocks on stdin).
+perl -e 'my $t=shift; my $p=fork; if(!$p){open(STDIN,"<","/dev/null");exec @ARGV;exit 127} eval{local $SIG{ALRM}=sub{die};alarm $t;waitpid($p,0);alarm 0}; if($@){kill "TERM",$p;exit 124} exit($?>>8)' \
+  60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" "Reply with exactly: ok" \
+  > "$DIR/smoke.jsonl" 2> "$DIR/smoke.err"
 echo "exit=$?"; grep -qi ok "$DIR/smoke.txt" && echo "SMOKE OK" || { echo "SMOKE FAILED"; tail -5 "$DIR/smoke.err"; }
 ```
 Expected: `exit=0` and `SMOKE OK`. If `SMOKE FAILED`, STOP and fix the Codex
@@ -390,7 +408,7 @@ Expected: no staged conclusion file remains.
 - Truth-seeking asymmetry → Task 1 Overview + critic block.
 - Preflight smoke call → Task 1 Step 0; Task 4 Step 1.
 - `thread_id` capture + resume → Task 1 Steps 1-2.
-- Per-call `timeout` (180s / 60s smoke) → Task 1 all codex calls.
+- Portable per-call timeout (180s / 60s smoke) + stdin `</dev/null` → Task 1 `codex_to` helper, all codex calls.
 - Adversarial critic block every turn → Task 1 kickoff + loop prompts.
 - Stop: converged / round cap 6 / error-retry-once → Task 1 Stop conditions.
 - Conclusion always saved + shown → Task 1 Step 3.

--- a/docs/superpowers/plans/2026-05-30-discuss-with-codex.md
+++ b/docs/superpowers/plans/2026-05-30-discuss-with-codex.md
@@ -1,0 +1,408 @@
+# discuss-with-codex Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `dev-skills` skill that runs an autonomous turn-by-turn adversarial discussion between Claude and the Codex CLI, converging on a saved written conclusion.
+
+**Architecture:** Single-file procedural skill (`SKILL.md`). Claude is one debater and the harness; it shells out to `codex exec` / `codex exec resume` for an always-adversarial, read-only critic. Conversational state lives in each model's own session (Codex via `thread_id` resume), so the "harness" is a simple loop, not a phase machine. Every codex call is wrapped in `timeout`.
+
+**Tech Stack:** Markdown skill (`SKILL.md` with YAML frontmatter), Codex CLI (`codex exec`, v0.135.0), bash, `jq`-free JSONL parsing via `grep`/`sed`.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md`
+
+---
+
+## File Structure
+
+- **Create** `dev-skills/skills/discuss-with-codex/SKILL.md` — the entire skill: frontmatter (triggering description) + the procedural workflow Claude follows (preflight, kickoff, discussion loop, stop conditions, conclusion, progress format, error handling). All codex command templates live here.
+- **Modify** `dev-skills/.claude-plugin/plugin.json` — bump `version` `3.6.0` → `3.7.0` (added skill).
+- **Modify** `README.md` — add a one-line bullet for the new skill under the `dev-skills` "Skills:" list (optional, curated highlight list).
+
+No agents, scripts, hooks, or marketplace/`.codex-plugin` changes — skills are auto-discovered.
+
+---
+
+## Task 1: Create the SKILL.md
+
+**Files:**
+- Create: `dev-skills/skills/discuss-with-codex/SKILL.md`
+
+- [ ] **Step 1: Write the skill file**
+
+Create `dev-skills/skills/discuss-with-codex/SKILL.md` with EXACTLY this content:
+
+````markdown
+---
+name: discuss-with-codex
+description: This skill should be used when the user asks to "discuss with codex", "debate this with codex", "get codex's take", "deliberate with codex", or wants Claude and the Codex CLI to reach a reasoned conclusion on a question or design through autonomous turn-by-turn adversarial discussion. Claude holds a genuine position while Codex acts as an always-adversarial read-only critic; the loop runs to convergence or a round cap, then a conclusion is saved and presented.
+---
+
+# Discuss with Codex
+
+## Overview
+
+Given a goal — a question, decision, or design — run an autonomous, turn-by-turn
+deliberation between **you (Claude)** and the **Codex CLI**, converging on a
+written conclusion. You harness the turns. Codex is an adversarial critic running
+read-only. The deliverable is a reasoned conclusion, not code changes.
+
+**Core asymmetry (the whole point):**
+- **Codex always attacks** — every turn it finds the weakest point, pushes back,
+  and proposes a better alternative.
+- **You are truth-seeking** — hold your genuine best position and update it
+  honestly, conceding or rebutting each objection.
+
+The conclusion is your position *after* it survives adversarial pressure, plus
+any objections that could not be dissolved (flagged as unresolved with your
+chosen resolution and reasoning).
+
+You drive the loop by running the bash commands below turn by turn — reading
+Codex's reply, then composing the next prompt with your own reasoning. It is NOT
+a single shell script: composing each rebuttal is your job.
+
+## When to use / not use
+
+- **Use** for: design decisions, architecture debates, "should we X or Y", pros/cons
+  questions, pressure-testing a plan.
+- **Do not use** when the user wants files changed or code written — this skill
+  only deliberates. Suggest a normal workflow instead.
+
+## Defaults
+
+- `ROUND_CAP=6` (one round = one Claude↔Codex exchange)
+- `CALL_TIMEOUT=180` seconds per codex call; `SMOKE_TIMEOUT=60` for preflight
+- Codex sandbox: `read-only`, repo as working dir
+- Conclusion: always saved AND presented
+
+## Setup (run once at start)
+
+```bash
+DIR="$(mktemp -d)"                      # transcript + working files
+REPO="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+echo "workdir: $DIR"; echo "repo: $REPO"
+```
+
+## Step 0 — Preflight (mandatory)
+
+A real smoke call catches broken Codex environments that `command -v` cannot
+(failed/missing Codex hooks, auth problems, sandbox refusals).
+
+```bash
+command -v codex >/dev/null || { echo "codex CLI not found — install it first"; exit 1; }
+timeout 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \
+  "Reply with exactly: ok" > "$DIR/smoke.jsonl" 2> "$DIR/smoke.err"
+echo "exit=$?"
+grep -qi "ok" "$DIR/smoke.txt" 2>/dev/null && echo "SMOKE OK" || { echo "SMOKE FAILED"; tail -5 "$DIR/smoke.err"; }
+```
+
+If the smoke call times out, exits non-zero, or `smoke.txt` lacks the reply,
+**STOP**. Report a one-line diagnosis from `$DIR/smoke.err` (e.g. "Codex hooks
+are failing — check the `~/.codex` plugin cache" or "Codex not authenticated").
+Do not fall back to a Claude-only discussion — this skill is pointless without Codex.
+
+## Step 1 — Kickoff
+
+1. Form your **honest initial position** on the goal (claim + reasoning). Show it
+   to the user.
+2. Build the kickoff prompt: the goal, your position, and the critic block.
+3. Send it (first call sets sandbox + cwd):
+
+```bash
+PROMPT="GOAL:
+<the goal>
+
+CLAUDE'S CURRENT POSITION:
+<your position + reasoning>
+
+$(cat <<'CRITIC'
+You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is NOT to agree.
+- Find the single weakest point in the position above and attack it concretely.
+- Push back hard; surface hidden assumptions, edge cases, and failure modes.
+- If a better alternative exists, propose it specifically.
+- Ground objections in this repo when relevant (you have read-only access).
+- Keep it tight: a few concrete objections, strongest first.
+- If, and only if, you genuinely have no substantive objection left, reply with the single line: NO FURTHER OBJECTIONS, then one sentence on why the position holds.
+CRITIC
+)"
+
+timeout 180 codex exec --json -s read-only -C "$REPO" \
+  -o "$DIR/msg.txt" "$PROMPT" \
+  > "$DIR/events.jsonl" 2> "$DIR/err.log"
+echo "exit=$?"
+
+THREAD_ID=$(grep -m1 '"type":"thread.started"' "$DIR/events.jsonl" \
+  | sed -E 's/.*"thread_id":"([^"]+)".*/\1/')
+echo "thread_id=$THREAD_ID"
+cat "$DIR/msg.txt"
+```
+
+If `THREAD_ID` is empty, use `codex exec resume --last` in later turns instead.
+
+## Step 2 — Discussion loop (repeat until a stop condition)
+
+Each round:
+1. Read Codex's objections from `$DIR/msg.txt`.
+2. For **each** objection, decide: **concede & revise** or **rebut with reasoning**.
+   Update your position accordingly.
+3. Print the round block (see Progress format).
+4. Check stop conditions (below). If stopping, go to Step 3.
+5. Otherwise send your revised position back:
+
+```bash
+PROMPT="I have revised my position in response to your objections.
+
+HOW I HANDLED YOUR LAST OBJECTIONS:
+<per-objection: conceded & revised, or rebutted with reasoning>
+
+CLAUDE'S REVISED POSITION:
+<updated position>
+
+$(cat <<'CRITIC'
+You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is NOT to agree.
+- Find the single weakest point in the position above and attack it concretely.
+- Push back hard; surface hidden assumptions, edge cases, and failure modes.
+- If a better alternative exists, propose it specifically.
+- Ground objections in this repo when relevant (you have read-only access).
+- Keep it tight: a few concrete objections, strongest first.
+- If, and only if, you genuinely have no substantive objection left, reply with the single line: NO FURTHER OBJECTIONS, then one sentence on why the position holds.
+CRITIC
+)"
+
+timeout 180 codex exec resume "$THREAD_ID" --json \
+  -o "$DIR/msg.txt" "$PROMPT" \
+  > "$DIR/events.jsonl" 2> "$DIR/err.log"
+echo "exit=$?"
+cat "$DIR/msg.txt"
+```
+
+## Stop conditions
+
+- **Converged** — Codex's reply contains `NO FURTHER OBJECTIONS`, or it only
+  restates points you have already addressed (no new substantive objection).
+  Judge this against Codex's actual words, not your preference.
+- **Round cap** — 6 rounds reached. Carry any live disagreements into the
+  conclusion as explicitly unresolved.
+- **Error** — a codex call exits non-zero or times out (`timeout` exit code 124)
+  → retry the same call once → if it still fails, conclude with what exists and
+  state the discussion was cut short.
+
+## Progress format (print one block per round, as it happens)
+
+```
+─── Round N ───
+Codex ▸ <faithful 2-4 bullet objections — no softening>
+Claude ▸ <concede/rebut per objection, condensed>
+```
+
+Show objections faithfully. Raw exchanges persist in `$DIR/msg.txt`. End with:
+`Converged after N rounds.` or `Round cap reached — K tension(s) unresolved.`
+
+## Step 3 — Conclusion (always)
+
+Write the conclusion to a dated file AND present it in chat.
+
+```bash
+OUT="docs/superpowers/specs/$(date +%F)-<topic-slug>-conclusion.md"
+```
+
+Conclusion contents:
+- The settled position.
+- Key decisions made.
+- The strongest objections Codex raised and how each resolved.
+- Any unresolved tensions, with your chosen resolution and why.
+- How it ended (converged after N rounds / round cap / cut short).
+
+Then tell the user the path and show the conclusion.
+````
+
+- [ ] **Step 2: Verify the file exists and frontmatter is well-formed**
+
+Run:
+```bash
+test -f dev-skills/skills/discuss-with-codex/SKILL.md && echo EXISTS
+head -3 dev-skills/skills/discuss-with-codex/SKILL.md
+grep -c '^name: discuss-with-codex$' dev-skills/skills/discuss-with-codex/SKILL.md
+grep -c '^description: ' dev-skills/skills/discuss-with-codex/SKILL.md
+```
+Expected: `EXISTS`, the first line is `---`, and both `grep -c` print `1`.
+
+- [ ] **Step 3: Verify required sections are present**
+
+Run:
+```bash
+for s in "## Overview" "## Step 0 — Preflight" "## Step 1 — Kickoff" "## Step 2 — Discussion loop" "## Stop conditions" "## Step 3 — Conclusion"; do
+  grep -qF "$s" dev-skills/skills/discuss-with-codex/SKILL.md && echo "OK  $s" || echo "MISSING  $s"
+done
+```
+Expected: all six lines print `OK`.
+
+- [ ] **Step 4: Verify the critical codex command lines are present and correct**
+
+Run:
+```bash
+F=dev-skills/skills/discuss-with-codex/SKILL.md
+grep -qF 'timeout 180 codex exec --json -s read-only -C "$REPO" \' "$F" && echo "OK kickoff call"
+grep -qF 'timeout 180 codex exec resume "$THREAD_ID" --json \' "$F" && echo "OK resume call"
+grep -qF "grep -m1 '\"type\":\"thread.started\"'" "$F" && echo "OK thread_id capture"
+grep -qF 'timeout 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \' "$F" && echo "OK smoke call"
+```
+Expected: all four `OK ...` lines print. This confirms the exact command templates
+(timeout wrappers, read-only sandbox, thread_id capture) survived authoring intact.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dev-skills/skills/discuss-with-codex/SKILL.md
+git commit -m "Add discuss-with-codex skill"
+```
+
+---
+
+## Task 2: Bump dev-skills plugin version
+
+**Files:**
+- Modify: `dev-skills/.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Verify current version**
+
+Run:
+```bash
+grep '"version"' dev-skills/.claude-plugin/plugin.json
+```
+Expected: `"version": "3.6.0"`
+
+- [ ] **Step 2: Bump to 3.7.0**
+
+Edit `dev-skills/.claude-plugin/plugin.json`, changing the version line from
+`"version": "3.6.0"` to `"version": "3.7.0"`.
+
+- [ ] **Step 3: Verify JSON is valid and version updated**
+
+Run:
+```bash
+python3 -c "import json;print(json.load(open('dev-skills/.claude-plugin/plugin.json'))['version'])"
+```
+Expected: `3.7.0`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dev-skills/.claude-plugin/plugin.json
+git commit -m "Bump dev-skills to 3.7.0 for discuss-with-codex"
+```
+
+---
+
+## Task 3: Add README entry (optional highlight)
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Locate the dev-skills Skills list**
+
+Run:
+```bash
+grep -n "step-workflow\*\*:" README.md
+```
+Expected: one match — the line listing `**step-workflow**: ...` under dev-skills.
+
+- [ ] **Step 2: Add the new bullet immediately after the step-workflow bullet**
+
+Insert this line directly after the `**step-workflow**:` bullet:
+```markdown
+- **discuss-with-codex**: Autonomous turn-by-turn adversarial discussion with the Codex CLI that converges on a saved written conclusion
+```
+
+- [ ] **Step 3: Verify it was added**
+
+Run:
+```bash
+grep -c "discuss-with-codex" README.md
+```
+Expected: `1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "Document discuss-with-codex in README"
+```
+
+---
+
+## Task 4: Live end-to-end verification
+
+**Precondition:** the user's Codex environment must be healthy. The known blocker
+(2026-05-30) is a core-hooks plugin version mismatch in `~/.codex` that sent
+`codex exec` into an emit loop. Confirm the preflight smoke call passes before
+running this task.
+
+**Files:** none modified (manual run).
+
+- [ ] **Step 1: Run the preflight smoke call standalone**
+
+Run:
+```bash
+DIR="$(mktemp -d)"; REPO="$(git rev-parse --show-toplevel)"
+timeout 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \
+  "Reply with exactly: ok" > "$DIR/smoke.jsonl" 2> "$DIR/smoke.err"
+echo "exit=$?"; grep -qi ok "$DIR/smoke.txt" && echo "SMOKE OK" || { echo "SMOKE FAILED"; tail -5 "$DIR/smoke.err"; }
+```
+Expected: `exit=0` and `SMOKE OK`. If `SMOKE FAILED`, STOP and fix the Codex
+environment (see Precondition) before continuing.
+
+- [ ] **Step 2: Drive the skill on a trivial goal**
+
+Invoke the skill yourself (follow `SKILL.md`) with a tiny goal, e.g.
+*"Should a coin-flip helper default to returning a boolean or the string
+'heads'/'tails'?"*. Run kickoff, capture `thread_id`, do at most 2 rounds, and
+write the conclusion.
+
+- [ ] **Step 3: Verify the loop mechanics worked**
+
+Confirm during the run:
+- `thread_id` was captured non-empty from the `thread.started` event.
+- `codex exec resume "$THREAD_ID"` produced a second-round reply.
+- A conclusion file `docs/superpowers/specs/$(date +%F)-*-conclusion.md` was written.
+
+Run:
+```bash
+ls docs/superpowers/specs/$(date +%F)-*-conclusion.md
+```
+Expected: the conclusion file path prints.
+
+- [ ] **Step 4: Clean up the throwaway conclusion**
+
+The trivial-goal conclusion is a test artifact, not a real deliverable.
+
+```bash
+rm docs/superpowers/specs/$(date +%F)-*-conclusion.md 2>/dev/null
+git status --short
+```
+Expected: no staged conclusion file remains.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Thin-harness architecture (Claude debater + Codex critic) → Task 1 SKILL.md Overview + loop.
+- Truth-seeking asymmetry → Task 1 Overview + critic block.
+- Preflight smoke call → Task 1 Step 0; Task 4 Step 1.
+- `thread_id` capture + resume → Task 1 Steps 1-2.
+- Per-call `timeout` (180s / 60s smoke) → Task 1 all codex calls.
+- Adversarial critic block every turn → Task 1 kickoff + loop prompts.
+- Stop: converged / round cap 6 / error-retry-once → Task 1 Stop conditions.
+- Conclusion always saved + shown → Task 1 Step 3.
+- Per-round progress format → Task 1 Progress format.
+- Read-only repo sandbox → Task 1 (`-s read-only -C "$REPO"`).
+- Auto-discovery (no marketplace change) + version bump → Task 2.
+
+**Placeholder scan:** The `<the goal>`, `<your position>`, `<topic-slug>` markers
+inside the SKILL.md are intentional runtime fill-ins for the executing agent, not
+plan placeholders — they are the parts Claude composes each run. All verification
+commands are concrete.
+
+**Type consistency:** Variable names consistent across tasks: `$DIR`, `$REPO`,
+`$THREAD_ID`, `$PROMPT`, `$DIR/msg.txt`, `$DIR/events.jsonl`. The capture field is
+`thread_id` from the `thread.started` event everywhere.

--- a/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
+++ b/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
@@ -76,17 +76,34 @@ Key mechanics verified:
 line; `codex exec resume <thread_id>` continues the session. Fallback if capture
 fails: `codex exec resume --last`.
 
-**Every codex call is wrapped in `timeout`.** Testing showed a single broken
-Codex hook can send `codex exec` into a near-infinite emit loop (it answered
-correctly, then repeated a hook-failure message 45+ times). A per-call wall-clock
-cap (default **180s**) is mandatory so one bad call cannot hang the skill. A
-timeout counts as a failed call (see Error handling).
+**Two invocation requirements discovered by live testing — both mandatory:**
+
+1. **Redirect stdin from `/dev/null`.** Even with a prompt argument, `codex exec`
+   prints `Reading additional input from stdin...` and blocks forever waiting for
+   stdin EOF when stdin is an open pipe. Every call must use `< /dev/null`.
+2. **Wrap every call in a portable timeout.** `timeout` is **not installed on
+   macOS** (`command not found`), and a broken Codex hook can send `codex exec`
+   into a near-infinite emit loop (observed: 45+ repeats of a hook-failure
+   message). Prefer `timeout`/`gtimeout`; fall back to a `perl` alarm (perl ships
+   at `/usr/bin/perl`). Default cap **180s** (60s for the preflight smoke call).
+   A timeout (exit 124) counts as a failed call (see Error handling).
+
+Helper (defined once at run start):
+```bash
+codex_to() {                      # usage: codex_to <seconds> <cmd...>
+  local s="$1"; shift
+  if command -v timeout  >/dev/null 2>&1; then timeout  "$s" "$@" </dev/null
+  elif command -v gtimeout >/dev/null 2>&1; then gtimeout "$s" "$@" </dev/null
+  else perl -e 'my $t=shift; my $p=fork; if(!$p){open(STDIN,"<","/dev/null");exec @ARGV;exit 127} eval{local $SIG{ALRM}=sub{die};alarm $t;waitpid($p,0);alarm 0}; if($@){kill "TERM",$p;exit 124} exit($?>>8)' "$s" "$@"
+  fi
+}
+```
 
 Patterns:
 
 First turn (kickoff):
 ```
-timeout 180 codex exec --json -s read-only -C "$REPO" \
+codex_to 180 codex exec --json -s read-only -C "$REPO" \
   -o "$DIR/codex_msg.txt" "$PROMPT" \
   > "$DIR/codex_events.jsonl" 2> "$DIR/codex_err.log"
 ```
@@ -96,7 +113,7 @@ timeout 180 codex exec --json -s read-only -C "$REPO" \
 
 Later turns:
 ```
-timeout 180 codex exec resume "$THREAD_ID" --json \
+codex_to 180 codex exec resume "$THREAD_ID" --json \
   -o "$DIR/codex_msg.txt" "$PROMPT" \
   > "$DIR/codex_events.jsonl" 2> "$DIR/codex_err.log"
 ```
@@ -108,7 +125,7 @@ user can open.
 ## Turn protocol
 
 1. **Preflight** — confirm `command -v codex`, then run a **real smoke call**
-   (`timeout 60 codex exec --json -s read-only -C "$REPO" -o smoke.txt "Reply
+   (`codex_to 60 codex exec --json -s read-only -C "$REPO" -o smoke.txt "Reply
    with exactly: ok"`). The smoke call catches a broken environment that
    `command -v` cannot — missing/failed Codex hooks, auth problems, sandbox
    refusals. If codex is missing, the smoke call fails/times out, or `smoke.txt`
@@ -172,7 +189,8 @@ Final status line: `Converged after N rounds` or
 | Setting | Default |
 |---|---|
 | Round cap | 6 |
-| Per-call timeout | 180s (60s for preflight smoke call) |
+| Per-call timeout | 180s (60s smoke) via `codex_to` portable wrapper |
+| Codex stdin | always `< /dev/null` (else codex blocks) |
 | Codex sandbox | `read-only`, repo as cwd |
 | Conclusion | always saved + shown in chat |
 | Codex stance | adversarial critic (every turn) |

--- a/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
+++ b/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
@@ -148,9 +148,14 @@ user can open.
 
 ## Convergence & stop conditions
 
-- **Converged** — Codex replies `NO FURTHER OBJECTIONS`, or its latest reply only
-  restates points Claude has already addressed (no new substantive objection).
-  Judged against Codex's own words, not Claude's preference.
+- **Converged** — either (a) Codex replies `NO FURTHER OBJECTIONS` / only restates
+  addressed points, or (b) **goal convergence**: the goal question has a stable
+  answer and Codex's new objections have drifted to out-of-scope refinements.
+  Dogfooding showed an always-adversarial critic essentially never says "no
+  further objections" — it keeps surfacing deeper edge cases — so without (b)
+  every discussion would run to the round cap. Judge against Codex's own words
+  (it often signals the core is settled); record accepted out-of-scope
+  refinements in the conclusion.
 - **Round cap** — default **6 rounds** (one round = one Claude↔Codex exchange).
   On cap, any live disagreements are carried into the conclusion as explicitly
   unresolved.

--- a/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
+++ b/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
@@ -1,0 +1,179 @@
+# discuss-with-codex — Design
+
+## Goal
+
+A `dev-skills` skill that, given a goal, runs an autonomous turn-by-turn
+deliberation between Claude and the Codex CLI and converges on a written
+conclusion. Claude harnesses the turns; Codex is an adversarial critic. The
+deliverable is a reasoned conclusion, not code changes.
+
+Inspired by PolyArch/humanize, but deliberately leaner: no fixed phase machine
+(gen-idea / gen-plan / refine-plan), no Gemini, no heavyweight progress monitor.
+The "harness" is a single loop because conversational state lives inside each
+model's own session.
+
+## Core idea: truth-seeking asymmetry
+
+The two participants play different games on purpose:
+
+- **Codex is adversarial** — every turn it is told to find the weakest part of
+  the current position, push back hard, and propose a better alternative.
+- **Claude is truth-seeking** — it holds its genuine best position and updates
+  it honestly under pressure, conceding or rebutting each objection.
+
+The conclusion is Claude's position *after* it has survived adversarial
+pressure, plus any objections that could not be dissolved (flagged as unresolved
+with Claude's chosen resolution and reasoning).
+
+## Scope
+
+In scope:
+- One goal in → autonomous Claude↔Codex loop → one conclusion out.
+- Codex read-only, grounded in the actual repo.
+- Conclusion always saved to a dated file and presented in chat.
+
+Out of scope (YAGNI):
+- Codex editing files or running the project.
+- A neutral third judge or a Claude-subagent debater (rejected: extra layers).
+- Gemini / other backends.
+- User checkpoints mid-loop (the loop is fully autonomous).
+- Resuming a past discussion across skill invocations.
+
+## Architecture: thin harness (Approach A)
+
+Claude *is* one of the two debaters. It holds the position in its own context
+and shells out to `codex exec` / `codex exec resume` for the critic each round.
+The discussion runs inline in the main session. Claude is simultaneously the
+participant and the harness.
+
+Rejected alternatives:
+- **B — neutral orchestrator + Claude-subagent debater.** Cleaner separation of
+  judge from debater, but adds a subagent layer (the humanize heaviness we are
+  avoiding) and weakens the "Claude vs Codex" framing.
+- **C — Codex-only, Claude as scribe.** Throws away the two-model value.
+
+Honest weakness of A: Claude both argues and judges convergence. Mitigated by
+defining the stop condition from *Codex's* words, not Claude's preference (see
+Convergence).
+
+## Codex invocation
+
+Codex CLI: `codex-cli 0.135.0` (`codex exec`).
+
+Key mechanics verified:
+- `codex exec [PROMPT]` runs non-interactively and prints the final message.
+- `-o, --output-last-message <FILE>` writes exactly the agent's final message to
+  a file — read Codex's reply from here, no log scraping.
+- `--json` prints JSONL events to stdout, including the session id.
+- `-s, --sandbox read-only` and `-C, --cd <DIR>` set the sandbox and working
+  root **on the first call only**.
+- `codex exec resume <SESSION_ID> [PROMPT]` continues the same session,
+  preserving Codex's own context. `resume` supports `--json` and `-o` but
+  **not** `-s` or `-C` — it inherits the original session's sandbox and cwd.
+
+Patterns:
+
+First turn (kickoff):
+```
+codex exec --json -s read-only -C "$REPO" -o "$DIR/codex_msg.txt" "$PROMPT" \
+  > "$DIR/codex_events.jsonl" 2> "$DIR/codex_err.log"
+```
+- Read Codex's reply from `$DIR/codex_msg.txt`.
+- Capture the session id from `$DIR/codex_events.jsonl`.
+- Fallback if id capture fails: use `codex exec resume --last` on later turns.
+
+Later turns:
+```
+codex exec resume "$SESSION_ID" --json -o "$DIR/codex_msg.txt" "$PROMPT" \
+  > "$DIR/codex_events.jsonl" 2> "$DIR/codex_err.log"
+```
+
+Working files live under a per-run temp dir (e.g. `$CLAUDE_JOB_DIR/tmp` when set,
+else a `mktemp -d`). The `codex_msg.txt` files double as the raw transcript the
+user can open.
+
+**To verify during implementation:** the exact JSONL field carrying the session
+id (e.g. `session_id` / `thread_id`). Pin it by running one kickoff call and
+inspecting `codex_events.jsonl`. Until pinned, the `resume --last` fallback works.
+
+## Turn protocol
+
+1. **Preflight** — `command -v codex`. If missing or unauthenticated, stop with a
+   one-line install/auth hint. No Claude-only fallback (the skill is pointless
+   without Codex).
+2. **Kickoff** — Claude writes its honest initial position on the goal (claim +
+   reasoning). Sends goal + position + critic instructions to Codex (first call).
+3. **Round** — Claude reads Codex's objections. For each objection it either
+   **concedes & revises** or **rebuts with reasoning**, and updates its position.
+   It sends the revised position plus its per-objection handling back via
+   `resume`.
+4. Repeat step 3 until a stop condition fires.
+
+**Critic instruction sent every turn** (in spirit):
+> You are an adversarial critic. Find the weakest part of this position, push
+> back hard, and propose a better alternative if one exists. Be concrete and
+> cite the repo where relevant. If you have no substantive objection left, reply
+> `NO FURTHER OBJECTIONS` and state why the position holds.
+
+## Convergence & stop conditions
+
+- **Converged** — Codex replies `NO FURTHER OBJECTIONS`, or its latest reply only
+  restates points Claude has already addressed (no new substantive objection).
+  Judged against Codex's own words, not Claude's preference.
+- **Round cap** — default **6 rounds** (one round = one Claude↔Codex exchange).
+  On cap, any live disagreements are carried into the conclusion as explicitly
+  unresolved.
+- **Error** — a codex call fails → retry once → if it still fails, conclude with
+  what exists and state that the discussion was cut short.
+
+## Conclusion output
+
+Always saved to `docs/superpowers/specs/YYYY-MM-DD-<topic>-conclusion.md` **and**
+presented in chat. Contents:
+
+- The settled position.
+- Key decisions made.
+- The strongest objections Codex raised and how each was resolved.
+- Any unresolved tensions, with Claude's chosen resolution and why.
+- How the discussion ended (converged after N rounds / round cap / cut short).
+
+## Progress monitoring
+
+One compact, fixed-format block per round, streamed as each round completes:
+
+```
+─── Round 2 ───
+Codex ▸ <faithful 2–4 bullet objections>
+Claude ▸ <concede/rebut per objection, condensed>
+```
+
+Objections are shown faithfully (no softening or editorializing). The full raw
+exchanges persist in the per-run `codex_msg.txt` files for the user to open.
+Final status line: `Converged after N rounds` or
+`Round cap reached — K tension(s) unresolved`.
+
+## Defaults summary
+
+| Setting | Default |
+|---|---|
+| Round cap | 6 |
+| Codex sandbox | `read-only`, repo as cwd |
+| Conclusion | always saved + shown in chat |
+| Codex stance | adversarial critic (every turn) |
+| Loop control | fully autonomous (no mid-loop checkpoints) |
+
+## Skill file structure
+
+```
+dev-skills/skills/discuss-with-codex/
+└── SKILL.md
+```
+
+Single-file skill. Triggers: "discuss with codex", "debate this with codex",
+"get codex's take", "deliberate with codex on …".
+
+## Future / non-goals
+
+- Configurable stance (peer vs critic) — only if a real need appears.
+- Multi-backend (Gemini, etc.) — explicitly excluded for now.
+- Persisting/resuming discussions across invocations.

--- a/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
+++ b/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
@@ -71,20 +71,33 @@ Key mechanics verified:
   preserving Codex's own context. `resume` supports `--json` and `-o` but
   **not** `-s` or `-C` — it inherits the original session's sandbox and cwd.
 
+**Session id (pinned empirically):** the first JSONL event is
+`{"type":"thread.started","thread_id":"<uuid>"}`. Capture `thread_id` from that
+line; `codex exec resume <thread_id>` continues the session. Fallback if capture
+fails: `codex exec resume --last`.
+
+**Every codex call is wrapped in `timeout`.** Testing showed a single broken
+Codex hook can send `codex exec` into a near-infinite emit loop (it answered
+correctly, then repeated a hook-failure message 45+ times). A per-call wall-clock
+cap (default **180s**) is mandatory so one bad call cannot hang the skill. A
+timeout counts as a failed call (see Error handling).
+
 Patterns:
 
 First turn (kickoff):
 ```
-codex exec --json -s read-only -C "$REPO" -o "$DIR/codex_msg.txt" "$PROMPT" \
+timeout 180 codex exec --json -s read-only -C "$REPO" \
+  -o "$DIR/codex_msg.txt" "$PROMPT" \
   > "$DIR/codex_events.jsonl" 2> "$DIR/codex_err.log"
 ```
 - Read Codex's reply from `$DIR/codex_msg.txt`.
-- Capture the session id from `$DIR/codex_events.jsonl`.
-- Fallback if id capture fails: use `codex exec resume --last` on later turns.
+- Capture the thread id: first line of `$DIR/codex_events.jsonl` of type
+  `thread.started`, field `thread_id`.
 
 Later turns:
 ```
-codex exec resume "$SESSION_ID" --json -o "$DIR/codex_msg.txt" "$PROMPT" \
+timeout 180 codex exec resume "$THREAD_ID" --json \
+  -o "$DIR/codex_msg.txt" "$PROMPT" \
   > "$DIR/codex_events.jsonl" 2> "$DIR/codex_err.log"
 ```
 
@@ -92,15 +105,16 @@ Working files live under a per-run temp dir (e.g. `$CLAUDE_JOB_DIR/tmp` when set
 else a `mktemp -d`). The `codex_msg.txt` files double as the raw transcript the
 user can open.
 
-**To verify during implementation:** the exact JSONL field carrying the session
-id (e.g. `session_id` / `thread_id`). Pin it by running one kickoff call and
-inspecting `codex_events.jsonl`. Until pinned, the `resume --last` fallback works.
-
 ## Turn protocol
 
-1. **Preflight** — `command -v codex`. If missing or unauthenticated, stop with a
-   one-line install/auth hint. No Claude-only fallback (the skill is pointless
-   without Codex).
+1. **Preflight** — confirm `command -v codex`, then run a **real smoke call**
+   (`timeout 60 codex exec --json -s read-only -C "$REPO" -o smoke.txt "Reply
+   with exactly: ok"`). The smoke call catches a broken environment that
+   `command -v` cannot — missing/failed Codex hooks, auth problems, sandbox
+   refusals. If codex is missing, the smoke call fails/times out, or `smoke.txt`
+   doesn't contain the expected reply, stop with a one-line diagnosis (e.g.
+   "Codex hooks are failing — check `~/.codex` plugin cache") plus a fix hint.
+   No Claude-only fallback (the skill is pointless without Codex).
 2. **Kickoff** — Claude writes its honest initial position on the goal (claim +
    reasoning). Sends goal + position + critic instructions to Codex (first call).
 3. **Round** — Claude reads Codex's objections. For each objection it either
@@ -123,8 +137,9 @@ inspecting `codex_events.jsonl`. Until pinned, the `resume --last` fallback work
 - **Round cap** — default **6 rounds** (one round = one Claude↔Codex exchange).
   On cap, any live disagreements are carried into the conclusion as explicitly
   unresolved.
-- **Error** — a codex call fails → retry once → if it still fails, conclude with
-  what exists and state that the discussion was cut short.
+- **Error** — a codex call fails or times out (non-zero exit, including the
+  `timeout` 124 code) → retry once → if it still fails, conclude with what exists
+  and state that the discussion was cut short.
 
 ## Conclusion output
 
@@ -157,6 +172,7 @@ Final status line: `Converged after N rounds` or
 | Setting | Default |
 |---|---|
 | Round cap | 6 |
+| Per-call timeout | 180s (60s for preflight smoke call) |
 | Codex sandbox | `read-only`, repo as cwd |
 | Conclusion | always saved + shown in chat |
 | Codex stance | adversarial critic (every turn) |


### PR DESCRIPTION
New `dev-skills` skill that runs an autonomous, turn-by-turn adversarial discussion between Claude and Codex (driven via `codex exec`), converging on a saved written conclusion. Claude holds a genuine position; Codex is an always-adversarial, read-only critic. Fully autonomous loop with a 6-round cap.

Key points (verified live against `codex exec` — kickoff, `thread_id` capture, `resume` with context retention, conclusion):
- Codex state persists via `codex exec resume <thread_id>`, so the harness is a simple loop, not a phase machine.
- Portable invocation: stdin pinned to `/dev/null` (codex blocks otherwise) and a `timeout`/`gtimeout`/`perl` fallback (macOS ships no `timeout`).
- Convergence recognizes goal-settled vs. adversarial drift, so discussions don't always run to the cap.

Also includes the design spec and implementation plan under `docs/superpowers/`, and bumps `dev-skills` to 3.7.0.