### PR TITLE
Clarify discuss-with-codex resume flag asymmetry and harden THREAD_ID handling (#113)

### DIFF
--- a/dev-skills/skills/discuss-with-codex/SKILL.md
+++ b/dev-skills/skills/discuss-with-codex/SKILL.md
@@ -81,7 +81,9 @@ Do not fall back to a Claude-only discussion — this skill is pointless without
 1. Form your **honest initial position** on the goal (claim + reasoning). Show it
    to the user.
 2. Build the kickoff prompt: the goal, your position, and the critic block.
-3. Send it (first call sets sandbox + cwd):
+3. Send it. **Only this first call carries `-s`/`-C`** — they configure the
+   session. Later `codex exec resume` calls inherit sandbox and cwd from the
+   session and will error if you pass `-s`/`-C` again.
 
 ```bash
 PROMPT="GOAL:
@@ -112,7 +114,9 @@ echo "thread_id=$THREAD_ID"
 cat "$DIR/msg.txt"
 ```
 
-If `THREAD_ID` is empty, use `codex exec resume --last` in later turns instead.
+If `THREAD_ID` is empty, **STOP** — the kickoff did not produce a `thread.started`
+event, which means the call failed or the event shape changed. Report the last
+lines of `$DIR/err.log` and `$DIR/events.jsonl`; do not proceed.
 
 ## Step 2 — Discussion loop (repeat until a stop condition)
 
@@ -144,6 +148,9 @@ You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is 
 CRITIC
 )"
 
+# NOTE: do NOT pass -s/-C to `codex exec resume`. Sandbox and cwd are bound to
+# the session at kickoff and `resume` rejects those flags. Always use the
+# explicit THREAD_ID form captured in Step 1.
 codex_to 180 codex exec resume "$THREAD_ID" --json \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"

--- a/dev-skills/skills/discuss-with-codex/SKILL.md
+++ b/dev-skills/skills/discuss-with-codex/SKILL.md
@@ -106,17 +106,23 @@ CRITIC
 codex_to 180 codex exec --json -s read-only -C "$REPO" \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"
-echo "exit=$?"
+status=$?
+echo "exit=$status"
 
-THREAD_ID=$(grep -m1 '"type":"thread.started"' "$DIR/events.jsonl" \
-  | sed -E 's/.*"thread_id":"([^"]+)".*/\1/')
+THREAD_ID=$(sed -nE '/"type"[[:space:]]*:[[:space:]]*"thread\.started"/s/.*"thread_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$DIR/events.jsonl" | head -n1)
 echo "thread_id=$THREAD_ID"
 cat "$DIR/msg.txt"
 ```
 
-If `THREAD_ID` is empty, **STOP** — the kickoff did not produce a `thread.started`
-event, which means the call failed or the event shape changed. Report the last
-lines of `$DIR/err.log` and `$DIR/events.jsonl`; do not proceed.
+Branch on the two failure classes:
+
+- **`status` is non-zero (124 = timed out)** — the call failed transiently.
+  Follow the **Error** stop condition (retry the kickoff once; if it still
+  fails, conclude with what exists and state the discussion was cut short).
+- **`status` is zero but `THREAD_ID` is empty** — the call succeeded yet did
+  not emit a `thread.started` event, which means the event shape changed.
+  **STOP** and report the last lines of `$DIR/err.log` and
+  `$DIR/events.jsonl`; do not fall back to the `--last` form.
 
 ## Step 2 — Discussion loop (repeat until a stop condition)
 

--- a/docs/superpowers/plans/2026-05-30-discuss-with-codex.md
+++ b/docs/superpowers/plans/2026-05-30-discuss-with-codex.md
@@ -117,7 +117,9 @@ Do not fall back to a Claude-only discussion — this skill is pointless without
 1. Form your **honest initial position** on the goal (claim + reasoning). Show it
    to the user.
 2. Build the kickoff prompt: the goal, your position, and the critic block.
-3. Send it (first call sets sandbox + cwd):
+3. Send it. **Only this first call carries `-s`/`-C`** — they configure the
+   session. Later `codex exec resume` calls inherit sandbox and cwd from the
+   session and will error if you pass `-s`/`-C` again.
 
 ```bash
 PROMPT="GOAL:
@@ -140,15 +142,23 @@ CRITIC
 codex_to 180 codex exec --json -s read-only -C "$REPO" \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"
-echo "exit=$?"
+status=$?
+echo "exit=$status"
 
-THREAD_ID=$(grep -m1 '"type":"thread.started"' "$DIR/events.jsonl" \
-  | sed -E 's/.*"thread_id":"([^"]+)".*/\1/')
+THREAD_ID=$(sed -nE '/"type"[[:space:]]*:[[:space:]]*"thread\.started"/s/.*"thread_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$DIR/events.jsonl" | head -n1)
 echo "thread_id=$THREAD_ID"
 cat "$DIR/msg.txt"
 ```
 
-If `THREAD_ID` is empty, use `codex exec resume --last` in later turns instead.
+Branch on the two failure classes:
+
+- **`status` is non-zero (124 = timed out)** — the call failed transiently.
+  Follow the **Error** stop condition (retry the kickoff once; if it still
+  fails, conclude with what exists and state the discussion was cut short).
+- **`status` is zero but `THREAD_ID` is empty** — the call succeeded yet did
+  not emit a `thread.started` event, which means the event shape changed.
+  **STOP** and report the last lines of `$DIR/err.log` and
+  `$DIR/events.jsonl`; do not fall back to the `--last` form.
 
 ## Step 2 — Discussion loop (repeat until a stop condition)
 
@@ -180,6 +190,9 @@ You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is 
 CRITIC
 )"
 
+# NOTE: do NOT pass -s/-C to `codex exec resume`. Sandbox and cwd are bound to
+# the session at kickoff and `resume` rejects those flags. Always use the
+# explicit THREAD_ID form captured in Step 1.
 codex_to 180 codex exec resume "$THREAD_ID" --json \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"
@@ -257,12 +270,17 @@ grep -qF 'codex_to()' "$F" && echo "OK timeout helper defined"
 grep -qF 'open(STDIN,"<","/dev/null")' "$F" && echo "OK stdin redirect in helper"
 grep -qF 'codex_to 180 codex exec --json -s read-only -C "$REPO" \' "$F" && echo "OK kickoff call"
 grep -qF 'codex_to 180 codex exec resume "$THREAD_ID" --json \' "$F" && echo "OK resume call"
-grep -qF "grep -m1 '\"type\":\"thread.started\"'" "$F" && echo "OK thread_id capture"
+grep -qE 'sed -nE .*"thread\\\.started"' "$F" && echo "OK thread_id capture (single-sed, tolerant)"
 grep -qF 'codex_to 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \' "$F" && echo "OK smoke call"
+# Invariants protecting the resume-flag/empty-THREAD_ID fix (issue #113):
+grep -qF 'codex exec resume --last' "$F" && echo "FAIL --last fallback present" || echo "OK no --last fallback"
+grep -qF '# NOTE: do NOT pass -s/-C to' "$F" && echo "OK Step 2 NOTE present" || echo "FAIL Step 2 NOTE missing"
+grep -qF 'Only this first call carries' "$F" && echo "OK Step 1 asymmetry prose present" || echo "FAIL Step 1 asymmetry prose missing"
+grep -qF 'sed -nE' "$F" && echo "OK tolerant thread_id parser" || echo "FAIL parser not whitespace-tolerant"
+grep -qF 'status=$?' "$F" && echo "OK kickoff exit status captured" || echo "FAIL kickoff exit status not captured"
 ```
-Expected: all six `OK ...` lines print. This confirms the command templates
-(portable timeout helper, stdin redirect, read-only sandbox, thread_id capture)
-survived authoring intact.
+Expected: all `OK ...` lines print, no `FAIL` lines. This confirms the command
+templates survived authoring AND the resume-flag invariants are locked in.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
+++ b/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
@@ -73,8 +73,18 @@ Key mechanics verified:
 
 **Session id (pinned empirically):** the first JSONL event is
 `{"type":"thread.started","thread_id":"<uuid>"}`. Capture `thread_id` from that
-line; `codex exec resume <thread_id>` continues the session. Fallback if capture
-fails: `codex exec resume --last`.
+line with a whitespace-tolerant pattern; `codex exec resume <thread_id>`
+continues the session. Branch on the two failure classes — these are
+**different stop conditions, not one**:
+
+- **Non-zero kickoff exit (124 = timed out)** — transient call failure.
+  Follow the **Error** rule below (retry once, then conclude cut-short).
+- **Zero exit but no parseable `thread.started`** — the call returned
+  without the expected event, meaning the event shape changed. **Stop**
+  and report `err.log` / `events.jsonl`.
+
+Never fall back to the `--last` form: it could silently attach to an
+unrelated prior session on disk.
 
 **Two invocation requirements discovered by live testing — both mandatory:**
 

--- a/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
+++ b/docs/superpowers/specs/2026-05-30-discuss-with-codex-design.md
@@ -64,17 +64,19 @@ Key mechanics verified:
 - `codex exec [PROMPT]` runs non-interactively and prints the final message.
 - `-o, --output-last-message <FILE>` writes exactly the agent's final message to
   a file — read Codex's reply from here, no log scraping.
-- `--json` prints JSONL events to stdout, including the session id.
+- `--json` prints JSONL events to stdout, including the session's `thread_id`.
 - `-s, --sandbox read-only` and `-C, --cd <DIR>` set the sandbox and working
   root **on the first call only**.
-- `codex exec resume <SESSION_ID> [PROMPT]` continues the same session,
+- `codex exec resume <THREAD_ID> [PROMPT]` continues the same session,
   preserving Codex's own context. `resume` supports `--json` and `-o` but
   **not** `-s` or `-C` — it inherits the original session's sandbox and cwd.
 
-**Session id (pinned empirically):** the first JSONL event is
-`{"type":"thread.started","thread_id":"<uuid>"}`. Capture `thread_id` from that
-line with a whitespace-tolerant pattern; `codex exec resume <thread_id>`
-continues the session. Branch on the two failure classes — these are
+**Thread id (pinned empirically — this is what the codex CLI elsewhere calls
+the "session id"):** the first JSONL event is
+`{"type":"thread.started","thread_id":"<uuid>"}` — one JSON object per line, so
+a `sed` pattern that operates per-line captures it reliably. Extract
+`thread_id` from that line with a whitespace-tolerant pattern;
+`codex exec resume <thread_id>` continues the session. Branch on the two failure classes — these are
 **different stop conditions, not one**:
 
 - **Non-zero kickoff exit (124 = timed out)** — transient call failure.

--- a/docs/superpowers/specs/2026-06-01-discuss-with-codex-resume-flags-conclusion.md
+++ b/docs/superpowers/specs/2026-06-01-discuss-with-codex-resume-flags-conclusion.md
@@ -1,0 +1,62 @@
+# Conclusion: discuss-with-codex resume-flag asymmetry (issue #113)
+
+Date: 2026-06-01
+Branch: `doc-113-codex-resume-flags`
+Initial discussion: 6 rounds with Codex CLI as adversarial read-only critic.
+Outcome: converged at Round 6 with `NO FURTHER OBJECTIONS`.
+
+## Settled position
+
+The fix delivers a small, internally-consistent change across three docs
+(SKILL.md, plan.md, design.md) that closes the bug reported in issue #113
+and four additional weaknesses surfaced during adversarial review:
+
+1. The `codex exec / codex exec resume` flag asymmetry (sandbox + cwd are
+   bound at kickoff; resume rejects `-s`/`-C`) is now documented at both
+   anchor points — Step 1 lead-in prose and an inline `# NOTE:` directly
+   above the Step 2 resume call.
+2. The empty-`THREAD_ID` case is no longer a silent fall-through to
+   `codex exec resume --last`. The skill now branches on the kickoff exit
+   status:
+   - Non-zero exit (124 = timed out) follows the existing **Error** stop
+     condition (retry once, then conclude cut-short).
+   - Zero exit but no parseable `thread.started` event is a hard stop with
+     diagnostics from `err.log` and `events.jsonl`.
+3. The `THREAD_ID` parser is now a single `sed -nE '/type-match/s/.../p'`
+   pipeline that tolerates JSON whitespace on both the type-match and the
+   thread_id extraction, and uses strict match semantics (the `p` flag
+   only emits when the substitution matched, so non-matching input
+   produces empty output rather than the raw line).
+4. The kickoff exit status is captured into a `status` variable so the
+   failure-class split is load-bearing.
+5. The plan doc's Step 4 verification block locks in 11 invariants — six
+   original (helper, stdin redirect, kickoff/resume/smoke call shapes,
+   tolerant thread_id capture) and five new (`--last` absent, Step 2
+   NOTE present, Step 1 asymmetry prose present, tolerant parser, status
+   capture).
+
+## Strongest objections raised and how they resolved
+
+| Round | Codex objection | Resolution |
+|-------|-----------------|------------|
+| 1     | The fix only touched SKILL.md; the design spec and plan doc still preserved the old `--last` fallback prose, so the bug could come back via regeneration or audit. | Updated both docs to match the SKILL.md hard-stop. |
+| 2     | "Scope defer" on the THREAD_ID parser is too convenient — the hard-stop change makes parse robustness part of this PR's behavior surface, not adjacent to it. | Conceded. Tightened the regex (`sed -nE … p`, whitespace tolerance, strict match semantics). Also updated plan's verification to lock the new invariants. |
+| 3     | End-to-end tolerance not actually achieved — only the sed stage was hardened; the upstream `grep -m1` filter still required compact JSON. Empirically verified against `{"type" : "thread.started", "thread_id" : "abc-123"}`. | Replaced grep+sed with a single `sed -nE '/pattern1/s/pattern2/.../p'` pipeline. Updated verification to assert the new shape. |
+| 4     | The new "empty THREAD_ID → hard stop" rule conflicted with the existing **Error** stop condition (which says non-zero exit / timeout → retry once). | Conceded. Captured `status=$?` and split the failure handling into two typed classes. |
+| 5     | "Internally consistent" claim was still false because the design doc still conflated the two failure classes. | Updated the design doc paragraph to mirror the split explicitly. |
+
+## Unresolved tensions
+
+None. All five substantive objections were conceded and addressed in-PR.
+
+## Out-of-scope refinements accepted
+
+None deferred. (One adjacent improvement was initially proposed for a
+follow-up issue — strengthening the JSON parser — but Codex's Round 2
+argument that the parse boundary had moved into PR scope was correct, so
+the parser was hardened in this PR rather than deferred.)
+
+## How the discussion ended
+
+Round 6: Codex replied with the single line `NO FURTHER OBJECTIONS` plus
+one sentence on why the position holds. Converged within the 6-round cap.


### PR DESCRIPTION
## Summary

Closes #113.

Fixes the resume-flag asymmetry documentation gap and four additional
issues surfaced when running the discuss-with-codex skill against the
initial fix (6-round adversarial review with the codex CLI, converged
with NO FURTHER OBJECTIONS).

- Step 1 lead-in and inline Step 2 `# NOTE:` now spell out that
  `codex exec resume` rejects `-s/-C` (sandbox and cwd are bound at
  kickoff).
- Replace the silent `codex exec resume --last` fallback with a typed
  failure split: non-zero kickoff exit follows the existing Error
  retry-once policy; zero exit but no `thread.started` event is a
  shape-drift hard stop with diagnostics from `err.log` and
  `events.jsonl`.
- Tighten the THREAD_ID parser to a single `sed -nE '/.../s/.../p'`
  pipeline that tolerates JSON whitespace end-to-end and uses strict
  match semantics. Capture kickoff `status=$?` so the failure split is
  load-bearing.
- Mirror the changes across SKILL.md, the design spec, and the plan
  doc so all three are internally consistent.
- Extend the plan's Step 4 verification block with five new invariants
  locking in the new behavior (no `--last` fallback, NOTE present,
  asymmetry prose present, tolerant parser, status capture); all 11
  print OK against the current SKILL.md.
- Add the conclusion document at
  `docs/superpowers/specs/2026-06-01-discuss-with-codex-resume-flags-conclusion.md`.

## Commits

- `c52875b` Clarify discuss-with-codex resume flag asymmetry (#113) —
  the original 3-edit prose fix.
- `20daafd` Harden discuss-with-codex per Codex-driven review (#113) —
  the five rounds of additional improvements from the adversarial
  review.
