### PR TITLE
Add standalone task-loop preflight skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Unified Claude Code plugin marketplace for development workflows, scientific content creation, and document processing",
-    "version": "2.2.0"
+    "version": "2.3.0"
   },
   "plugins": [
     {

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
-  "description": "Autonomous, orchestrated cycle-driven development: control protocol, specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.4.0"
+  "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
+  "version": "0.5.0"
 }

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -32,10 +32,9 @@ c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-si
    generic cycle skeleton plus auto-detected/interviewed project specifics, and scaffold
    `directions.md` (steering), the logs directory, `.gitignore`, and the `loop:in-progress`
    label.
-3. **`run-cycle`** *(in progress — see Status)* — the orchestrator: under built-in `/loop`
-   (self-paced), it computes the dependency-ordered task frontier, spawns one `cycle-worker`
-   teammate per ready task, validates + merges their PRs, and stops on a scheduled
-   drain-signal (not an iteration cap).
+3. **`run-cycle`** — the orchestrator: under built-in `/loop` (self-paced), it computes the
+   dependency-ordered task frontier, spawns one `cycle-worker` teammate per ready task,
+   validates + merges their PRs, and stops on a scheduled drain-signal (not an iteration cap).
 
 ## Prerequisites
 
@@ -45,7 +44,9 @@ c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-si
   `verification-before-completion`, `using-git-worktrees`, `finishing-a-development-branch`.
 - **`dev-skills`** — `discuss-with-codex`, `goal-rubric`, `doc-update`, `step-workflow`.
 
-The skills **fail fast** with install guidance if a required dependency is missing.
+**Run the `preflight` skill once per machine** to verify all of these are loadable (it reports
+needed / installed / missing) and to enable Agent Teams (below) — it's a standalone check, not
+a step in the a→b→c workflow.
 
 ## Enablement (orchestrator)
 
@@ -57,7 +58,8 @@ Claude Code ≥ v2.1.32:
 { "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
 ```
 
-The `specify-aims` and `create-cycle` skills do **not** require Agent Teams.
+The **`preflight`** skill sets this for you (and reminds you to restart). The `specify-aims` and
+`create-cycle` skills do **not** require Agent Teams.
 
 ## Files this creates in your project
 
@@ -75,6 +77,7 @@ The `specify-aims` and `create-cycle` skills do **not** require Agent Teams.
 ```
 task-loop/
 ├── skills/
+│   ├── preflight/        # standalone: verify required skills + enable Agent Teams (run once)
 │   ├── specify-aims/     # step a: author the proposal (Charter + Roadmap)
 │   ├── create-cycle/     # step b: render task-loop.md + scaffolding
 │   └── run-cycle/        # step c: the orchestrator (state machine in references/)

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -44,9 +44,10 @@ c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-si
   `verification-before-completion`, `using-git-worktrees`, `finishing-a-development-branch`.
 - **`dev-skills`** — `discuss-with-codex`, `goal-rubric`, `doc-update`, `step-workflow`.
 
-**Run the `preflight` skill once per machine** to verify all of these are loadable (it reports
-needed / installed / missing) and to enable Agent Teams (below) — it's a standalone check, not
-a step in the a→b→c workflow.
+**Run the `preflight` skill** to check two scopes: that these skills are loadable in your
+**session** (re-run it per task-loop session — it reports installed / owner-unverified /
+missing) and that **Agent Teams is enabled on your machine** (a one-time `settings.json` write,
+below). It's a standalone check, not a step in the a→b→c workflow.
 
 ## Enablement (orchestrator)
 

--- a/task-loop/skills/preflight/SKILL.md
+++ b/task-loop/skills/preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preflight
-description: This skill should be used when the user asks to "preflight", "run the task-loop preflight", "check task-loop prerequisites", "check if task-loop can run", "verify task-loop dependencies", or "enable agent teams for task-loop". It verifies that every skill the task-loop workflow depends on can be loaded in this session and reports needed/installed/missing, then ensures the experimental Agent Teams config is enabled (adjusting settings.json if needed). Run it before specify-aims / create-cycle / run-cycle.
+description: This skill should be used when the user asks to "preflight", "run the task-loop preflight", "check task-loop prerequisites", "check if task-loop can run", "verify task-loop dependencies", or "enable agent teams for task-loop". It checks two scopes — whether the skills the task-loop depends on are loadable in this session (re-run safely any time), and whether the experimental Agent Teams feature is enabled on this machine (a one-time settings.json write). Run it when setting up a machine and at the start of a task-loop session.
 version: 0.1.0
 ---
 
@@ -8,29 +8,29 @@ version: 0.1.0
 
 ## Overview
 
-Verify a session is ready to run the task-loop workflow, and make it ready where possible.
-Two checks:
-1. **Required skills are loadable** — every skill the task-loop invokes must be available in
-   this session; report `needed` / `installed` / `missing`.
-2. **Agent Teams config** — the orchestrator needs the experimental feature enabled; **set it**
-   in `settings.json` if it is not already.
+Verify a session/machine is ready to run the task-loop workflow. Two checks, **two scopes**:
 
-`specify-aims` / `create-cycle` / `run-cycle` delegate their fail-fast checks here.
+- **Check 1 — required skills (this *session*):** are the skills the task-loop invokes loadable
+  right now? This is session/project state — re-run preflight whenever you start a task-loop
+  session; it is cheap and idempotent.
+- **Check 2 — Agent Teams config (this *machine*):** is the experimental feature enabled in
+  `settings.json`? If not, set it — a one-time, machine-wide write (then a restart).
+
+`specify-aims` / `create-cycle` need only Check 1; `run-cycle` needs both.
 
 ## When to use / not use
 
-- **Use** before starting a task-loop run, or whenever a task-loop skill reports a missing
-  prerequisite.
-- It is a read/verify + a single targeted config write — it does **not** install plugins
-  (that needs the user) and does **not** run any task.
+- **Use** when setting up a machine for the task-loop, and at the start of a task-loop session
+  to re-verify the skills are loadable.
+- It is a verify + a single, guarded config write — it does **not** install plugins (that needs
+  the user) and does **not** run any task.
 
-## Check 1 — Required skills are loadable
+## Check 1 — Required skills are loadable (this session)
 
 The task-loop invokes the skills below. A skill is loadable **iff it appears in this session's
-available-skills list** — that list is exactly "what Claude can load," and it reflects an
-installed *and enabled* plugin. **Do not invoke a skill to test it** — invoking
-`brainstorming` / `discuss-with-codex` (etc.) would actually *start* it. Instead, check each
-name against the available skills.
+available-skills list** (that list reflects an installed *and enabled* plugin). **Do not invoke
+a skill to test it** — invoking `brainstorming` / `discuss-with-codex` (etc.) would actually
+*start* it. Check each name against the available skills instead.
 
 Required (10 skills across 2 plugins):
 
@@ -38,52 +38,61 @@ Required (10 skills across 2 plugins):
   `verification-before-completion`, `using-git-worktrees`, `finishing-a-development-branch`.
 - **`dev-skills`** — `discuss-with-codex`, `goal-rubric`, `doc-update`, `step-workflow`.
 
-For each required `plugin:skill`, mark it **installed** (present in available skills) or
-**missing** (absent). Report grouped, e.g.:
+**Matching (owner-verified preferred):** the task-loop depends on these *specific plugins'*
+skills, not just any skill with the same name. Match the fully-qualified `plugin:skill`
+(case-insensitive) — the available-skills list normally shows entries that way
+(`superpowers:brainstorming`, `dev-skills:discuss-with-codex`). Classify each required skill:
 
-```
-Required (10): superpowers ×6, dev-skills ×4
-Installed (9): superpowers:brainstorming, superpowers:writing-plans, …, dev-skills:goal-rubric
-Missing  (1): superpowers:test-driven-development
-```
+- **installed** — a skill from the expected plugin is available;
+- **present, owner-unverified** — only a same-named skill is available and the list does not
+  expose the owning plugin (a personal/other-plugin `brainstorming` is **not** the dependency);
+- **missing** — no skill of that name is available.
 
-For any **missing** skill, give install guidance: install the owning plugin from its
-marketplace (`superpowers`, and `dev-skills` from the `cc-toolkit` marketplace) via `/plugin`,
-then re-run preflight. List the distinct missing **plugins** so the user installs each once.
+## Check 2 — Agent Teams config (this machine)
 
-## Check 2 — Agent Teams config (set it, don't just check)
+`run-cycle` needs **experimental Agent Teams** (off by default) and Claude Code **≥ v2.1.32**.
 
-`run-cycle` (the orchestrator) needs the **experimental Agent Teams** feature — off by default —
-and Claude Code **≥ v2.1.32**. (`specify-aims` and `create-cycle` do **not** need it.)
+**Source of truth = `settings.json`.** A shell env var of the same name is informational only —
+the agent cannot reliably read the running session's resolved process env, so decide the write
+from the settings file.
 
-1. **Check** whether `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` resolves to `1` (already in the
-   environment, or in a `settings.json` `env` block).
-2. **If it is not set, set it.** Edit `.claude/settings.json` (project scope; use
-   `~/.claude/settings.json` for global) to add `"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"`
-   inside the top-level `env` object — **merging carefully**: read the file (treat a missing
-   file as `{}`), preserve every existing key, create the `env` object only if absent, and write
-   valid JSON back. Then tell the user a **session restart is required** for it to take effect.
-   The intended result:
+**Target = global `~/.claude/settings.json`** (machine-wide, matching "set it once per machine"
+and the rest of this repo's settings-writing skills). Use a project `.claude/settings.json` only
+as a deliberate exception, and warn the user it is often version-controlled and shared.
+
+**Guarded write (mirror `cc-customize/skills/model-config`):**
+1. **Read** `~/.claude/settings.json`. **Refuse and stop** (report exactly what to fix, edit
+   nothing) if it does **not** parse as a JSON object, or if `env` exists but is not an object
+   (a scalar/array) — a "surgical" edit on malformed config would corrupt it.
+2. If the file is **absent** → `Write`:
    ```json
    { "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
    ```
-3. **Version:** check `claude --version` ≥ v2.1.32 and report it (this cannot be auto-fixed —
-   if older, tell the user to update Claude Code).
+3. If it **exists and is a valid object** → use the **`Edit`** tool to add/replace **only** the
+   `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` key inside the existing `env` object (create `env` only
+   if absent). **Preserve every other key.** The value is the **quoted string `"1"`**, not `1`.
+4. If you just wrote it, a **session restart** is required for it to take effect.
 
-## Report
+**Version:** report `claude --version` (must be ≥ v2.1.32 — cannot be auto-fixed; tell the user
+to update if older).
 
-End with a clear verdict:
+## Report (two scopes, text labels — no emoji)
 
-- ✅ **Ready** — all 10 skills loadable; Agent Teams enabled (note "restart required" if it was
-  just set); version OK.
-- ❌ **Not ready** — list the missing skills + which plugins to install; note any config change
-  made and the restart; note an out-of-date version.
+- **Machine config:** `ENABLED` · `JUST-CONFIGURED (restart required)` · `BLOCKED (settings.json
+  needs a manual fix: …)` · `VERSION TOO OLD (have X, need ≥ v2.1.32)`.
+- **Session readiness:** `ALL LOADABLE` · `OWNER-UNVERIFIED (list which)` · `MISSING (list +
+  which plugin to install)`.
+- **Overall:** `READY` only when every required skill is **installed** (owner-verified) **and**
+  Agent Teams is **ENABLED**. A *just-configured* (pending restart) machine, an
+  *owner-unverified* skill, an old version, or any missing skill → `NOT READY`, with the specific
+  blocker and next step (install plugin via `/plugin`; restart; update the CLI).
 
 Re-run preflight after installing plugins or restarting.
 
 ## Notes
 
-- This is the shared fail-fast for the suite: `specify-aims` / `create-cycle` need only Check 1;
-  `run-cycle` needs Check 1 **and** Check 2.
-- Detection is intentionally session-based ("can Claude load it?"), not a filesystem scan — an
-  installed-but-disabled plugin correctly reads as unavailable.
+- Detection is session-based ("can Claude load it *now*?"), not a filesystem scan — an
+  installed-but-disabled plugin correctly reads as unavailable, and a "Ready" from one session
+  does not carry to a different project/session, so re-run it per task-loop session.
+- The config write is the only durable, machine-wide effect; running preflight again is a no-op
+  once the key is set.

--- a/task-loop/skills/preflight/SKILL.md
+++ b/task-loop/skills/preflight/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: preflight
+description: This skill should be used when the user asks to "preflight", "run the task-loop preflight", "check task-loop prerequisites", "check if task-loop can run", "verify task-loop dependencies", or "enable agent teams for task-loop". It verifies that every skill the task-loop workflow depends on can be loaded in this session and reports needed/installed/missing, then ensures the experimental Agent Teams config is enabled (adjusting settings.json if needed). Run it before specify-aims / create-cycle / run-cycle.
+version: 0.1.0
+---
+
+# Preflight
+
+## Overview
+
+Verify a session is ready to run the task-loop workflow, and make it ready where possible.
+Two checks:
+1. **Required skills are loadable** — every skill the task-loop invokes must be available in
+   this session; report `needed` / `installed` / `missing`.
+2. **Agent Teams config** — the orchestrator needs the experimental feature enabled; **set it**
+   in `settings.json` if it is not already.
+
+`specify-aims` / `create-cycle` / `run-cycle` delegate their fail-fast checks here.
+
+## When to use / not use
+
+- **Use** before starting a task-loop run, or whenever a task-loop skill reports a missing
+  prerequisite.
+- It is a read/verify + a single targeted config write — it does **not** install plugins
+  (that needs the user) and does **not** run any task.
+
+## Check 1 — Required skills are loadable
+
+The task-loop invokes the skills below. A skill is loadable **iff it appears in this session's
+available-skills list** — that list is exactly "what Claude can load," and it reflects an
+installed *and enabled* plugin. **Do not invoke a skill to test it** — invoking
+`brainstorming` / `discuss-with-codex` (etc.) would actually *start* it. Instead, check each
+name against the available skills.
+
+Required (10 skills across 2 plugins):
+
+- **`superpowers`** — `brainstorming`, `writing-plans`, `test-driven-development`,
+  `verification-before-completion`, `using-git-worktrees`, `finishing-a-development-branch`.
+- **`dev-skills`** — `discuss-with-codex`, `goal-rubric`, `doc-update`, `step-workflow`.
+
+For each required `plugin:skill`, mark it **installed** (present in available skills) or
+**missing** (absent). Report grouped, e.g.:
+
+```
+Required (10): superpowers ×6, dev-skills ×4
+Installed (9): superpowers:brainstorming, superpowers:writing-plans, …, dev-skills:goal-rubric
+Missing  (1): superpowers:test-driven-development
+```
+
+For any **missing** skill, give install guidance: install the owning plugin from its
+marketplace (`superpowers`, and `dev-skills` from the `cc-toolkit` marketplace) via `/plugin`,
+then re-run preflight. List the distinct missing **plugins** so the user installs each once.
+
+## Check 2 — Agent Teams config (set it, don't just check)
+
+`run-cycle` (the orchestrator) needs the **experimental Agent Teams** feature — off by default —
+and Claude Code **≥ v2.1.32**. (`specify-aims` and `create-cycle` do **not** need it.)
+
+1. **Check** whether `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` resolves to `1` (already in the
+   environment, or in a `settings.json` `env` block).
+2. **If it is not set, set it.** Edit `.claude/settings.json` (project scope; use
+   `~/.claude/settings.json` for global) to add `"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"`
+   inside the top-level `env` object — **merging carefully**: read the file (treat a missing
+   file as `{}`), preserve every existing key, create the `env` object only if absent, and write
+   valid JSON back. Then tell the user a **session restart is required** for it to take effect.
+   The intended result:
+   ```json
+   { "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
+   ```
+3. **Version:** check `claude --version` ≥ v2.1.32 and report it (this cannot be auto-fixed —
+   if older, tell the user to update Claude Code).
+
+## Report
+
+End with a clear verdict:
+
+- ✅ **Ready** — all 10 skills loadable; Agent Teams enabled (note "restart required" if it was
+  just set); version OK.
+- ❌ **Not ready** — list the missing skills + which plugins to install; note any config change
+  made and the restart; note an out-of-date version.
+
+Re-run preflight after installing plugins or restarting.
+
+## Notes
+
+- This is the shared fail-fast for the suite: `specify-aims` / `create-cycle` need only Check 1;
+  `run-cycle` needs Check 1 **and** Check 2.
+- Detection is intentionally session-based ("can Claude load it?"), not a filesystem scan — an
+  installed-but-disabled plugin correctly reads as unavailable.


### PR DESCRIPTION
Adds a standalone **`preflight`** skill to the task-loop plugin.

It is a **run-once-per-machine** check — deliberately *not* wired into the a→b→c workflow steps (that would re-run it every time):

- **Required-skills check (agent-driven):** verifies each of the 10 skills the task-loop depends on is loadable by checking the session's available-skills list (which reflects installed *and enabled*) — no filesystem scan, and no invoking the skills (which would be side-effectful). Reports needed / installed / missing with install guidance.
- **Agent Teams config:** sets `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json (safe merge) and reminds the user a restart is required; reports the CLI version (>= v2.1.32).

Pure prose, no bundled script. Plugin → 0.5.0, marketplace → 2.3.0. README documents preflight as a standalone and fixes a stale run-cycle status note.
