### PR TITLE
task-loop: drop inline preflight + no-local-files control plane (GitHub-only state, Codex-hardened)

### DIFF
--- a/docs/superpowers/specs/2026-06-13-task-loop-control-plane-conclusion.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-control-plane-conclusion.md
@@ -1,0 +1,107 @@
+# task-loop control plane — "three jobs, no local files": Codex deliberation conclusion
+
+**Date:** 2026-06-13 · **Outcome:** converged after 4 rounds (Codex: `NO FURTHER OBJECTIONS`).
+
+Pressure-test of PR #120's redesign: move all orchestrator runtime state off local disk into
+the GitHub control issue, and run the control plane as a small set of cooperating jobs. The
+deliberation hardened the design and corrected several over-claims.
+
+## Settled position
+
+**State (no local runtime files).**
+- Control-issue **comments** = the append-only, single-sequencer control-event log; `replay`
+  rebuilds all fast state (`plan_revision`, frontier, scan floors, dedupe) every turn.
+- Control-issue **body** = the single mutable **runtime header** (fenced JSON): `lease`
+  (`owner`/`expires_at`/`heartbeat`), `stop_at`, `watchdog_schedule_id`, `stop_schedule_id`,
+  advisory `phase`. The orchestrator is its **sole writer**; sibling jobs only read it.
+- Fast state is **never** persisted to disk — always reconstructed from GitHub. This is what
+  makes recovery clean: any session running `/run-cycle` rebuilds 100% from GitHub.
+
+**Execution model (one model, chosen).**
+- **Loop 1 = a live `/loop` Agent-Teams lead session** — NOT a scheduler job.
+- Teammate **idle notifications are a within-session latency optimization, not part of the
+  correctness model.** Correctness rests entirely on GitHub replay + idempotent respawn.
+- A watchdog "resubmit" launches a **fresh** `/run-cycle` session (new lead, new team) that
+  enters recovery; it does not inherit the dead lead's teammates (teammates die with the lead's
+  session).
+
+**Lease safety (required guards, not asserted outcomes).**
+- Before **any** side effect (emit a control event, merge, write the body): write the lease
+  epoch to the body, **re-read**, confirm ownership; and immediately before posting `seq=N+1`,
+  **re-read the comment log and confirm the true max seq is still N** (check-then-append). On
+  mismatch a competing sequencer is detected → re-ingest; if it persists, the non-owner **exits**.
+- If `replay` ever raises on a dup/gap seq → **halt and escalate to a human**, never continue.
+- GitHub gives no atomic CAS, so a vanishingly-small TOCTOU window remains between re-read and
+  append. Accepted because (a) the watchdog only acts when the heartbeat is already stale, so
+  concurrent orchestrators are rare by construction, and (b) the residual corruption is
+  detectable + halting, not silent. Structural alternative (if ever needed): make GitHub the
+  sequencer by deriving order from server `createdAt`/node-id instead of a self-assigned seq.
+
+**Recovery semantics (Option 1 — disposable pre-PR work).** The dividing line is *"is there a
+GitHub-visible artifact?"*:
+- A dispatched/`in_progress` task with **no remote branch and no PR** is treated as
+  not-yet-started → **abandon and re-dispatch a fresh attempt** (new `attempt_id`) from clean
+  `master`. At most one in-flight task's un-pushed local WIP is lost and simply redone — zero
+  correctness loss.
+- A task **with** a GitHub-visible artifact (remote branch / PR, recorded as `attempt_id` +
+  head SHA in the `RECOVERY` ledger) is **adopted** via GitHub and driven to merge.
+- Local-worktree adoption is **only a same-machine optimization**, never a correctness
+  requirement. Deterministic per-task branch naming + `attempt_id` make re-dispatch and adoption
+  idempotent (a second worker finds the branch/PR and adopts/aborts — never opens a 2nd PR).
+
+**Watchdog — two tiers (do not over-claim auto-resurrection).**
+- **Tier 0 (guaranteed floor): detect + alert.** A scheduled job reads the body heartbeat; if
+  stale **and** `now < stop_at`, it posts a **plain non-control comment** (no `task-loop-event`
+  fence, no seq — invisible to the sequencer) + a push notification "orchestrator down, resume
+  needed." Needs gh **read** for liveness and gh **write** only for the alert. Works from
+  anywhere. Manual `/run-cycle` is a clean resume (thanks to no-local-files).
+- **Tier 1 (optional, explicitly configured + tested): unattended auto-relaunch.** Requires a
+  named **local supervisor** (OS launchd/cron, or a verified locally-running scheduled job) with
+  a tested command template: `cwd`=repo, env incl. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`,
+  plugin loaded, `gh` authenticated, entry launches `/run-cycle` under `/loop`, log capture.
+  This is **setup/config, not runtime state** (it does not reintroduce runtime local files), but
+  it is a real precondition that must be installed and validated by the Phase-0 spike before any
+  claim of unattended resurrection.
+- The `now < stop_at` guard ensures neither tier resurrects the run after an intentional stop.
+- **Loop 2 = scheduled one-time stop** at `stop_at`: reads `watchdog_schedule_id` from the body,
+  cancels the watchdog, confirms loop 1 has drained.
+
+**Precondition surfaced:** the watchdog/stop jobs and any auto-relaunch must run in the **same
+local environment** where Agent Teams is enabled — a cloud-only routine cannot spawn local
+teammates.
+
+## Strongest objections & how each resolved
+
+1. **Execution-model contradiction** (loop 1 = scheduler job *and* live `/loop` lead). Resolved
+   by choosing one model: loop 1 is the live `/loop` lead; idle-notify demoted to a within-session
+   optimization; correctness = GitHub replay + respawn.
+2. **No durable worker identity → double-spawn.** Resolved with deterministic branch naming +
+   `attempt_id` + GitHub-visible-artifact adoption; teammates die with the lead so a restart has
+   no surviving workers.
+3. **Soft lease poisons the seq log.** Resolved by *requiring* a write-then-re-read fence +
+   check-then-append guard + halt-on-corruption (vs. asserting the loser exits).
+4. **Missing launcher contract** (a dead `/loop` can't relaunch itself; `ScheduleWakeup` dies
+   with it; cloud can't spawn local teammates). Resolved with the Tier-0/Tier-1 split — detect+alert
+   floor + explicit tested local-supervisor for auto-relaunch.
+5. **"Resume 100% from GitHub" is false for pre-PR local WIP.** Resolved with Option 1
+   (disposable pre-PR work; GitHub-visible = adoptable, local-only = disposable).
+
+## Unresolved tensions
+
+None blocking. One **accepted residual**: the lease's non-CAS TOCTOU window (bounded + detectable
++ halting, per above); the server-order-sequencer rewrite is the escape hatch if it ever proves
+insufficient in practice — to be confirmed by the Phase-0 spike.
+
+## Follow-up edits to land in PR #120
+
+- run-cycle SKILL.md: stop calling all three "scheduler jobs"; loop 1 = `/loop` lead, loops 2/3 =
+  scheduler guard jobs; watchdog = Tier-0 detect+alert floor, Tier-1 = tested launcher contract;
+  add the local-environment precondition.
+- orchestrator-loop.md: idle-notify = optimization; lease write-then-reread + check-then-append +
+  halt-on-corruption; recovery Option 1 (disposable pre-PR WIP, GitHub-visible adoption,
+  `attempt_id`, deterministic branch).
+- create-cycle skeleton: RECOVERY semantics — pre-PR WIP disposable; deterministic branch +
+  `attempt_id`.
+- preflight: optional Tier-1 local-supervisor check; phase-0 spike validates the launcher contract.
+
+How it ended: **converged after 4 rounds** — Codex issued `NO FURTHER OBJECTIONS`.

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -92,8 +92,8 @@ Created in the **target project** (not the plugin):
 | `docs/task-loop/directions.md` | durable (git) | human | steering channel, read first each planning round |
 | `docs/task-loop/logs/NNN_<task>_rubric.md` | durable (git) | worker | binary acceptance criteria (orchestrator↔worker "done" interface) |
 | `docs/task-loop/logs/NNN_<task>_log.md` | durable (git) | worker | decision record: task, steering, codex dispositions, rubric evidence, follow-ups |
-| GitHub issues — **append-only control events** | durable (remote) | worker + orchestrator | **authoritative cross-agent coordination log** (see §8) |
-| `.claude/task-loop/orchestrator-state.json` | runtime (gitignored) | **orchestrator only** | private fast cache (lease/heartbeat, `plan_revision`, ready/active/blocked, **`stop_at`**, schedule handles); rebuilt from GitHub on resume |
+| GitHub control issue — **comments** (append-only control events) | durable (remote) | worker + orchestrator | **authoritative cross-agent coordination log** (see §8) |
+| GitHub control issue — **body runtime header** | durable (remote) | **orchestrator only** (sole writer) | the single mutable runtime cell: `lease`/`heartbeat`, **`stop_at`**, `watchdog_schedule_id`, `stop_schedule_id`, advisory `phase`. **No local files** — `plan_revision`/ready/active/blocked are rebuilt from the comment log on every turn |
 
 > Note: the playbook lives at `docs/task-loop/task-loop.md` (grouped layout). The slight
 > name echo is intentional — the dir is the namespace, the file is the playbook.
@@ -137,8 +137,8 @@ a generic skeleton + project specifics, and scaffold the rest.
 3. Render `task-loop.md` = the **generic cycle skeleton** (§6) + a project-specifics
    section (north-star, referenced docs, contracts, test conventions, branch/hook rules).
 4. Scaffold `docs/task-loop/directions.md`, `docs/task-loop/logs/`, ensure `.gitignore`
-   covers `.claude/task-loop/` runtime state + `/goal` scratch, and create the
-   `loop:in-progress` GitHub label.
+   covers `/goal` scratch (the loop keeps **no** local runtime state — it lives in the GitHub
+   control issue), and create the `loop:in-progress` GitHub label.
 5. Commit via branch + PR.
 
 ## 6. The generic cycle skeleton (what every `task-loop.md` inherits)
@@ -185,15 +185,16 @@ resumable state; `step-workflow` numbered file naming.
 
 Human entry point. Starts the orchestrator under **built-in `/loop` self-paced** (per the
 loop-mechanism conclusion — **not** ralph, **not** a blocking Stop hook), creates the
-Agent Team, and runs the state machine. It runs as **three coordinated loops** (see the
-run-cycle skill's *Control plane*): the running loop (1) self-bounds on a prompted `stop_at`
-(default 24 h); a built-in-`schedule` **watchdog** (3, every 30 min) resubmits loop 1 if it dies
-before `stop_at`; a built-in-`schedule` one-time **stop** (2) at `stop_at` cancels the watchdog
-and confirms loop 1 has drained.
+Agent Team, and runs the state machine. It runs as **three built-in scheduler jobs — no local
+files** (see the run-cycle skill's *Control plane*): the running loop (1) self-bounds on a prompted
+`stop_at` (default 24 h); a **watchdog** (3, every 30 min) resubmits loop 1 if it dies before
+`stop_at`; a one-time **stop** (2) at `stop_at` cancels the watchdog and confirms loop 1 has
+drained. All three coordinate purely through the GitHub control issue.
 
 ### State machine (each `/loop` turn)
-- **acquire/heartbeat lease** in `orchestrator-state.json`; on resume detect a stale lease
-  and rebuild fast state from the GitHub append-only log.
+- **acquire/heartbeat lease** in the **control-issue body runtime header** (sole writer: the
+  orchestrator); on resume detect a stale lease and rebuild fast state from the GitHub append-only
+  comment log.
 - **check `stop_at` first** → if the clock has reached it, go to `draining`.
 - `dispatching` — read `directions.md` + repo + GitHub; run the **replan barrier** (§8);
   `TaskCreate` ready tasks with dependency edges; spawn **one `cycle-worker` per ready
@@ -287,7 +288,7 @@ assign sequence numbers (GitHub gives comment IDs, not a project-wide ordered st
   `depends_on_hypotheses`; if blast radius is unclear → **broad freeze**.
   (`proposal.md`'s frontmatter records the last roadmap revision *committed to git* — the
   durable narrative, which may lag; the **authoritative live `current_plan_revision`** is
-  the GitHub control-event log, cached in `orchestrator-state.json`.)
+  derived by replaying the GitHub control-event log — it is **not** persisted locally.)
 - **Replan barrier** (before dispatch): ingest findings, bump `plan_revision` on
   invalidation, recompute frontier, halt stale dependent dispatch.
 - **Revision materialization** (no revision without a materialized plan): a
@@ -324,10 +325,11 @@ Subagent definition referenced by `agentType` when the orchestrator spawns a tea
 ## 11. Durable state & recovery
 A fresh agent on clean `master` recovers from: git `master`, the GitHub append-only
 control-event log + per-task `RECOVERY`, open PRs, and `docs/task-loop/logs/`. The
-orchestrator rebuilds `orchestrator-state.json` (incl. `current_plan_revision` and the
-ready/active/blocked sets) from the GitHub log. Ephemeral Agent-Teams state (teammates,
-`~/.claude/tasks/`) is **not** relied upon — the orchestrator respawns workers for
-still-open tasks. The planning step is idempotent.
+orchestrator rebuilds its fast state (incl. `current_plan_revision` and the
+ready/active/blocked sets) **in memory** by replaying the GitHub control-event log — there is no
+local state file to restore, only the control-issue body header (lease + `stop_at` + schedule
+handles). Ephemeral Agent-Teams state (teammates, `~/.claude/tasks/`) is **not** relied upon — the
+orchestrator respawns workers for still-open tasks. The planning step is idempotent.
 
 **Per-task recovery (the `RECOVERY` ledger).** A worker's progress through irreversible actions
 is a state machine recorded in its **task-issue body** (`gh issue edit`, last-write-wins):

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -185,11 +185,13 @@ resumable state; `step-workflow` numbered file naming.
 
 Human entry point. Starts the orchestrator under **built-in `/loop` self-paced** (per the
 loop-mechanism conclusion — **not** ralph, **not** a blocking Stop hook), creates the
-Agent Team, and runs the state machine. It runs as **three built-in scheduler jobs — no local
-files** (see the run-cycle skill's *Control plane*): the running loop (1) self-bounds on a prompted
-`stop_at` (default 24 h); a **watchdog** (3, every 30 min) resubmits loop 1 if it dies before
-`stop_at`; a one-time **stop** (2) at `stop_at` cancels the watchdog and confirms loop 1 has
-drained. All three coordinate purely through the GitHub control issue.
+Agent Team, and runs the state machine. It runs as **a live `/loop` lead plus two scheduler guard
+jobs — no local files** (see the run-cycle skill's *Control plane*): loop 1 is a live `/loop`
+Agent-Teams lead that self-bounds on a prompted `stop_at` (default 24 h); a **watchdog** (3, every
+30 min) **detects** the lead's death and **alerts** (Tier 0, a plain non-control comment + push
+notification), with unattended auto-relaunch (Tier 1) gated on a tested local supervisor; a one-time
+**stop** (2) at `stop_at` cancels the watchdog and confirms loop 1 has drained. All three coordinate
+purely through the GitHub control issue.
 
 ### State machine (each `/loop` turn)
 - **acquire/heartbeat lease** in the **control-issue body runtime header** (sole writer: the

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -93,8 +93,7 @@ Created in the **target project** (not the plugin):
 | `docs/task-loop/logs/NNN_<task>_rubric.md` | durable (git) | worker | binary acceptance criteria (orchestrator↔worker "done" interface) |
 | `docs/task-loop/logs/NNN_<task>_log.md` | durable (git) | worker | decision record: task, steering, codex dispositions, rubric evidence, follow-ups |
 | GitHub issues — **append-only control events** | durable (remote) | worker + orchestrator | **authoritative cross-agent coordination log** (see §8) |
-| `.claude/task-loop/orchestrator-state.json` | runtime (gitignored) | **orchestrator only** | private fast cache (lease, `plan_revision`, ready/active/blocked); rebuilt from GitHub on resume |
-| `.claude/task-loop/stop-request.json` | runtime (gitignored) | scheduled stop job only | atomic stop signal (temp-file + rename) |
+| `.claude/task-loop/orchestrator-state.json` | runtime (gitignored) | **orchestrator only** | private fast cache (lease/heartbeat, `plan_revision`, ready/active/blocked, **`stop_at`**, schedule handles); rebuilt from GitHub on resume |
 
 > Note: the playbook lives at `docs/task-loop/task-loop.md` (grouped layout). The slight
 > name echo is intentional — the dir is the namespace, the file is the playbook.
@@ -186,13 +185,16 @@ resumable state; `step-workflow` numbered file naming.
 
 Human entry point. Starts the orchestrator under **built-in `/loop` self-paced** (per the
 loop-mechanism conclusion — **not** ralph, **not** a blocking Stop hook), creates the
-Agent Team, and runs the state machine. A small `schedule`/`CronCreate` helper
-(documented here) sets the stop time by writing `stop-request.json` atomically.
+Agent Team, and runs the state machine. It runs as **three coordinated loops** (see the
+run-cycle skill's *Control plane*): the running loop (1) self-bounds on a prompted `stop_at`
+(default 24 h); a built-in-`schedule` **watchdog** (3, every 30 min) resubmits loop 1 if it dies
+before `stop_at`; a built-in-`schedule` one-time **stop** (2) at `stop_at` cancels the watchdog
+and confirms loop 1 has drained.
 
 ### State machine (each `/loop` turn)
 - **acquire/heartbeat lease** in `orchestrator-state.json`; on resume detect a stale lease
   and rebuild fast state from the GitHub append-only log.
-- **check `stop-request.json` first** → if set, go to `draining`.
+- **check `stop_at` first** → if the clock has reached it, go to `draining`.
 - `dispatching` — read `directions.md` + repo + GitHub; run the **replan barrier** (§8);
   `TaskCreate` ready tasks with dependency edges; spawn **one `cycle-worker` per ready
   task** (capped to frontier width).

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.5.1"
+  "version": "0.6.0"
 }

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -34,10 +34,10 @@ c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-si
    label.
 3. **`run-cycle`** — the orchestrator: each turn it computes the dependency-ordered task frontier,
    spawns one `cycle-worker` teammate per ready task, and validates + merges their PRs. It runs as
-   **three built-in scheduler jobs (no local files)** — the running loop, a watchdog that resubmits
-   it if it dies, and a one-time stop — coordinating purely through the GitHub control issue, and it
-   **prompts for a run duration (default 24h)**, self-bounding on that stop time (a graceful drain,
-   not an iteration cap).
+   a **live `/loop` lead plus two scheduler guard jobs (no local files)** — a watchdog that detects
+   the lead's death and alerts (unattended auto-relaunch needs a tested local supervisor) and a
+   one-time stop — coordinating purely through the GitHub control issue, and it **prompts for a run
+   duration (default 24h)**, self-bounding on that stop time (a graceful drain, not an iteration cap).
 
 ## Prerequisites
 

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -33,8 +33,9 @@ c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-si
    `directions.md` (steering), the logs directory, `.gitignore`, and the `loop:in-progress`
    label.
 3. **`run-cycle`** — the orchestrator: under built-in `/loop` (self-paced), it computes the
-   dependency-ordered task frontier, spawns one `cycle-worker` teammate per ready task,
-   validates + merges their PRs, and stops on a scheduled drain-signal (not an iteration cap).
+   dependency-ordered task frontier, spawns one `cycle-worker` teammate per ready task, and
+   validates + merges their PRs. It **prompts for a run duration (default 24h)** and schedules a
+   graceful stop via the built-in `schedule` skill (a drain-signal, not an iteration cap).
 
 ## Prerequisites
 

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -34,8 +34,9 @@ c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-si
    label.
 3. **`run-cycle`** — the orchestrator: under built-in `/loop` (self-paced), it computes the
    dependency-ordered task frontier, spawns one `cycle-worker` teammate per ready task, and
-   validates + merges their PRs. It **prompts for a run duration (default 24h)** and schedules a
-   graceful stop via the built-in `schedule` skill (a drain-signal, not an iteration cap).
+   validates + merges their PRs. It runs as **three coordinated loops** — the running loop, a
+   watchdog that resubmits it if it dies, and a one-time stop — and **prompts for a run duration
+   (default 24h)**, self-bounding on that stop time (a graceful drain, not an iteration cap).
 
 ## Prerequisites
 

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -32,11 +32,12 @@ c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-si
    generic cycle skeleton plus auto-detected/interviewed project specifics, and scaffold
    `directions.md` (steering), the logs directory, `.gitignore`, and the `loop:in-progress`
    label.
-3. **`run-cycle`** — the orchestrator: under built-in `/loop` (self-paced), it computes the
-   dependency-ordered task frontier, spawns one `cycle-worker` teammate per ready task, and
-   validates + merges their PRs. It runs as **three coordinated loops** — the running loop, a
-   watchdog that resubmits it if it dies, and a one-time stop — and **prompts for a run duration
-   (default 24h)**, self-bounding on that stop time (a graceful drain, not an iteration cap).
+3. **`run-cycle`** — the orchestrator: each turn it computes the dependency-ordered task frontier,
+   spawns one `cycle-worker` teammate per ready task, and validates + merges their PRs. It runs as
+   **three built-in scheduler jobs (no local files)** — the running loop, a watchdog that resubmits
+   it if it dies, and a one-time stop — coordinating purely through the GitHub control issue, and it
+   **prompts for a run duration (default 24h)**, self-bounding on that stop time (a graceful drain,
+   not an iteration cap).
 
 ## Prerequisites
 
@@ -72,8 +73,8 @@ The **`preflight`** skill sets this for you (and reminds you to restart). The `s
 | `docs/task-loop/task-loop.md` | `create-cycle` | the per-task playbook each worker follows |
 | `docs/task-loop/directions.md` | you | human steering channel (read first each round) |
 | `docs/task-loop/logs/NNN_<task>_{rubric,log}.md` | worker | binary acceptance + decision/evidence trail |
-| GitHub control issue + per-task issues | orchestrator + workers | append-only control-event log |
-| `.claude/task-loop/*.json` *(gitignored)* | orchestrator / stop job | runtime lease + stop signal |
+| GitHub control issue (comments) + per-task issues | orchestrator + workers | append-only control-event log |
+| GitHub control issue (body runtime header) | orchestrator (sole writer) | lease/heartbeat, `stop_at`, schedule handles — **no local files** |
 
 ## Components
 

--- a/task-loop/skills/create-cycle/SKILL.md
+++ b/task-loop/skills/create-cycle/SKILL.md
@@ -79,7 +79,7 @@ proposal).
 ### 5. Scaffold the rest
 - Copy `assets/directions-template.md` to `docs/task-loop/directions.md`.
 - Create `docs/task-loop/logs/.gitkeep`.
-- Add `.gitignore` entries: `.claude/task-loop/` (runtime lease + stop-request) and any
+- Add `.gitignore` entries: `.claude/task-loop/` (runtime lease + orchestrator state) and any
   `goal-rubric-*.md` scratch.
 - Create the label: `gh label create loop:in-progress` (ignore "already exists").
 

--- a/task-loop/skills/create-cycle/SKILL.md
+++ b/task-loop/skills/create-cycle/SKILL.md
@@ -38,14 +38,6 @@ and (b) render them into the skeleton, then scaffold the rest.
 
 ## Process
 
-### 0. Preflight: verify prerequisites
-Confirm the required prerequisite plugins are available before rendering, and **fail fast**
-with install guidance if not: `dev-skills` (`discuss-with-codex`, `goal-rubric`, `doc-update`,
-`step-workflow`) and `superpowers` (`brainstorming`, `writing-plans`,
-`test-driven-development`, `verification-before-completion`, `using-git-worktrees`,
-`finishing-a-development-branch`) — the rendered playbook depends on all of them. Also confirm
-`docs/task-loop/proposal.md` exists (else direct the user to `specify-aims` first).
-
 ### 1. Read the proposal
 Read `docs/task-loop/proposal.md`. The Charter's Aim + Success criteria become the
 **north star**; the Roadmap stages + hypotheses inform what tasks will look like. If the

--- a/task-loop/skills/create-cycle/SKILL.md
+++ b/task-loop/skills/create-cycle/SKILL.md
@@ -33,7 +33,8 @@ and (b) render them into the skeleton, then scaffold the rest.
 - `docs/task-loop/directions.md` — the human steering file (from
   `assets/directions-template.md`).
 - `docs/task-loop/logs/` — the per-task decision-record directory (with a `.gitkeep`).
-- `.gitignore` entries for runtime state (`.claude/task-loop/`) and `goal-rubric-*.md` scratch.
+- `.gitignore` entry for `goal-rubric-*.md` scratch (the loop keeps **no** local runtime state — all
+  of it lives in the GitHub control issue).
 - The `loop:in-progress` GitHub label (`gh label create loop:in-progress`).
 
 ## Process
@@ -79,8 +80,9 @@ proposal).
 ### 5. Scaffold the rest
 - Copy `assets/directions-template.md` to `docs/task-loop/directions.md`.
 - Create `docs/task-loop/logs/.gitkeep`.
-- Add `.gitignore` entries: `.claude/task-loop/` (runtime lease + orchestrator state) and any
-  `goal-rubric-*.md` scratch.
+- Add a `.gitignore` entry for any `goal-rubric-*.md` scratch. The loop keeps **no** local runtime
+  files (no lease file, no orchestrator state) — the lease/heartbeat, `stop_at`, and schedule
+  handles all live in the GitHub control-issue body; the event log lives in its comments.
 - Create the label: `gh label create loop:in-progress` (ignore "already exists").
 
 ### 6. Commit on a branch + PR

--- a/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
+++ b/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
@@ -41,11 +41,14 @@ orchestrator (`run-cycle`) is the sole integrator and the sole editor of
 ## The cycle
 
 ### 1. Recover & anchor
-Read this task issue's **`RECOVERY` block** (see *RECOVERY ledger* below) and **resume by its
-`status`** if an attempt was interrupted, or explicitly abandon it (delete the branch, note the
-reason) before starting fresh. Read `docs/task-loop/directions.md` first (human steering,
-highest priority). Re-read the source-of-truth docs at the **current `plan_revision`** (the
-value in `docs/task-loop/proposal.md` frontmatter on `master`).
+Read this task issue's **`RECOVERY` block** (see *RECOVERY ledger* below) and resume by the
+**GitHub-visible-artifact rule**: if a **remote branch and/or PR exists** (the ledger carries
+`attempt_id` + `pr_head_sha`), **adopt** it and resume by `status`; if there is **no remote branch
+and no PR**, any prior work was local-only pre-PR WIP and is **disposable** — abandon it (note the
+reason) and start a fresh attempt from clean `master`. Never depend on adopting a local worktree
+from another machine/session. Read `docs/task-loop/directions.md` first (human steering, highest
+priority). Re-read the source-of-truth docs at the **current `plan_revision`** (the value in
+`docs/task-loop/proposal.md` frontmatter on `master`).
 
 ### 2. Confirm the task
 The orchestrator already chose and scoped this task and passed `task_id`,
@@ -53,12 +56,15 @@ The orchestrator already chose and scoped this task and passed `task_id`,
 against the issue; confirm `spawned_plan_revision` matches the proposal on `master`.
 
 ### 3. Branch into an isolated worktree
-Use `superpowers:using-git-worktrees`. Branch from fresh `master`:
-`git checkout master && git pull && git checkout -b <prefix>-<short-slug>` (prefix from
-{{BRANCH_PREFIXES}}). Open the decision record `docs/task-loop/logs/NNN_<task>_log.md` with
-frontmatter `status: in_progress`, `task`, `issue`, `branch`, `spawned_plan_revision`, and
-write the initial **`RECOVERY` block** to the issue body: `status=in_progress`,
-`resume_from=<step>`, `branch`, `spawned_plan_revision`, `dirty_tree_expected=yes`.
+Use `superpowers:using-git-worktrees`. Branch from fresh `master` using the **deterministic branch
+name the orchestrator passed** (stable per task, so a respawn reuses it rather than forking a
+duplicate): `git checkout master && git pull && git checkout -B <deterministic-branch>` (prefix
+from {{BRANCH_PREFIXES}}). Open the decision record `docs/task-loop/logs/NNN_<task>_log.md` with
+frontmatter `status: in_progress`, `task`, `issue`, `branch`, `attempt_id`, `spawned_plan_revision`,
+and write the initial **`RECOVERY` block** to the issue body: `status=in_progress`,
+`resume_from=<step>`, `branch`, `attempt_id`, `spawned_plan_revision`, `dirty_tree_expected=yes`.
+Local pre-PR WIP is **disposable** (not recoverable off-machine) — durability begins at the first
+push (step 9).
 
 ### 4. Define the rubric (binary)
 Use `dev-skills:goal-rubric` to draft a binary pass/fail rubric (each item a test name, a

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -40,64 +40,69 @@ Before starting, verify and stop with guidance if any fails:
   provenance and **halts** if it ever finds a task-loop PR merged by someone else, rather than
   laundering it as authorized — but settings should prevent that case.)
 
-## Control plane — three coordinated loops
+## Control plane — three built-in loop jobs (no local files)
 
-`run-cycle` runs as **three** cooperating loops, because a running loop cannot reliably police
-its own death:
+`run-cycle` runs as **three cooperating jobs created with the built-in scheduler** — a running
+loop cannot reliably police its own death, so two sibling jobs guard and bound it. **No local
+files**: all coordination state lives in GitHub (the single control issue), and the schedule
+handles live in the scheduler itself, recorded in the control-issue body.
 
-1. **Running loop (loop 1)** — *this* session under built-in `/loop` self-paced: it drives the
-   orchestrator turn (plan → dispatch → merge), **heartbeats its lease every turn**, and
-   self-bounds on `stop_at`.
-2. **Stop loop (loop 2)** — a **one-time** scheduled job (built-in `schedule`) at `stop_at`. It
-   **cancels the watchdog (loop 3) first** (so it can't resurrect the run after an intentional
-   stop), then confirms loop 1 is draining. The clean teardown.
-3. **Watchdog loop (loop 3)** — a **recurring** scheduled job (built-in `schedule`) **every
-   30 minutes**: if loop 1's lease `heartbeat` is stale (it crashed/exited) **and
-   `now < stop_at`**, it **resubmits loop 1** (re-invokes `run-cycle`, which resumes from durable
-   state). The `now < stop_at` guard is a second safety so it never resurrects after the stop.
+1. **Running loop (loop 1)** — the orchestrator job: each turn it **heartbeats its lease into the
+   control-issue body**, replays the control-issue comment log to rebuild fast state, plans →
+   dispatches → merges, and **self-bounds on `stop_at`**. It loops (re-wakes) until `stop_at`.
+2. **Watchdog loop (loop 3)** — a **recurring** built-in job **every 30 min**: it reads the
+   control-issue body; if loop 1's `heartbeat` is stale (it crashed/exited) **and `now < stop_at`**,
+   it **resubmits loop 1** (which resumes from GitHub). The `now < stop_at` guard ensures it never
+   resurrects the run after an intentional stop.
+3. **Stop loop (loop 2)** — a **one-time** built-in job at `stop_at`: it reads the control-issue
+   body for `watchdog_schedule_id`, **cancels the watchdog (loop 3) first** (so it can't resurrect
+   the run), then confirms loop 1 has drained. The clean teardown of loops 1 **and** 3.
 
 So loop 3 keeps loop 1 alive through crashes; loop 2 tears down loops 1 **and** 3 at `stop_at`.
-Loops 2 & 3 are created via the built-in `schedule`; their handles live in
-`orchestrator-state.json` (`stop_schedule_id`, `watchdog_schedule_id`) so loop 2 can cancel
-loop 3.
+All three are built-in scheduler jobs; their handles (`watchdog_schedule_id`, `stop_schedule_id`)
+are recorded in the **control-issue body runtime header** (the orchestrator is its sole writer) so
+loop 2 can cancel loop 3 — **no `orchestrator-state.json`, no flag file, nothing on local disk.**
 
 ## Setup
 
 `run-cycle` is invoked two ways — a **fresh start** (you) or a **resubmit** (loop 3, after a
-crash). Detect which **first**:
+crash). Detect which **first**, and keep **all** state in GitHub — no local files:
 
-0. **Fresh vs resubmit:** read `orchestrator-state.json`. If it already holds a valid `stop_at`
-   **and** schedule handles, this is a **resubmit/resume** — **skip the duration prompt and the
-   schedule creation** (steps 5–7); the loops already exist. Otherwise it is a **fresh start**.
-1. **Control issue:** find the project's single pinned control issue (labelled
-   `task-loop:control`), or create it if absent (`gh issue create`, then pin + label). Its body
-   names the project; all sequenced `CONTROL_EVENT` comments live here.
-2. **Runtime dir:** ensure `.claude/task-loop/` exists (gitignored) for `orchestrator-state.json`.
-3. **Lease:** acquire the single-coordinator lease in `orchestrator-state.json`; if a live lease
-   is held by another instance, exit (do not run two orchestrators).
-4. **Team:** create the agent team you will spawn `cycle-worker` teammates into (recreated on a
+0. **Control issue:** find the project's single pinned control issue (labelled
+   `task-loop:control`), or create it if absent (`gh issue create`, then pin + label). Its
+   **comments** are the append-only, sequenced `CONTROL_EVENT` log; its **body** is the mutable
+   **runtime header** — a fenced ` ```task-loop-runtime ` JSON block holding `lease`, `stop_at`,
+   `watchdog_schedule_id`, `stop_schedule_id`, and an advisory `phase`. The orchestrator (loop 1)
+   is the header's **sole writer**; loops 2 & 3 only read it.
+1. **Fresh vs resubmit:** read the body header. If it already holds a valid `stop_at` **and** both
+   schedule handles, this is a **resubmit/resume** — **skip the duration prompt and schedule
+   creation** (steps 4–6); the loops already exist. Otherwise it is a **fresh start**.
+2. **Lease:** read the header `lease`. If a **live** lease (`expires_at` in the future) is owned by
+   a different instance → **exit** (never two orchestrators). Else write the header with your
+   `lease` (`owner`, `expires_at = now + TTL`, `heartbeat = now`). This is the only single-
+   coordinator guard — no local lock file.
+3. **Team:** create the agent team you spawn `cycle-worker` teammates into (recreated on a
    resubmit, since teammates are ephemeral).
-5. *(fresh only)* **Run duration (prompt for it).** **Ask the user** how long it should run —
-   *"How long should the loop run before a graceful stop? (default: 24 hours)"* — accepting a
-   duration or an absolute time, **default 24 hours**. This is an **interactive prompt, not a
-   command-line argument**. Record the absolute `stop_at` (UTC) in `orchestrator-state.json`.
-6. *(fresh only)* **Create the watchdog (loop 3)** with the built-in `schedule`: a recurring job
-   **every 30 min** that resubmits `run-cycle` when loop 1's lease `heartbeat` is stale and
-   `now < stop_at`. Store its handle as `watchdog_schedule_id`.
-7. *(fresh only)* **Create the stop (loop 2)** with the built-in `schedule`: a one-time job at
-   `stop_at` that **cancels `watchdog_schedule_id`** then confirms loop 1 has drained. Store its
-   handle as `stop_schedule_id`.
-8. **Start `/loop` self-paced** (loop 1) and run the orchestrator turn (below / `references/`).
-   It self-bounds: each turn it compares the clock to `stop_at` and caps its `ScheduleWakeup` so
-   it wakes by `stop_at` to drain — so the run stops even if loop 2 fails. (To run longer or stop
-   sooner, edit `stop_at`.)
+4. *(fresh only)* **Run duration (prompt for it).** **Ask the user** *"How long should the loop run
+   before a graceful stop? (default: 24 hours)"* — accept a duration or an absolute time, **default
+   24 hours**. An **interactive prompt, not a command-line argument**. Write the absolute `stop_at`
+   (UTC) into the body header.
+5. *(fresh only)* **Create the watchdog (loop 3)** with the built-in scheduler: a recurring job
+   **every 30 min** that resubmits `run-cycle` when the header `heartbeat` is stale and
+   `now < stop_at`. Write its handle into the header as `watchdog_schedule_id`.
+6. *(fresh only)* **Create the stop (loop 2)** with the built-in scheduler: a one-time job at
+   `stop_at` that reads `watchdog_schedule_id` from the header, **cancels it**, then confirms loop 1
+   has drained. Write its handle into the header as `stop_schedule_id`.
+7. **Run the orchestrator turn (loop 1)** (below / `references/`). It self-bounds: each turn it
+   compares the clock to `stop_at` and caps its next wake so it wakes by `stop_at` to drain — so the
+   run stops even if loop 2 fails. (To run longer or stop sooner, edit `stop_at` in the header.)
 
 ## The orchestrator turn (high level)
 
 Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
 1. **Lease & rebuild:** refresh the lease; rebuild fast state by replaying the control issue
    (`control_log.replay`). On resume, take over a stale lease and rebuild from GitHub.
-2. **Stop check:** if the clock has reached `stop_at` (from `orchestrator-state.json`) → enter
+2. **Stop check:** if the clock has reached `stop_at` (from the control-issue body header) → enter
    `draining`.
 3. **Event-drain & ingest:** read each task issue's comments at/after its scan floor, dedupe by
    UUID, **process findings before merge requests**. Ack a fresh `PLAN_FINDING` here (one
@@ -125,8 +130,8 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
 
 - **Sole integrator:** only the orchestrator runs `gh pr merge`. Workers end at
   `MERGE_REQUEST`.
-- **Single writer:** only the orchestrator writes `orchestrator-state.json`, emits sequenced
-  `CONTROL_EVENT`s, bumps `plan_revision`, and edits `docs/task-loop/proposal.md`.
+- **Single writer:** only the orchestrator writes the **control-issue body runtime header**, emits
+  sequenced `CONTROL_EVENT`s, bumps `plan_revision`, and edits `docs/task-loop/proposal.md`.
 - **Merge gates:** every merge passes the **pre-merge event-drain barrier** and is
   **head-SHA-bound** (`--match-head-commit`); no revision becomes current until its
   proposal-update PR is merged to `master` (materialization).
@@ -151,7 +156,7 @@ when set, else the installed `task-loop/scripts/`):
 - Design rationale: `docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md` (§7, §8, §11,
   §12) and the two conclusions (`…-cycle-loop-mechanism-conclusion.md`,
   `…-living-proposal-ownership-conclusion.md`).
-- Run it bounded: it always runs under `/loop` self-paced and is **always** bounded by a
-  graceful stop time — Setup step 5 prompts for a duration (**default 24 hours**) and records an
-  absolute `stop_at`; the orchestrator self-bounds via the built-in `ScheduleWakeup` (no flag
-  file, no external stopper) and drains + exits when it reaches `stop_at`.
+- Run it bounded: it is **always** bounded by a graceful stop time — Setup step 4 prompts for a
+  duration (**default 24 hours**) and records an absolute `stop_at` in the control-issue body
+  header; the orchestrator self-bounds (caps its next wake to `stop_at`) and drains + exits when it
+  reaches `stop_at` — **no local files, no flag file, no external stopper.**

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -40,34 +40,65 @@ Before starting, verify and stop with guidance if any fails:
   provenance and **halts** if it ever finds a task-loop PR merged by someone else, rather than
   laundering it as authorized — but settings should prevent that case.)
 
-## Setup (run once at the start of a run)
+## Control plane — three coordinated loops
 
+`run-cycle` runs as **three** cooperating loops, because a running loop cannot reliably police
+its own death:
+
+1. **Running loop (loop 1)** — *this* session under built-in `/loop` self-paced: it drives the
+   orchestrator turn (plan → dispatch → merge), **heartbeats its lease every turn**, and
+   self-bounds on `stop_at`.
+2. **Stop loop (loop 2)** — a **one-time** scheduled job (built-in `schedule`) at `stop_at`. It
+   **cancels the watchdog (loop 3) first** (so it can't resurrect the run after an intentional
+   stop), then confirms loop 1 is draining. The clean teardown.
+3. **Watchdog loop (loop 3)** — a **recurring** scheduled job (built-in `schedule`) **every
+   30 minutes**: if loop 1's lease `heartbeat` is stale (it crashed/exited) **and
+   `now < stop_at`**, it **resubmits loop 1** (re-invokes `run-cycle`, which resumes from durable
+   state). The `now < stop_at` guard is a second safety so it never resurrects after the stop.
+
+So loop 3 keeps loop 1 alive through crashes; loop 2 tears down loops 1 **and** 3 at `stop_at`.
+Loops 2 & 3 are created via the built-in `schedule`; their handles live in
+`orchestrator-state.json` (`stop_schedule_id`, `watchdog_schedule_id`) so loop 2 can cancel
+loop 3.
+
+## Setup
+
+`run-cycle` is invoked two ways — a **fresh start** (you) or a **resubmit** (loop 3, after a
+crash). Detect which **first**:
+
+0. **Fresh vs resubmit:** read `orchestrator-state.json`. If it already holds a valid `stop_at`
+   **and** schedule handles, this is a **resubmit/resume** — **skip the duration prompt and the
+   schedule creation** (steps 5–7); the loops already exist. Otherwise it is a **fresh start**.
 1. **Control issue:** find the project's single pinned control issue (labelled
    `task-loop:control`), or create it if absent (`gh issue create`, then pin + label). Its body
    names the project; all sequenced `CONTROL_EVENT` comments live here.
-2. **Runtime dir:** ensure `.claude/task-loop/` exists (gitignored) for
-   `orchestrator-state.json` (the lease + fast-state cache) and `stop-request.json`.
+2. **Runtime dir:** ensure `.claude/task-loop/` exists (gitignored) for `orchestrator-state.json`.
 3. **Lease:** acquire the single-coordinator lease in `orchestrator-state.json`; if a live lease
    is held by another instance, exit (do not run two orchestrators).
-4. **Team:** create the agent team you will spawn `cycle-worker` teammates into.
-5. **Schedule the graceful stop (prompt for the duration).** Before starting the loop, **ask the
-   user** how long it should run before winding down — *"How long should the loop run before a
-   graceful stop? (default: 24 hours)"* — accepting a duration or an absolute time, and
-   **default to 24 hours** if they don't specify. This is an **interactive prompt, not a
-   command-line argument**. Then use Claude's built-in **`schedule`** skill to create a
-   **one-time** scheduled run at `now + <duration>` whose task is to **atomically write**
-   `.claude/task-loop/stop-request.json` (temp file + `mv`). Record the scheduled stop time in
-   `orchestrator-state.json`. When the loop observes the flag it **drains** (no new dispatch;
-   in-flight workers finish their current cycle) and exits via the two-phase quiescence — a
-   graceful stop, not a hard kill. (To run longer or stop sooner, re-schedule via `schedule`.)
-6. **Start `/loop` self-paced** and run the orchestrator turn (below / `references/`).
+4. **Team:** create the agent team you will spawn `cycle-worker` teammates into (recreated on a
+   resubmit, since teammates are ephemeral).
+5. *(fresh only)* **Run duration (prompt for it).** **Ask the user** how long it should run —
+   *"How long should the loop run before a graceful stop? (default: 24 hours)"* — accepting a
+   duration or an absolute time, **default 24 hours**. This is an **interactive prompt, not a
+   command-line argument**. Record the absolute `stop_at` (UTC) in `orchestrator-state.json`.
+6. *(fresh only)* **Create the watchdog (loop 3)** with the built-in `schedule`: a recurring job
+   **every 30 min** that resubmits `run-cycle` when loop 1's lease `heartbeat` is stale and
+   `now < stop_at`. Store its handle as `watchdog_schedule_id`.
+7. *(fresh only)* **Create the stop (loop 2)** with the built-in `schedule`: a one-time job at
+   `stop_at` that **cancels `watchdog_schedule_id`** then confirms loop 1 has drained. Store its
+   handle as `stop_schedule_id`.
+8. **Start `/loop` self-paced** (loop 1) and run the orchestrator turn (below / `references/`).
+   It self-bounds: each turn it compares the clock to `stop_at` and caps its `ScheduleWakeup` so
+   it wakes by `stop_at` to drain — so the run stops even if loop 2 fails. (To run longer or stop
+   sooner, edit `stop_at`.)
 
 ## The orchestrator turn (high level)
 
 Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
 1. **Lease & rebuild:** refresh the lease; rebuild fast state by replaying the control issue
    (`control_log.replay`). On resume, take over a stale lease and rebuild from GitHub.
-2. **Stop check:** if `.claude/task-loop/stop-request.json` exists → enter `draining`.
+2. **Stop check:** if the clock has reached `stop_at` (from `orchestrator-state.json`) → enter
+   `draining`.
 3. **Event-drain & ingest:** read each task issue's comments at/after its scan floor, dedupe by
    UUID, **process findings before merge requests**. Ack a fresh `PLAN_FINDING` here (one
    `PLAN_FINDING_RECORDED`); a fresh `MERGE_REQUEST` is **not** acked here — it is collected as a
@@ -121,5 +152,6 @@ when set, else the installed `task-loop/scripts/`):
   §12) and the two conclusions (`…-cycle-loop-mechanism-conclusion.md`,
   `…-living-proposal-ownership-conclusion.md`).
 - Run it bounded: it always runs under `/loop` self-paced and is **always** bounded by a
-  scheduled graceful stop — Setup step 5 prompts for a duration (**default 24 hours**) and uses
-  the built-in `schedule` skill to write `.claude/task-loop/stop-request.json` at that time.
+  graceful stop time — Setup step 5 prompts for a duration (**default 24 hours**) and records an
+  absolute `stop_at`; the orchestrator self-bounds via the built-in `ScheduleWakeup` (no flag
+  file, no external stopper) and drains + exits when it reaches `stop_at`.

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -40,28 +40,42 @@ Before starting, verify and stop with guidance if any fails:
   provenance and **halts** if it ever finds a task-loop PR merged by someone else, rather than
   laundering it as authorized — but settings should prevent that case.)
 
-## Control plane — three built-in loop jobs (no local files)
+## Control plane — one live loop + two guard jobs (no local files)
 
-`run-cycle` runs as **three cooperating jobs created with the built-in scheduler** — a running
-loop cannot reliably police its own death, so two sibling jobs guard and bound it. **No local
-files**: all coordination state lives in GitHub (the single control issue), and the schedule
-handles live in the scheduler itself, recorded in the control-issue body.
+`run-cycle` runs as **three cooperating jobs** — a running loop cannot reliably police its own
+death, so two sibling guard jobs bound and watch it. **No local files**: all coordination state
+lives in GitHub (the single control issue); schedule handles live in the scheduler itself,
+recorded in the control-issue body.
 
-1. **Running loop (loop 1)** — the orchestrator job: each turn it **heartbeats its lease into the
-   control-issue body**, replays the control-issue comment log to rebuild fast state, plans →
-   dispatches → merges, and **self-bounds on `stop_at`**. It loops (re-wakes) until `stop_at`.
-2. **Watchdog loop (loop 3)** — a **recurring** built-in job **every 30 min**: it reads the
-   control-issue body; if loop 1's `heartbeat` is stale (it crashed/exited) **and `now < stop_at`**,
-   it **resubmits loop 1** (which resumes from GitHub). The `now < stop_at` guard ensures it never
-   resurrects the run after an intentional stop.
-3. **Stop loop (loop 2)** — a **one-time** built-in job at `stop_at`: it reads the control-issue
-   body for `watchdog_schedule_id`, **cancels the watchdog (loop 3) first** (so it can't resurrect
-   the run), then confirms loop 1 has drained. The clean teardown of loops 1 **and** 3.
+1. **Running loop (loop 1)** — a **live `/loop` Agent-Teams lead session** (the orchestrator),
+   **not** a scheduler job. Each turn it **heartbeats its lease into the control-issue body**,
+   replays the control-issue comment log to rebuild fast state, plans → dispatches → merges, and
+   **self-bounds on `stop_at`**. Teammate idle notifications are a **within-session latency
+   optimization, not part of correctness** — correctness rests entirely on GitHub replay +
+   idempotent respawn (see `references/`).
+2. **Watchdog (loop 3)** — a **recurring scheduler job every 30 min**. It reads the control-issue
+   body; if loop 1's `heartbeat` is stale **and `now < stop_at`**, loop 1 is presumed dead:
+   - **Tier 0 (always — the guaranteed floor): detect + alert.** Post a **plain non-control
+     comment** (no `task-loop-event` fence — invisible to the sequencer) plus a push notification
+     "orchestrator down, resume needed." Recovery is then a clean **manual `/run-cycle`** (it
+     rebuilds 100% from GitHub — that is the payoff of no-local-files).
+   - **Tier 1 (only if a tested local supervisor is configured): unattended auto-relaunch.** A
+     dead `/loop` session cannot relaunch itself and a cloud routine cannot spawn local Agent-Teams
+     teammates, so true auto-resurrection needs a **named local supervisor** (OS launchd/cron, or
+     a verified locally-running job) with a tested launch template (repo cwd, `CLAUDE_CODE_
+     EXPERIMENTAL_AGENT_TEAMS=1`, plugin loaded, `gh` authed, `/run-cycle` under `/loop`, log
+     capture). That is **setup/config, not runtime state**, but it is a real precondition — the
+     Phase-0 spike must validate it before any unattended-resurrection claim. Absent it, the
+     watchdog stays at Tier 0.
+   The `now < stop_at` guard ensures neither tier resurrects the run after an intentional stop.
+3. **Stop (loop 2)** — a **one-time scheduler job at `stop_at`**. It reads the control-issue body
+   for `watchdog_schedule_id`, **cancels the watchdog (loop 3) first** (so it can't resurrect the
+   run), then confirms loop 1 has drained. The clean teardown of loops 1 **and** 3.
 
-So loop 3 keeps loop 1 alive through crashes; loop 2 tears down loops 1 **and** 3 at `stop_at`.
-All three are built-in scheduler jobs; their handles (`watchdog_schedule_id`, `stop_schedule_id`)
-are recorded in the **control-issue body runtime header** (the orchestrator is its sole writer) so
-loop 2 can cancel loop 3 — **no `orchestrator-state.json`, no flag file, nothing on local disk.**
+The two guard jobs (2 & 3) and any Tier-1 relaunch must run in the **same local environment**
+where Agent Teams is enabled. Their handles (`watchdog_schedule_id`, `stop_schedule_id`) live in
+the **control-issue body runtime header** (orchestrator is its sole writer) so loop 2 can cancel
+loop 3 — **no `orchestrator-state.json`, no flag file, nothing on local disk.**
 
 ## Setup
 
@@ -78,9 +92,10 @@ crash). Detect which **first**, and keep **all** state in GitHub — no local fi
    schedule handles, this is a **resubmit/resume** — **skip the duration prompt and schedule
    creation** (steps 4–6); the loops already exist. Otherwise it is a **fresh start**.
 2. **Lease:** read the header `lease`. If a **live** lease (`expires_at` in the future) is owned by
-   a different instance → **exit** (never two orchestrators). Else write the header with your
-   `lease` (`owner`, `expires_at = now + TTL`, `heartbeat = now`). This is the only single-
-   coordinator guard — no local lock file.
+   a different instance → **exit** (never two orchestrators). Else claim it: write the header with
+   your `lease` (`owner`, `expires_at = now + TTL`, `heartbeat = now`), then **re-read and confirm
+   you still own it** before any side effect (the **write-then-re-read fence** — GitHub has no
+   atomic CAS). This is the only single-coordinator guard — no local lock file.
 3. **Team:** create the agent team you spawn `cycle-worker` teammates into (recreated on a
    resubmit, since teammates are ephemeral).
 4. *(fresh only)* **Run duration (prompt for it).** **Ask the user** *"How long should the loop run
@@ -88,8 +103,10 @@ crash). Detect which **first**, and keep **all** state in GitHub — no local fi
    24 hours**. An **interactive prompt, not a command-line argument**. Write the absolute `stop_at`
    (UTC) into the body header.
 5. *(fresh only)* **Create the watchdog (loop 3)** with the built-in scheduler: a recurring job
-   **every 30 min** that resubmits `run-cycle` when the header `heartbeat` is stale and
-   `now < stop_at`. Write its handle into the header as `watchdog_schedule_id`.
+   **every 30 min** that, when the header `heartbeat` is stale and `now < stop_at`, **detects +
+   alerts** (Tier 0: a plain non-control comment + push notification) and — only if a tested local
+   supervisor is configured — auto-relaunches `run-cycle` (Tier 1). Write its handle into the header
+   as `watchdog_schedule_id`. (See *Control plane* for the Tier-0/Tier-1 launcher contract.)
 6. *(fresh only)* **Create the stop (loop 2)** with the built-in scheduler: a one-time job at
    `stop_at` that reads `watchdog_schedule_id` from the header, **cancels it**, then confirms loop 1
    has drained. Write its handle into the header as `stop_schedule_id`.

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -31,8 +31,6 @@ are in **`references/orchestrator-loop.md`** — read it before driving the loop
 ## Preconditions (fail fast)
 
 Before starting, verify and stop with guidance if any fails:
-- **Agent Teams enabled:** `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and Claude Code ≥ v2.1.32.
-- **Prerequisite plugins** installed: `superpowers` and `dev-skills` (workers need them).
 - **Scaffolding present:** `docs/task-loop/proposal.md`, `docs/task-loop/task-loop.md`,
   `docs/task-loop/directions.md`, and the `loop:in-progress` label exist.
 - **`gh` authenticated** with write access to issues and PRs.

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -50,7 +50,17 @@ Before starting, verify and stop with guidance if any fails:
 3. **Lease:** acquire the single-coordinator lease in `orchestrator-state.json`; if a live lease
    is held by another instance, exit (do not run two orchestrators).
 4. **Team:** create the agent team you will spawn `cycle-worker` teammates into.
-5. **Start `/loop` self-paced** and run the orchestrator turn (below / `references/`).
+5. **Schedule the graceful stop (prompt for the duration).** Before starting the loop, **ask the
+   user** how long it should run before winding down — *"How long should the loop run before a
+   graceful stop? (default: 24 hours)"* — accepting a duration or an absolute time, and
+   **default to 24 hours** if they don't specify. This is an **interactive prompt, not a
+   command-line argument**. Then use Claude's built-in **`schedule`** skill to create a
+   **one-time** scheduled run at `now + <duration>` whose task is to **atomically write**
+   `.claude/task-loop/stop-request.json` (temp file + `mv`). Record the scheduled stop time in
+   `orchestrator-state.json`. When the loop observes the flag it **drains** (no new dispatch;
+   in-flight workers finish their current cycle) and exits via the two-phase quiescence — a
+   graceful stop, not a hard kill. (To run longer or stop sooner, re-schedule via `schedule`.)
+6. **Start `/loop` self-paced** and run the orchestrator turn (below / `references/`).
 
 ## The orchestrator turn (high level)
 
@@ -110,6 +120,6 @@ when set, else the installed `task-loop/scripts/`):
 - Design rationale: `docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md` (§7, §8, §11,
   §12) and the two conclusions (`…-cycle-loop-mechanism-conclusion.md`,
   `…-living-proposal-ownership-conclusion.md`).
-- Run it bounded: drive the orchestrator under `/loop` self-paced; set the stop time with a
-  scheduled writer of `.claude/task-loop/stop-request.json` (see the Phase 0 spike for the
-  available primitive).
+- Run it bounded: it always runs under `/loop` self-paced and is **always** bounded by a
+  scheduled graceful stop — Setup step 5 prompts for a duration (**default 24 hours**) and uses
+  the built-in `schedule` skill to write `.claude/task-loop/stop-request.json` at that time.

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -20,16 +20,15 @@ state = control_log.replay(events)
 #    plan_revision,pr_head_sha}}, seen_source_uuids, source_uuid_to_seq, scan_floor_ts_by_issue
 ```
 
-`orchestrator-state.json` (in `.claude/task-loop/`, gitignored) is a **cache** of this plus the
-lease — never the source of truth. Shape:
+**No local files.** The only mutable runtime cell is the **control-issue body runtime header** — a
+fenced ` ```task-loop-runtime ` JSON block the orchestrator (loop 1) is the **sole writer** of.
+Everything else is the append-only comment log (replayed above) or live session memory; nothing is
+written to local disk. Header shape:
 
 ```json
 {
-  "lease": {"owner": "<id>", "started_at": "<utc>", "expires_at": "<utc>", "heartbeat": "<utc>"},
+  "lease": {"owner": "<id>", "expires_at": "<utc>", "heartbeat": "<utc>"},
   "phase": "dispatching|waiting|idle|draining|exiting_pending|exiting",
-  "current_plan_revision": 0,
-  "active_worker_ids": [],
-  "next_wake_reason": "",
   "stop_at": "<utc>",
   "drain_deadline_at": null,
   "watchdog_schedule_id": null,
@@ -37,10 +36,15 @@ lease — never the source of truth. Shape:
 }
 ```
 
-The lease `heartbeat` is refreshed every turn; the **watchdog** (loop 3) treats a stale
-`heartbeat`/`expires_at` as "the running loop died" and resubmits it. `stop_at` is the
-self-bound graceful-stop time; `watchdog_schedule_id`/`stop_schedule_id` are the built-in
-`schedule` handles for loops 3 and 2 (so they can be cancelled). See *Control plane*.
+`phase`/`current_plan_revision`/`active_worker_ids` are **derived** (rebuilt by `replay` + session
+memory) — the header only persists what a *sibling job* must read: the `lease` heartbeat, `stop_at`,
+and the two schedule handles. The lease `heartbeat` is refreshed every turn (a `gh issue edit` of
+the body); the **watchdog** (loop 3) reads the header and treats a stale `heartbeat`/`expires_at` as
+"the running loop died" and resubmits it. `stop_at` is the self-bound graceful-stop time;
+`watchdog_schedule_id`/`stop_schedule_id` are the built-in scheduler handles for loops 3 and 2 (so
+loop 2 can cancel loop 3). See *Control plane*. Body writes are last-writer-wins, which is safe
+because the lease loser exits — but two near-simultaneous writers are possible, so the lease is a
+**soft** single-coordinator guard, not an atomic CAS.
 
 ## State machine
 
@@ -58,12 +62,12 @@ self-bound graceful-stop time; `watchdog_schedule_id`/`stop_schedule_id` are the
 ## Per-turn algorithm
 
 ### 1. Lease & rebuild
-- Read `orchestrator-state.json`. If a **live** lease (`expires_at` in the future) is owned by a
-  different instance → exit (never two orchestrators). Else acquire/refresh the lease
-  (`owner`, `started_at`, `expires_at = now + TTL`, `heartbeat = now`).
+- Read the **control-issue body header**. If a **live** lease (`expires_at` in the future) is owned
+  by a different instance → exit (never two orchestrators). Else acquire/refresh the lease by
+  writing the header (`owner`, `expires_at = now + TTL`, `heartbeat = now`).
 - On resume / stale lease (`expires_at` past, or `phase: exiting` without a clean prior audit):
-  take over, then **rebuild fast state from the control issue** (above). Do not trust a stale
-  cache.
+  take over, then **rebuild fast state from the control issue** (replay the comment log, above).
+  There is no local cache to distrust — fast state is always reconstructed from GitHub.
 
 ### 2. Stop check
 - If the clock has reached `stop_at` → set `phase: draining`. (The orchestrator self-bounds; it
@@ -156,7 +160,9 @@ pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order
   Anything changed → revert to `dispatching`/`waiting`.
 
 ### 8. Heartbeat
-Refresh the lease `heartbeat`/`expires_at` and persist the `orchestrator-state.json` cache.
+Refresh the lease `heartbeat`/`expires_at` (and advisory `phase`/`stop_at`/schedule handles) by
+writing the **control-issue body header** (`gh issue edit`). This is the only durable write of the
+turn besides the appended `CONTROL_EVENT` comments — there is no local cache to persist.
 
 ## Emitting control events
 

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -64,7 +64,9 @@ because the lease loser exits — but two near-simultaneous writers are possible
 ### 1. Lease & rebuild
 - Read the **control-issue body header**. If a **live** lease (`expires_at` in the future) is owned
   by a different instance → exit (never two orchestrators). Else acquire/refresh the lease by
-  writing the header (`owner`, `expires_at = now + TTL`, `heartbeat = now`).
+  writing the header (`owner`, `expires_at = now + TTL`, `heartbeat = now`), then **re-read the
+  header and confirm you still own it** before any side effect (the **write-then-re-read fence**;
+  GitHub gives no atomic CAS, so this is how a lease loser detects it lost and exits).
 - On resume / stale lease (`expires_at` past, or `phase: exiting` without a clean prior audit):
   take over, then **rebuild fast state from the control issue** (replay the comment log, above).
   There is no local cache to distrust — fast state is always reconstructed from GitHub.
@@ -117,8 +119,10 @@ For each known task issue (every `tasks[*].issue_number`):
   - Emit `TASK_CREATED{task_id, plan_revision, issue_number}` and `TASK_DISPATCHED{task_id,
     plan_revision}`.
   - Spawn **one** `cycle-worker` teammate (`agentType: cycle-worker`) with a prompt carrying
-    `task_id`, `issue=<n>`, `spawned_plan_revision=<current>`, and the task scope. Record its id
-    in `active_worker_ids`.
+    `task_id`, `issue=<n>`, `spawned_plan_revision=<current>`, a fresh `attempt_id`, the
+    **deterministic branch name** (e.g. `<type>-<issue>-<task>`), and the task scope. Record its id
+    in `active_worker_ids`. On a respawn, reuse the deterministic branch so the worker adopts any
+    existing remote branch/PR rather than opening a duplicate (see *Recovery*).
 
 ### 6. Merge (sole integrator, on a pending `MERGE_REQUEST`)
 A `MERGE_REQUEST` is pending (un-acked) from §3. This step is the **only** place it is acked,
@@ -178,6 +182,16 @@ stamped, new_last = control_log.assign_seq([{
 gh_store.post_comment(CONTROL_ISSUE, control_log.format_event(stamped[0]))
 ```
 
+**Check-then-append guard (required).** Immediately before posting, **re-read the comment log and
+confirm its true max `seq` is still `state["last_seq"]`** — only then `assign_seq` + post. If a
+higher `seq` has appeared, a competing sequencer exists: re-ingest, recompute, retry; if it
+persists you have lost the lease → **exit**. Together with the write-then-re-read lease fence (§1),
+this is the single-sequencer guarantee under GitHub's non-CAS body writes — a vanishingly-small
+TOCTOU window between the re-read and the append remains and is accepted (the watchdog only acts on
+an already-stale heartbeat, so two live orchestrators are rare by construction). If `replay` ever
+raises on a seq gap/dup or duplicate `source_uuid`, that is **detectable corruption → halt and
+escalate to a human**, never continue.
+
 Event types — **orchestrator-originated** (no source): `TASK_CREATED` (carries `issue_number`),
 `TASK_DISPATCHED`, `PLAN_REVISION_BUMP` (carries `proposal_sha`), `TASK_STALE`,
 `TASK_REVISION_COMPATIBLE`, `INBOX_SCAN_CHECKPOINT` (carries `issue_number` + `through_ts`).
@@ -195,12 +209,25 @@ acknowledged` (every blocked/stale task has a follow-up), `unmerged == 0` (no op
 
 ## Recovery (cold resume)
 
-A fresh orchestrator on clean `master` rebuilds entirely from: the control issue (replay →
+A fresh orchestrator on clean `master` rebuilds entirely from GitHub: the control issue (replay →
 revision, dedupe set, scan floors, task statuses), per-task `RECOVERY` ledgers (issue bodies),
-open PRs, and `docs/task-loop/logs/`. Ephemeral teammates and `~/.claude/tasks/` are **not**
-relied upon — respawn `cycle-worker`s for still-open tasks. A worker found in `pr_open` /
-`merge_requesting` (via its `RECOVERY`) is *ready but unannounced*: drive it to merge. The
-planning step is idempotent — the same frontier is recomputed and only missing workers respawn.
+open PRs, and `docs/task-loop/logs/`. Ephemeral teammates and `~/.claude/tasks/` are **not** relied
+upon, and because teammates die with the lead's session a crashed loop 1 leaves **no surviving
+workers** — so respawn is safe. Respawn follows **one rule, the GitHub-visible-artifact line:**
+
+- **No remote branch and no PR** for a dispatched task → any work was local-only pre-PR WIP, which
+  is **disposable**: abandon it and **re-dispatch a fresh attempt** (new `attempt_id`) from clean
+  `master`. At most one in-flight task's un-pushed WIP is lost and simply redone — zero correctness
+  loss. This is what makes "resume from any session / clean checkout" honest.
+- **A remote branch and/or PR exists** (recorded as `attempt_id` + head SHA in the `RECOVERY`
+  ledger) → **adopt** it via GitHub and drive it to merge. A worker in `pr_open` /
+  `merge_requesting` is *ready but unannounced*.
+
+Dispatch uses **deterministic per-task branch/worktree naming** + an `attempt_id`, so re-dispatch
+and adoption are idempotent: a respawned worker that finds the branch/PR already present adopts or
+aborts — it never opens a second PR. Local-worktree adoption is **only a same-machine
+optimization**, never a correctness requirement. The planning step is idempotent — the same
+frontier is recomputed and only missing workers respawn.
 
 ## Deliberate with Codex
 

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -30,17 +30,25 @@ lease — never the source of truth. Shape:
   "current_plan_revision": 0,
   "active_worker_ids": [],
   "next_wake_reason": "",
-  "drain_deadline_at": null
+  "stop_at": "<utc>",
+  "drain_deadline_at": null,
+  "watchdog_schedule_id": null,
+  "stop_schedule_id": null
 }
 ```
 
+The lease `heartbeat` is refreshed every turn; the **watchdog** (loop 3) treats a stale
+`heartbeat`/`expires_at` as "the running loop died" and resubmits it. `stop_at` is the
+self-bound graceful-stop time; `watchdog_schedule_id`/`stop_schedule_id` are the built-in
+`schedule` handles for loops 3 and 2 (so they can be cancelled). See *Control plane*.
+
 ## State machine
 
-- **dispatching** — ready work exists, no stop signal → create tasks + spawn workers.
+- **dispatching** — ready work exists, `stop_at` not reached → create tasks + spawn workers.
 - **waiting** — active workers exist → wait on automatic teammate idle notifications.
-- **idle** — no ready work, no active workers, no stop signal → long `ScheduleWakeup` (e.g.
-  1200–1800 s); **do not exit** (continuous service).
-- **draining** — `stop-request.json` observed → no new dispatch; wait for active workers, bounded
+- **idle** — no ready work, no active workers, `stop_at` not reached → long `ScheduleWakeup`
+  (capped so it never sleeps past `stop_at`); **do not exit** (continuous service).
+- **draining** — clock reached `stop_at` → no new dispatch; wait for active workers, bounded
   by `drain_deadline_at`.
 - **exiting_pending** — drain complete → record the pre-exit audit, `ScheduleWakeup` a 60–120 s
   cooldown.
@@ -58,7 +66,8 @@ lease — never the source of truth. Shape:
   cache.
 
 ### 2. Stop check
-- If `.claude/task-loop/stop-request.json` exists → set `phase: draining`.
+- If the clock has reached `stop_at` → set `phase: draining`. (The orchestrator self-bounds; it
+  also caps each `ScheduleWakeup` so it wakes by `stop_at` to drain on time.)
 
 ### 3. Event-drain & ingest (also the pre-merge barrier)
 For each known task issue (every `tasks[*].issue_number`):
@@ -136,7 +145,8 @@ pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order
 ### 7. Wait / idle / exit
 - **Active workers exist** → `waiting`: rely on automatic idle notifications; set a long
   `ScheduleWakeup` fallback. Drop `active_worker_ids` entries as workers report and are merged.
-- **Frontier empty, none active, no stop signal** → `idle`: long `ScheduleWakeup`; **do not exit**.
+- **Frontier empty, none active, `stop_at` not reached** → `idle`: long `ScheduleWakeup` (capped
+  to wake by `stop_at`); **do not exit**.
 - **draining** → dispatch nothing; wait for active workers until `drain_deadline_at`; past the
   deadline, mark overdue workers `orphaned_acknowledged` (record worktree/issue/PR pointers — no
   abrupt kill) and proceed.

--- a/task-loop/skills/specify-aims/SKILL.md
+++ b/task-loop/skills/specify-aims/SKILL.md
@@ -46,11 +46,6 @@ frontmatter is the narrative copy.
 
 ## Process
 
-### 0. Preflight: verify prerequisites
-This skill invokes `superpowers:brainstorming` and `dev-skills:discuss-with-codex`. Confirm
-both prerequisite plugins are available and **fail fast** with install guidance if either is
-missing, before starting.
-
 ### 1. Explore the project
 Read the repo: existing docs, README, prior art, and the user's stated direction. Note what
 exists and what "done" might plausibly mean.


### PR DESCRIPTION
Removes the inline prerequisite/Agent-Teams checks that `specify-aims`, `create-cycle`, and `run-cycle` each carried.

Those duplicated the standalone `preflight` skill — the single, run-by-itself place that verifies the required skills are loadable and enables Agent Teams. The workflow skills now neither run nor reference a preflight check; they assume prerequisites are met (preflight is the separate setup step). Plugin → 0.5.1.
