### PR TITLE
task-loop: worker worktree isolation, per-attempt concurrency, and one-file per-cycle records

### DIFF
--- a/docs/superpowers/plans/2026-06-13-task-loop-phase0-spike.md
+++ b/docs/superpowers/plans/2026-06-13-task-loop-phase0-spike.md
@@ -124,11 +124,27 @@ RESULT: ___ (dependency blocks: ___ ; auto-unblock on completion: ___)
 
 RESULT: ___ (nested team blocked as expected: ___)
 
-### C6. Ephemerality on resume (confirm the constraint)
-- [ ] Confirm in-process teammates do **not** survive `/resume` / session end (expected). This
-  validates the recovery model: the orchestrator must respawn workers from durable state.
+### C6. Ephemerality on resume (HARD READY gate)
+- [ ] Confirm in-process teammates do **not** survive `/resume` / session end. This underpins the
+  recovery model. **Hard gate:** if teammates *can* survive detached, two attempts could coexist
+  far more easily, so the durable `attempt_id` fence + per-attempt branches are not optional —
+  do **not** run unattended until ephemerality is confirmed.
 
 RESULT: ___ (teammates ephemeral on resume: ___)
+
+### C7. Worktree isolation actually honored (HARD READY gate)
+- [ ] Spawn **two** teammates with `agentType: cycle-worker` (which declares `isolation: worktree`),
+  each reporting `git rev-parse --show-toplevel`. Require the two toplevels to be **distinct from
+  each other AND both different from the lead's** `git rev-parse --show-toplevel`.
+- [ ] **Hard gate:** if isolation is silently ignored (a teammate's toplevel == the lead root),
+  workers share the lead cwd and race the index/filesystem — the merge gate cannot detect cross-task
+  contamination. "Agent Teams enabled" is **not** READY without this probe passing. (The worker's
+  runtime self-check is the second line of defense, but the probe must pass first.)
+
+Prompt to try: *"Create an agent team. Spawn two cycle-worker teammates; each runs
+`git rev-parse --show-toplevel` and reports it. Then print the lead's own toplevel."*
+
+RESULT: ___ (two distinct worktrees, both ≠ lead root: ___)
 
 ---
 
@@ -179,8 +195,10 @@ RESULT: ___ (detection method: ___)
 
 ## Decision gate
 
-`run-cycle` is **buildable as designed** when A1–A2, B1–B2, C1–C4, and D1–D2 all pass (C5/C6/E1
-are confirmations/inputs, not blockers).
+`run-cycle` is **buildable as designed** when A1–A2, B1–B2, C1–C4, and D1–D2 all pass. **C6
+(ephemerality) and C7 (worktree isolation honored) are now HARD gates for unattended runs** — the
+single-flight safety (durable `attempt_id` + per-attempt branches) and the no-cross-task-contamination
+guarantee depend on them (C5/E1 remain confirmations/inputs).
 
 - [ ] **All required checks pass** → proceed to build `run-cycle` (the orchestrator state machine
   on top of `control_log`/`gh_store`, using the confirmed primitives).

--- a/docs/superpowers/specs/2026-06-13-task-loop-impl-review-conclusion.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-impl-review-conclusion.md
@@ -1,0 +1,73 @@
+# task-loop PR #121 — implementation review (Codex) conclusion
+
+**Date:** 2026-06-13 · **PR:** #121 (`bugfix-worker-worktree-and-log-naming`) ·
+**Outcome:** converged — fresh-thread Codex review returned `NO FURTHER OBJECTIONS`.
+
+This reviewed the **implementation** (the committed diff), after the prior round reviewed and
+converged on the **design**. Codex found concrete code/doc bugs the design review couldn't — most
+notably a real protocol bug in the status reducer. All were fixed.
+
+## Bugs found & fixed (in order surfaced)
+
+**Round 1 (control_log + recovery protocol)**
+1. **Recovery comments weren't an executable protocol** — docs said "fenced `task-loop-recovery`
+   JSON" but the example was YAML-ish and there was no parser. → Added `RECOVERY_FENCE`,
+   `format_recovery` / `parse_recovery` / `latest_recovery(comments, attempt_id)` (latest-wins,
+   ignores other attempts; consumes `read_comments` oldest-first), with tests; skeleton example is
+   now one exact fenced-JSON block.
+2. **`attempt_id` not type-checked** — `_validate` only rejected None/"". → Added `_STR_FIELDS`;
+   a non-string `attempt_id` now raises.
+3. **Permissive replay** — `TASK_DISPATCHED` before `TASK_CREATED` produced an active task with
+   `issue_number=None`. → `replay` now rejects a non-`TASK_CREATED` task event for an unestablished
+   task.
+
+**Round 2 (executability + consistency)**
+4. **Per-attempt PR command wrong** — pushed the per-attempt branch but opened the PR with a bare
+   `gh pr create` (would infer the wrong head). → Explicit `gh pr create --head
+   <branch>-attempt-<id> --base master`; no-adoption checkout is explicit `git checkout -B <local>
+   origin/master`.
+5. **Doc sweep too narrow** — stale spawn payloads/examples remained (cycle-worker example blocks,
+   the replay state-shape comment, run-cycle dispatch/merge summaries, helpers list). → Swept and
+   fixed.
+6. **"iteration assigned once" unenforced** — a duplicate `TASK_CREATED` would overwrite
+   `issue_number`/`iteration`. → `replay` now rejects duplicate `TASK_CREATED`, with a test.
+
+**Round 3 (contradiction + spec)**
+7. **Failed-fence contradiction** — the worker was told both "post nothing further" and "post a
+   terminal recovery comment" on a stale/superseded fence; since recovery comments are the durable
+   surface, "post nothing" would strand the orchestrator. → Resolved: post **exactly one** terminal
+   `task-loop-recovery` comment (`stale_revision_blocked` / `superseded_attempt`), then push/PR/post
+   nothing.
+8. **Design-spec stale summaries** — worker-cycle step 10, inbox-event definition, and the
+   cycle-worker system-prompt summary still showed the no-attempt / issue-body / `NNN_*` model. →
+   Updated. E2E test inbox fixtures now carry `attempt_id` + `spawned_plan_revision`.
+
+**Fresh-thread verification (the highest-value catch)**
+9. **`MERGE_DENIED` auto-staled the task** — `_STATUS_BY_TYPE` mapped `MERGE_DENIED → "stale"`, but
+   the new model also emits `MERGE_DENIED` for a **superseded-attempt** denial, where the task is
+   still active under the current attempt. Auto-staling there wrongly kills a live task (and the
+   genuine-invalid path already emits an explicit `TASK_STALE`, so it was also redundant). →
+   Dropped `MERGE_DENIED` from `_STATUS_BY_TYPE`; status changes only via explicit `TASK_STALE`.
+   Tests split into "MERGE_DENIED alone leaves task active (still acked)" + "MERGE_DENIED +
+   TASK_STALE ⇒ stale".
+10. **`MERGE_GRANTED` emitted twice** — the rewritten post-merge cleanup line re-stated "emit
+    `MERGE_GRANTED`" after the merge step already emitted it → duplicate `source_uuid` (which
+    `replay` rejects). → Emit exactly once; the post-merge line only removes the worker + cleans the
+    worktree.
+11. **README test-count drift** — said "45 unit tests". → Now 58.
+
+## Final state
+
+- `control_log.py` is the only protocol code changed; **58 unit tests pass**.
+- Live skill docs (cycle-worker, skeleton, run-cycle + orchestrator-loop, preflight, spec) are
+  internally consistent with the per-attempt / recovery-comment / iteration model.
+- Fresh-thread Codex verification: `NO FURTHER OBJECTIONS`.
+
+## Process note
+
+`codex exec resume` returned a **stale (cached) reply** on the verification turn — byte-identical to
+the prior round despite the files having changed. Worked around it by spawning **fresh** `codex exec`
+threads for verification (independently confirmed each fix with `grep`/tests first). Recommend
+preferring fresh threads over `resume` for "re-check after edits" passes.
+
+How it ended: **converged** — fresh-thread `NO FURTHER OBJECTIONS`.

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -176,10 +176,11 @@ stripped to the create-cycle fills). A worker runs this **once** for its assigne
 9. **Open PR & review** — commit (clean text, `-F`, explicit paths); open PR with
    `Plan-Revision: N` + task ID; **`discuss-with-codex` adversarial PR review until no
    blocking issues**.
-10. **Request merge & hand off** — re-check `plan_revision` validity; post a
-    `MERGE_REQUEST` *inbox* event (PR head SHA, revision) and **go idle. The worker does
-    NOT merge.** If its revision was invalidated at any phase boundary, it marks itself
-    `stale_revision_blocked` and shuts down without merging.
+10. **Request merge & hand off** — re-check **both `plan_revision` AND `attempt_id`**; post a
+    `MERGE_REQUEST` *inbox* event (PR head SHA, `spawned_plan_revision`, `attempt_id`) and **go
+    idle. The worker does NOT merge.** If its revision was invalidated or its attempt superseded at
+    any phase boundary, it posts a terminal recovery comment (`stale_revision_blocked` /
+    `superseded_attempt`) and shuts down without merging.
 11. *(Finalization — the orchestrator emits `MERGE_GRANTED` after it merges; the worker's
     `<NNN>_<task>.md` record is already on `master`. The worker records what it can before
     handoff.)*
@@ -253,8 +254,8 @@ assign sequence numbers (GitHub gives comment IDs, not a project-wide ordered st
 
 - **Worker inbox events** are *unsequenced* comments on the worker's **own task issue**,
   each a fenced JSON block tagged with a client-generated `uuid`, `task_id`,
-  `spawned_plan_revision`, event type (`PLAN_FINDING`, `MERGE_REQUEST`), and (for
-  `MERGE_REQUEST`) `pr_head_sha`.
+  `spawned_plan_revision`, `attempt_id` (so the merge gate can deny a superseded attempt), event
+  type (`PLAN_FINDING`, `MERGE_REQUEST`), and (for `MERGE_REQUEST`) `pr_head_sha`.
 - The orchestrator **ingests** inbox events across task issues and **emits normalized
   `CONTROL_EVENT` comments on the control issue** with a monotonic integer `seq` it alone
   assigns. Control event types are two families:
@@ -321,9 +322,10 @@ assign sequence numbers (GitHub gives comment IDs, not a project-wide ordered st
 Subagent definition referenced by `agentType` when the orchestrator spawns a teammate.
 - **System prompt:** "Execute exactly one task's cycle by following
   `docs/task-loop/task-loop.md`. Deliberate with `discuss-with-codex` at rubric / open
-  design questions / PR review. Never edit `proposal.md`. Never merge — open the PR,
-  re-check your `plan_revision`, post `MERGE_REQUEST`, and go idle. Record durable state
-  as control events + your `NNN_*` records."
+  design questions / PR review. Never edit `proposal.md`. Never merge — open the PR from your
+  per-attempt branch, re-check both `plan_revision` and `attempt_id`, post a `MERGE_REQUEST`
+  (carrying `attempt_id`), and go idle. Record durable state as `attempt_id`-tagged recovery
+  comments + your `<NNN>_<task>.md` record."
 - **Tools:** full dev set (Bash, Read, Edit, Write, git/gh via Bash, Skill, Workflow).
 - Note: a teammate ignores the agent def's `skills:`/`mcpServers:` frontmatter but loads
   skills from project/user settings, so it can invoke `discuss-with-codex` etc.

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -180,8 +180,9 @@ stripped to the create-cycle fills). A worker runs this **once** for its assigne
     `MERGE_REQUEST` *inbox* event (PR head SHA, revision) and **go idle. The worker does
     NOT merge.** If its revision was invalidated at any phase boundary, it marks itself
     `stale_revision_blocked` and shuts down without merging.
-11. *(Finalization — set `RECOVERY: complete`, evidence into the log — happens after the
-    orchestrator merges; the worker records what it can before handoff.)*
+11. *(Finalization — the orchestrator emits `MERGE_GRANTED` after it merges; the worker's
+    `<NNN>_<task>.md` record is already on `master`. The worker records what it can before
+    handoff.)*
 
 **Generic operating principles** (constant across projects): deliberate-with-codex
 instead of asking the user; never let long jobs block (background + `Monitor`/
@@ -227,7 +228,7 @@ run the **pre-merge event-drain barrier** (§8), re-read `current_plan_revision`
 task's compatibility + CI/review state, then `gh pr merge --squash --delete-branch
 --match-head-commit <validated SHA>`. If invalid → `MERGE_DENIED` + mark task stale + tell
 the worker to shut down / rescope. If the orchestrator is dead/draining, nothing merges
-(stalled merge ≫ stale merge); the PR + `RECOVERY` persist for resume.
+(stalled merge ≫ stale merge); the PR + the worker's recovery comments persist for resume.
 
 The `MERGE_REQUEST` inbox event is **not** acked during the event-drain (its only legal
 source-tagged events are merge *outcomes*); it is a *pending decision* that pins the issue's
@@ -335,7 +336,7 @@ Subagent definition referenced by `agentType` when the orchestrator spawns a tea
 
 ## 11. Durable state & recovery
 A fresh agent on clean `master` recovers from: git `master`, the GitHub append-only
-control-event log + per-task `RECOVERY`, open PRs, and `docs/task-loop/logs/`. The
+control-event log + per-task recovery comments, open PRs, and `docs/task-loop/logs/`. The
 orchestrator rebuilds its fast state (incl. `current_plan_revision` and the
 ready/active/blocked sets) **in memory** by replaying the GitHub control-event log — there is no
 local state file to restore, only the control-issue body header (lease + `stop_at` + schedule

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -75,7 +75,8 @@ package `superpowers`. The suite invokes skills from two **required prerequisite
 plugins** that the user must have installed:
 - **`dev-skills`** — `discuss-with-codex`, `goal-rubric`, `doc-update`, `step-workflow`.
 - **`superpowers`** — `brainstorming`, `writing-plans`, `test-driven-development`,
-  `verification-before-completion`, `using-git-worktrees`, `finishing-a-development-branch`.
+  `verification-before-completion`, `finishing-a-development-branch`. (Worker worktree isolation is
+  automatic via the `cycle-worker` agent's `isolation: worktree`, not `using-git-worktrees`.)
 
 `README.md` declares these prerequisites explicitly. `run-cycle` and `create-cycle`
 **fail fast** with install guidance if a required skill is unavailable (rather than
@@ -90,8 +91,7 @@ Created in the **target project** (not the plugin):
 | `docs/task-loop/proposal.md` | durable (git) | `specify-aims` (initial); **orchestrator only** thereafter | charter (aims/success/non-goals, human-gated) + roadmap (stages + hypothesis ledger, orchestrator-authored PRs). **Not** the live coordination primitive. |
 | `docs/task-loop/task-loop.md` | durable (git) | create-cycle | the per-task playbook each worker reads |
 | `docs/task-loop/directions.md` | durable (git) | human | steering channel, read first each planning round |
-| `docs/task-loop/logs/NNN_<task>_rubric.md` | durable (git) | worker | binary acceptance criteria (orchestrator↔worker "done" interface) |
-| `docs/task-loop/logs/NNN_<task>_log.md` | durable (git) | worker | decision record: task, steering, codex dispositions, rubric evidence, follow-ups |
+| `docs/task-loop/logs/<NNN>_<task>.md` | durable (git) | worker | one per-cycle record with a **Rubric** section (binary acceptance — the orchestrator↔worker "done" interface, also posted to the issue) and a **Decision log** section (task, steering, codex dispositions, rubric evidence, follow-ups). `<NNN>` = zero-padded iteration index from `001`, orchestrator-assigned |
 | GitHub control issue — **comments** (append-only control events) | durable (remote) | worker + orchestrator | **authoritative cross-agent coordination log** (see §8) |
 | GitHub control issue — **body runtime header** | durable (remote) | **orchestrator only** (sole writer) | the single mutable runtime cell: `lease`/`heartbeat`, **`stop_at`**, `watchdog_schedule_id`, `stop_schedule_id`, advisory `phase`. **No local files** — `plan_revision`/ready/active/blocked are rebuilt from the comment log on every turn |
 
@@ -151,10 +151,14 @@ stripped to the create-cycle fills). A worker runs this **once** for its assigne
    `directions.md`; re-read the referenced docs at the current `plan_revision`.
 2. **Confirm task** — the orchestrator already chose/scoped it; validate scope and the
    `spawned_plan_revision`.
-3. **Issue & branch** — confirm issue; branch from fresh master into the worker's **own
-   git worktree**; open the `RECOVERY` ledger (issue body) + `NNN_<task>_log.md`.
+3. **Issue & branch** — confirm issue; the worker **already runs in its own git worktree**
+   (the `cycle-worker` agent declares `isolation: worktree`, so isolation is automatic — it does
+   **not** create one), so just adopt/create the deterministic branch from fresh master; open the
+   `RECOVERY` ledger (issue body) + the per-cycle record `<NNN>_<task>.md` (`NNN` = the
+   orchestrator-assigned iteration index, zero-padded from `001`).
 4. **Rubric** — `goal-rubric` → binary rubric → finalize via a `discuss-with-codex`
-   pass → write `NNN_<task>_rubric.md` and post to the issue.
+   pass → write **and commit** it into the **Rubric** section of `<NNN>_<task>.md` and post to the
+   issue (the record is git-tracked).
 5. **Spec → plan → implement** — `brainstorming` (autonomous: decline user gates → route
    open questions to `discuss-with-codex`) → spec → `writing-plans` → **TDD**. Long
    compute → background; intra-task parallelism → `Workflow`/inline subagents (never a

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -146,16 +146,19 @@ a generic skeleton + project specifics, and scaffold the rest.
 The worker's per-task playbook (generalized from METBG's 11 steps; project specifics
 stripped to the create-cycle fills). A worker runs this **once** for its assigned task:
 
-1. **Recover & anchor** — read the issue body's `RECOVERY` ledger (a worker-maintained
-   state machine, **not** a control event) and resume by its `status`, or abandon; read
+1. **Recover & anchor** — read the latest **`attempt_id`-tagged recovery comment** (append-only,
+   **not** a mutated body, **not** a control event) and resume by its `status`, or abandon; read
    `directions.md`; re-read the referenced docs at the current `plan_revision`.
-2. **Confirm task** — the orchestrator already chose/scoped it; validate scope and the
-   `spawned_plan_revision`.
+2. **Confirm task** — the orchestrator already chose/scoped it; validate scope, the
+   `spawned_plan_revision`, **and that `attempt_id == current_attempt_id`** (else stop,
+   `superseded_attempt`).
 3. **Issue & branch** — confirm issue; the worker **already runs in its own git worktree**
-   (the `cycle-worker` agent declares `isolation: worktree`, so isolation is automatic — it does
-   **not** create one), so just adopt/create the deterministic branch from fresh master; open the
-   `RECOVERY` ledger (issue body) + the per-cycle record `<NNN>_<task>.md` (`NNN` = the
-   orchestrator-assigned iteration index, zero-padded from `001`).
+   (the `cycle-worker` agent declares `isolation: worktree`) and **self-checks it**
+   (`git rev-parse --show-toplevel` != `lead_worktree_root`, else `WORKTREE_ISOLATION_FAILED`); it
+   does **not** create one. It works an attempt-scoped local branch and pushes only to its
+   **per-attempt remote branch** `<branch>-attempt-<attempt_id>` (no shared writable ref). Open the
+   per-cycle record `<NNN>_<task>.md` (`NNN` = the orchestrator-assigned iteration index from
+   `001`) and post the first recovery comment.
 4. **Rubric** — `goal-rubric` → binary rubric → finalize via a `discuss-with-codex`
    pass → write **and commit** it into the **Rubric** section of `<NNN>_<task>.md` and post to the
    issue (the record is git-tracked).
@@ -255,8 +258,10 @@ assign sequence numbers (GitHub gives comment IDs, not a project-wide ordered st
   `CONTROL_EVENT` comments on the control issue** with a monotonic integer `seq` it alone
   assigns. Control event types are two families:
   - *orchestrator-originated* (no source provenance): `TASK_CREATED` (carries the task's
-    `issue_number`), `TASK_DISPATCHED`, `PLAN_REVISION_BUMP` (carries `proposal_sha`),
-    `TASK_STALE`, `TASK_REVISION_COMPATIBLE`, `INBOX_SCAN_CHECKPOINT` (carries
+    `issue_number` + `iteration`, the per-task record index), `TASK_DISPATCHED` (carries
+    `attempt_id`, the durable single-flight ownership token — `replay` stores
+    `current_attempt_id` per task, latest dispatch wins), `PLAN_REVISION_BUMP` (carries
+    `proposal_sha`), `TASK_STALE`, `TASK_REVISION_COMPATIBLE`, `INBOX_SCAN_CHECKPOINT` (carries
     `issue_number` + `through_ts`);
   - *inbox-derived* (carry `source_issue` / `source_comment_id` / `source_comment_ts` /
     `source_uuid`): `MERGE_GRANTED`, `MERGE_DENIED` (answer a `MERGE_REQUEST`),
@@ -337,15 +342,19 @@ local state file to restore, only the control-issue body header (lease + `stop_a
 handles). Ephemeral Agent-Teams state (teammates, `~/.claude/tasks/`) is **not** relied upon — the
 orchestrator respawns workers for still-open tasks. The planning step is idempotent.
 
-**Per-task recovery (the `RECOVERY` ledger).** A worker's progress through irreversible actions
-is a state machine recorded in its **task-issue body** (`gh issue edit`, last-write-wins):
-`in_progress → creating_pr → pr_open → merge_requesting → merge_requested`. It is written as an
-ordered pre/post-condition around `gh pr create` and the merge request, so the orchestrator can
-distinguish *ready-but-unannounced* from *still-working* even if the worker died before posting
-its `MERGE_REQUEST`. A merge-request attempt is **immutable**: its `merge_request_uuid` is bound
-to `merge_request_head_sha` and the branch freezes once `merge_requesting` begins — a changed
-head requires a fresh UUID, so the protocol's UUID dedupe can never strand a newer head. (Full
-definition in the generated `task-loop.md` *RECOVERY ledger*.)
+**Per-task recovery (the recovery comments).** A worker's progress through irreversible actions is
+a state machine recorded as **append-only, `attempt_id`-tagged recovery comments** (`gh issue
+comment`) — **never** a mutated issue body, so two attempts can never race the same surface:
+`in_progress → creating_pr → pr_open → merge_requesting → merge_requested`. The orchestrator reads
+the **latest comment for `current_attempt_id`** to distinguish *ready-but-unannounced* from
+*still-working* even if the worker died before posting its `MERGE_REQUEST`. Each **attempt** owns a
+**per-attempt remote branch** (`<branch>-attempt-<attempt_id>`) and is gated by the durable
+`current_attempt_id` (a superseded attempt's `MERGE_REQUEST` is denied), so safety does not depend
+on a "one worker at a time" assumption. A merge-request attempt is additionally **immutable**: its
+`merge_request_uuid` is bound to `merge_request_head_sha` and the branch freezes once
+`merge_requesting` begins — a changed head requires a fresh UUID, so the protocol's UUID dedupe can
+never strand a newer head. (Full
+definition in the generated `task-loop.md` *Recovery comments* section.)
 
 ## 12. Agent Teams enablement & constraints
 - Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (settings.json) and Claude Code

--- a/docs/superpowers/specs/2026-06-13-task-loop-worker-concurrency-conclusion.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-worker-concurrency-conclusion.md
@@ -1,0 +1,93 @@
+# task-loop worker isolation & per-cycle records — Codex deliberation conclusion
+
+**Date:** 2026-06-13 · **PR:** #121 (`bugfix-worker-worktree-and-log-naming`) ·
+**Outcome:** converged after 6 rounds (Codex: `NO FURTHER OBJECTIONS`).
+
+Pressure-test of two fixes — (1) declared `isolation: worktree` for the worker + drop manual
+worktree creation, (2) consolidate the per-cycle rubric+log into one iteration-indexed record.
+The review went well past the diff and exposed five concurrency/correctness holes in the broader
+worker↔orchestrator protocol. The throughline: **stop protecting shared mutable state with
+assumptions; either make state durable in the sequenced log, or give each attempt its own
+non-shared surface.**
+
+## Settled position — what PR #121 (and its follow-ups) must contain
+
+**A. Worker worktree isolation — declared *and* verified.**
+- `cycle-worker` declares `isolation: worktree`; the worker never creates one manually.
+- **Runtime self-check (defense against silent non-isolation):** the orchestrator passes
+  `lead_worktree_root` (its own `git rev-parse --show-toplevel`) in every spawn prompt. The
+  worker runs `git rev-parse --show-toplevel` **before any checkout**; if it equals the lead
+  root, it **stops and escalates `WORKTREE_ISOLATION_FAILED`** — never edits/pushes (prevents
+  cross-task filesystem/index races the head-SHA merge gate cannot detect).
+- **Phase-0 isolation probe** (hard READY gate): spawn two plugin-provided isolated probe
+  teammates; require distinct `--show-toplevel` values, both ≠ lead root. "Agent Teams enabled"
+  alone is **not** READY.
+
+**B. Per-attempt surfaces — no shared writable refs or bodies.**
+- **Per-attempt remote branches:** each attempt pushes only to `<det>-attempt-<attempt_id>`.
+  Unique names mean a superseded worker can physically only touch its own dead branch — it can
+  never clobber the current attempt's branch. (Replaces the earlier *shared* deterministic
+  branch, which a stale worker or a check-then-act fence could not protect.)
+- **PR per attempt;** the orchestrator merges **only the current attempt's** PR (`attempt_id ==
+  current_attempt_id`) and denies stale-attempt `MERGE_REQUEST`s (on top of UUID dedupe +
+  `--match-head-commit`).
+- **Continuity without sharing:** a new attempt may branch *from* the latest GitHub-visible
+  attempt branch when the orchestrator passes `adopt_from_branch` (Option-1 still holds:
+  local-only pre-PR WIP is disposable; only pushed/PR'd work is adopted). Adoption is a *read* of
+  another branch, never a *write* to it.
+- **RECOVERY is per-attempt append-only comments** (attempt_id-tagged, non-control, no seq) —
+  not a shared last-writer-wins issue body. The orchestrator reads the latest recovery comment
+  for the current attempt. (This removes the body-overwrite race.)
+
+**C. Durable attempt ownership (the fence — now defense-in-depth, not the safety basis).**
+- `attempt_id` is a **required field on the sequenced `TASK_DISPATCHED`**; `replay()` stores
+  `state["tasks"][task_id]["current_attempt_id"]` (latest dispatch wins).
+- The worker re-checks `attempt_id == current_attempt_id` before every side effect (the existing
+  `spawned_plan_revision` boundary check, extended to attempts); if superseded it records
+  `superseded_attempt` and stops. Inbox events carry `attempt_id`; the orchestrator ignores/denies
+  stale ones. Safety now comes from **unique per-attempt surfaces + current-attempt-only merge**,
+  with the fence avoiding wasted work.
+- **Phase-0 ephemerality** ("teammates die with the lead") is a **hard READY gate** — it keeps
+  the two-workers-coexist window rare; the per-attempt surfaces make it *safe* when it occurs.
+
+**D. Iteration index — a real protocol field (not prose).**
+- Add `iteration` to `_REQUIRED_FIELDS["TASK_CREATED"]` and `_INT_FIELDS`; `replay()` stores
+  `state["tasks"][task_id]["iteration"]`. Add replay tests (cold replay preserves it;
+  missing/non-int raises). Docs: `TASK_CREATED{task_id, plan_revision, issue_number, iteration}`.
+- `NNN` is the zero-padded iteration index from `001`, **assigned once at `TASK_CREATED`**,
+  recovered by `replay()`, **reused on re-dispatch** (per-task slot, not per-attempt). This
+  dissolves the earlier circularity (an abandoned no-artifact task still has its NNN in the log).
+- **`docs/task-loop/logs/` is audit-only, not a recovery source.** One record per cycle,
+  `<NNN>_<task>.md`, with a **Rubric** section (authoritative) and a **Decision log** section;
+  the issue-posted rubric is a verbatim published copy, the file is the source of truth.
+
+## Strongest objections & how each resolved
+
+1. **Iteration index unrecoverable** — `replay()` never stored it; the logs/ fallback was
+   circular. → Make `iteration` a real required/int/replay-stored field; logs/ audit-only.
+2. **Stale worktree holds the branch hostage** — `git checkout -B <det>` fails if another
+   worktree has `<det>` checked out (reproduced). → Decouple local (attempt-scoped) from remote
+   branch; ultimately → per-attempt remote branches.
+3. **`isolation: worktree` is an unverified SPOF** — silent non-isolation → workers race the lead
+   cwd; merge gate can't catch cross-task contamination. → Runtime self-check vs `lead_worktree_root`
+   + Phase-0 probe (hard gate).
+4. **Remote branch ownership not durably exclusive** — "one worker per task" was session memory.
+   → Durable `attempt_id` fence on the sequenced log.
+5. **Fence is check-then-act, not atomic on shared surfaces** — a superseded worker can push/
+   overwrite before its next check. → Eliminate shared surfaces: per-attempt branches +
+   append-only per-attempt recovery comments.
+
+## Unresolved tensions
+
+None at protocol level. Remaining work is implementation + test coverage (Codex's closing words).
+
+## Scope note (essential-vs-follow-up)
+
+PR #121's *original* intent (worktree isolation + one-file record) should land with the items it
+directly depends on: **A** (isolation declared+verified), the **iteration field D** (small,
+tested `control_log.py` change), and the **per-attempt branch** core of **B**. The fuller
+**attempt-ownership protocol (C)** and **RECOVERY-as-append-only-comments** touch the merged
+#118/#120 protocol broadly and are best staged as a focused follow-up PR rather than silently
+ballooning #121 — but the design above is the agreed target.
+
+How it ended: **converged after 6 rounds** — `NO FURTHER OBJECTIONS`.

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.6.0"
+  "version": "0.6.1"
 }

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.6.1"
+  "version": "0.7.0"
 }

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -97,7 +97,8 @@ task-loop/
 ## Status
 
 - ✅ **Control protocol** (`control_log.py`, `gh_store.py`) — single-sequencer log, UUID
-  dedupe, checkpoint-based scan floor, schema validation; 45 unit tests.
+  dedupe, checkpoint-based scan floor, per-attempt ownership + iteration fields, recovery-comment
+  parser, schema validation; 58 unit tests.
 - ✅ **`specify-aims`**, **`create-cycle`**, **`run-cycle`** skills + **`cycle-worker`** agent.
 - ⚠️ **Phase 0 spike (operator-run)** — `run-cycle` is built against the documented
   Agent-Teams / `/loop` / stop-signal contract; the operator validates those primitives with

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -44,7 +44,8 @@ c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-si
 `task-loop` invokes skills from two **required** plugins — install them first:
 
 - **`superpowers`** — `brainstorming`, `writing-plans`, `test-driven-development`,
-  `verification-before-completion`, `using-git-worktrees`, `finishing-a-development-branch`.
+  `verification-before-completion`, `finishing-a-development-branch`. (Worker worktree isolation is
+  automatic via the `cycle-worker` agent's `isolation: worktree` declaration.)
 - **`dev-skills`** — `discuss-with-codex`, `goal-rubric`, `doc-update`, `step-workflow`.
 
 **Run the `preflight` skill** to check two scopes: that these skills are loadable in your
@@ -72,7 +73,7 @@ The **`preflight`** skill sets this for you (and reminds you to restart). The `s
 | `docs/task-loop/proposal.md` | `specify-aims`, then orchestrator | Charter + Roadmap (living research spine) |
 | `docs/task-loop/task-loop.md` | `create-cycle` | the per-task playbook each worker follows |
 | `docs/task-loop/directions.md` | you | human steering channel (read first each round) |
-| `docs/task-loop/logs/NNN_<task>_{rubric,log}.md` | worker | binary acceptance + decision/evidence trail |
+| `docs/task-loop/logs/NNN_<task>.md` | worker | one git-tracked per-cycle record (**Rubric** + **Decision log** sections); `NNN` = zero-padded iteration index from `001` (orchestrator-assigned, tracks cycles chronologically) |
 | GitHub control issue (comments) + per-task issues | orchestrator + workers | append-only control-event log |
 | GitHub control issue (body runtime header) | orchestrator (sole writer) | lease/heartbeat, `stop_at`, schedule handles — **no local files** |
 

--- a/task-loop/agents/cycle-worker.md
+++ b/task-loop/agents/cycle-worker.md
@@ -61,11 +61,12 @@ description of the task. If any is missing, ask the orchestrator (the team lead)
 - **Fence every irreversible boundary on BOTH `spawned_plan_revision` AND `attempt_id`** (before
   finalizing the spec, before each push, before opening the PR, and before requesting merge):
   replay the `control_issue` and confirm `spawned_plan_revision` is still current **and**
-  `attempt_id == current_attempt_id` for your task. If your revision is stale, record
-  `stale_revision_blocked`; if your `attempt_id` was superseded (a later dispatch took over),
-  record `superseded_attempt`. In either case **post nothing further, push nothing, and shut
-  down** — do not merge or continue. (You write only your own per-attempt branch + your own
-  recovery comments, so a late check is never *unsafe* — but stop promptly to avoid wasted work.)
+  `attempt_id == current_attempt_id` for your task. If either fails, post **exactly one terminal
+  `task-loop-recovery` comment** for this attempt (`status=stale_revision_blocked` for a stale
+  revision, `status=superseded_attempt` for a superseded attempt) — that comment is the durable
+  signal the orchestrator needs — then **push nothing, open no PR, post no inbox event, and shut
+  down**. (You write only your own per-attempt branch + your own recovery comments, so a late check
+  is never *unsafe* — but stop promptly to avoid wasted work.)
 - **Post inbox events on YOUR task issue only**, as a fenced `task-loop-event` JSON comment via
   `gh issue comment --body-file` (keeps JSON out of the command text). Use a fresh `uuid`
   (`uuidgen`); include `spawned_plan_revision` **and `attempt_id`** on every inbox event (and

--- a/task-loop/agents/cycle-worker.md
+++ b/task-loop/agents/cycle-worker.md
@@ -5,15 +5,15 @@ description: Use this agent when the task-loop orchestrator (run-cycle) needs to
 <example>
 Context: The run-cycle orchestrator has computed the ready task frontier and is dispatching work.
 user: "(orchestrator) Dispatch task T7 (issue #42, spawned_plan_revision 3): build Stage 2 endpoints."
-assistant: "I'll spawn a teammate using the cycle-worker agent type with the prompt 'task_id=T7 issue=42 spawned_plan_revision=3 — build Stage 2 endpoints per the Roadmap', and wait for its idle/completion notification."
-<commentary>The orchestrator assigns exactly one task per worker; the cycle-worker runs that single task's full cycle and reports back without merging.</commentary>
+assistant: "I'll spawn a teammate using the cycle-worker agent type, passing task_id=T7, issue=42, control_issue=#5, spawned_plan_revision=3, iteration=007, a fresh attempt_id, the per-attempt branch feat-42-T7-attempt-<id>, and lead_worktree_root — then wait for its idle/completion notification."
+<commentary>The orchestrator assigns exactly one task per worker, carrying the iteration index + the durable attempt_id; the cycle-worker runs that single task's full cycle in its own isolated worktree and reports back without merging.</commentary>
 </example>
 
 <example>
 Context: A previous worker's PR was merged, unblocking a dependent task in the shared task list.
 user: "(orchestrator) Task T9 is now unblocked; assign it."
-assistant: "I'll spawn a cycle-worker teammate for T9 with its task_id, issue number, and current plan_revision."
-<commentary>Each unblocked task gets its own fresh cycle-worker; the orchestrator passes the task_id, issue number, and current spawned_plan_revision, and the worker isolates its work in a git worktree and posts a MERGE_REQUEST inbox event when done.</commentary>
+assistant: "I'll spawn a cycle-worker teammate for T9, passing its task_id, issue number, control_issue, current spawned_plan_revision, iteration index, a fresh attempt_id, its per-attempt branch, and lead_worktree_root."
+<commentary>Each unblocked task gets its own fresh cycle-worker; the worker runs in its own auto-provided git worktree (isolation: worktree), pushes only its per-attempt branch, and posts a MERGE_REQUEST inbox event (carrying attempt_id) when done.</commentary>
 </example>
 
 model: inherit
@@ -89,10 +89,11 @@ description of the task. If any is missing, ask the orchestrator (the team lead)
   you can never race the lead's tree. **Do not create another worktree** (no `using-git-worktrees`,
   no `git worktree add`). Then work on an **attempt-scoped local branch** and push only to your
   **per-attempt remote branch**: `git fetch origin`; if `adopt_from_branch` was given
-  `git checkout -B <local> origin/<adopt_from_branch>`, else `git checkout -B <local>` from the
-  fresh base; push with `git push origin HEAD:<branch>-attempt-<attempt_id>`. You write **only your
-  own** per-attempt branch — never a shared one. Stage files by explicit path; commit with clean,
-  attribution-free text via `git commit -F`.
+  `git checkout -B <local> origin/<adopt_from_branch>`, else `git checkout -B <local> origin/master`
+  (the fresh base); push with `git push origin HEAD:<branch>-attempt-<attempt_id>` and open the PR
+  with an **explicit head** (`gh pr create --head <branch>-attempt-<attempt_id> --base master ...`),
+  never letting `gh` infer it. You write **only your own** per-attempt branch — never a shared one.
+  Stage files by explicit path; commit with clean, attribution-free text via `git commit -F`.
 - **No nested teams.** For intra-task parallelism use `Workflow` or inline subagents, never a
   sub-team.
 

--- a/task-loop/agents/cycle-worker.md
+++ b/task-loop/agents/cycle-worker.md
@@ -18,6 +18,7 @@ assistant: "I'll spawn a cycle-worker teammate for T9 with its task_id, issue nu
 
 model: inherit
 color: green
+isolation: worktree
 tools: ["Bash", "Read", "Edit", "Write", "Glob", "Grep", "Skill", "Workflow", "TodoWrite", "Monitor", "ScheduleWakeup", "WebFetch", "WebSearch"]
 ---
 
@@ -32,14 +33,17 @@ orchestrator (the team lead) before starting.
 
 **Your core responsibilities:**
 1. Read `docs/task-loop/task-loop.md` and follow its cycle **step by step** for your one
-   task: recover/anchor → confirm scope → branch into your own git worktree → binary rubric →
+   task: recover/anchor → confirm scope → create your task branch (in the worktree you already
+   run in) → binary rubric →
    spec/plan → TDD implementation → verify rubric with real output → reconcile → doc-update →
    open PR + adversarial Codex review → request merge → finalize the decision record.
 2. **Deliberate, don't ask the user.** Use the `discuss-with-codex` skill at the rubric, at
-   every open design question, and for the PR review. Record each disposition in your
-   `docs/task-loop/logs/NNN_<task>_log.md`.
-3. Maintain your durable records: `docs/task-loop/logs/NNN_<task>_rubric.md` (binary
-   acceptance) and `..._log.md` (decisions + evidence), plus the **`RECOVERY` ledger** in the
+   every open design question, and for the PR review. Record each disposition in the **Decision
+   log** section of your `docs/task-loop/logs/<NNN>_<task>.md` record.
+3. Maintain your durable per-cycle record `docs/task-loop/logs/<NNN>_<task>.md` — **one**
+   git-tracked file with a **Rubric** section (binary acceptance) and a **Decision log** section
+   (decisions + evidence), where `<NNN>` is the orchestrator-assigned iteration index (zero-padded
+   from `001`) — plus the **`RECOVERY` ledger** in the
    **task issue body** (`gh issue edit --body-file`; one canonical location, last-write-wins).
    Follow the playbook's *RECOVERY ledger* as an **ordered pre/post-condition around every
    irreversible action** (`creating_pr`→`pr_open`→`merge_requesting`→`merge_requested`) so a
@@ -68,9 +72,13 @@ orchestrator (the team lead) before starting.
   the attempt: return to `pr_open`, push the fix (new head), and mint a **new** UUID. On resume
   from `merge_requesting`, repost the *same* UUID only if the current head still equals
   `merge_request_head_sha`.
-- **Work in your own git worktree** (via `superpowers:using-git-worktrees`) so parallel workers
-  never collide on files. Stage files by explicit path; commit with clean, attribution-free
-  text via `git commit -F`.
+- **You already run in your own isolated git worktree** — your agent declares
+  `isolation: worktree`, so the harness gives every worker a separate worktree (branched from
+  fresh `master`) automatically. **Do not create another worktree** (no `using-git-worktrees`,
+  no `git worktree add`) — that would nest a redundant tree. Just `git fetch` and **adopt** the
+  task's deterministic remote branch if it exists, else `git checkout -B <deterministic-branch>`
+  from the worktree's fresh base. Stage files by explicit path; commit with clean,
+  attribution-free text via `git commit -F`.
 - **No nested teams.** For intra-task parallelism use `Workflow` or inline subagents, never a
   sub-team.
 

--- a/task-loop/agents/cycle-worker.md
+++ b/task-loop/agents/cycle-worker.md
@@ -27,9 +27,11 @@ development cycle by following `docs/task-loop/task-loop.md`, then hand off and 
 are one teammate among possibly several; the orchestrator (`run-cycle`) assigned you one task
 and is the only agent that integrates work.
 
-**Your inputs (from the spawn prompt):** `task_id`, the task's GitHub `issue` number,
-`spawned_plan_revision`, and a short description of the task. If any is missing, ask the
-orchestrator (the team lead) before starting.
+**Your inputs (from the spawn prompt):** `task_id`, the task's GitHub `issue` number, the
+`control_issue` number, `spawned_plan_revision`, `iteration` (your record index), `attempt_id`
+(your durable ownership token), your per-attempt branch `<branch>-attempt-<attempt_id>`,
+`lead_worktree_root` (for the isolation self-check), optionally `adopt_from_branch`, and a short
+description of the task. If any is missing, ask the orchestrator (the team lead) before starting.
 
 **Your core responsibilities:**
 1. Read `docs/task-loop/task-loop.md` and follow its cycle **step by step** for your one
@@ -43,28 +45,35 @@ orchestrator (the team lead) before starting.
 3. Maintain your durable per-cycle record `docs/task-loop/logs/<NNN>_<task>.md` — **one**
    git-tracked file with a **Rubric** section (binary acceptance) and a **Decision log** section
    (decisions + evidence), where `<NNN>` is the orchestrator-assigned iteration index (zero-padded
-   from `001`) — plus the **`RECOVERY` ledger** in the
-   **task issue body** (`gh issue edit --body-file`; one canonical location, last-write-wins).
-   Follow the playbook's *RECOVERY ledger* as an **ordered pre/post-condition around every
-   irreversible action** (`creating_pr`→`pr_open`→`merge_requesting`→`merge_requested`) so a
-   cold resume — or the orchestrator — can always tell *ready-but-unannounced* from
-   *still-working*. `RECOVERY` is worker state, **not** a sequenced control event.
+   from `001`) — plus your **recovery state** as **append-only, `attempt_id`-tagged comments** on
+   the task issue (a fenced `task-loop-recovery` block via `gh issue comment --body-file`; **never**
+   a mutated issue body — two attempts must never write the same surface). Post a recovery comment
+   at each ordered transition (`creating_pr`→`pr_open`→`merge_requesting`→`merge_requested`, plus
+   your worktree path) so a cold resume — or the orchestrator — reads the **latest comment for your
+   `attempt_id`** to tell *ready-but-unannounced* from *still-working*. Recovery comments are worker
+   state, **not** sequenced control events.
 
 **Hard rules — never violate:**
 - **Never run `gh pr merge`.** The orchestrator is the sole integrator. You end at *PR open +
   merge request*.
 - **Never edit `docs/task-loop/proposal.md`.** If a result invalidates a hypothesis, post a
   `PLAN_FINDING` inbox event and file an issue; the orchestrator decides any revision change.
-- **Re-check `spawned_plan_revision` at every irreversible boundary** (before finalizing the
-  spec, before opening the PR, and before requesting merge). If it is no longer current, mark
-  the decision record `stale_revision_blocked`, post nothing further, and shut down — do not
-  merge or continue.
+- **Fence every irreversible boundary on BOTH `spawned_plan_revision` AND `attempt_id`** (before
+  finalizing the spec, before each push, before opening the PR, and before requesting merge):
+  replay the `control_issue` and confirm `spawned_plan_revision` is still current **and**
+  `attempt_id == current_attempt_id` for your task. If your revision is stale, record
+  `stale_revision_blocked`; if your `attempt_id` was superseded (a later dispatch took over),
+  record `superseded_attempt`. In either case **post nothing further, push nothing, and shut
+  down** — do not merge or continue. (You write only your own per-attempt branch + your own
+  recovery comments, so a late check is never *unsafe* — but stop promptly to avoid wasted work.)
 - **Post inbox events on YOUR task issue only**, as a fenced `task-loop-event` JSON comment via
   `gh issue comment --body-file` (keeps JSON out of the command text). Use a fresh `uuid`
-  (`uuidgen`); include `spawned_plan_revision` on every inbox event (and `pr_head_sha` on a
-  `MERGE_REQUEST`). Assign **no** sequence numbers — only the orchestrator sequences the
-  canonical control log. The event's own `ts` is **audit-only**: the orchestrator orders
-  events by each GitHub comment's `createdAt`, not by your stamp, so a skewed `ts` is harmless.
+  (`uuidgen`); include `spawned_plan_revision` **and `attempt_id`** on every inbox event (and
+  `pr_head_sha` on a `MERGE_REQUEST`) — the orchestrator's merge gate **denies a `MERGE_REQUEST`
+  whose `attempt_id` is no longer current**. Assign **no** sequence numbers — only the orchestrator
+  sequences the canonical control log. The event's own `ts` is **audit-only**: the orchestrator
+  orders events by each GitHub comment's `createdAt`, not by your stamp, so a skewed `ts` is
+  harmless.
 - **A merge-request attempt is immutable.** Once you enter `merge_requesting`, **freeze the
   branch** (push no more commits) and bind the `merge_request_uuid` to `merge_request_head_sha`.
   Never reuse a UUID for a different head — the protocol dedupes by UUID only, so a later head
@@ -72,25 +81,36 @@ orchestrator (the team lead) before starting.
   the attempt: return to `pr_open`, push the fix (new head), and mint a **new** UUID. On resume
   from `merge_requesting`, repost the *same* UUID only if the current head still equals
   `merge_request_head_sha`.
-- **You already run in your own isolated git worktree** — your agent declares
-  `isolation: worktree`, so the harness gives every worker a separate worktree (branched from
-  fresh `master`) automatically. **Do not create another worktree** (no `using-git-worktrees`,
-  no `git worktree add`) — that would nest a redundant tree. Just `git fetch` and **adopt** the
-  task's deterministic remote branch if it exists, else `git checkout -B <deterministic-branch>`
-  from the worktree's fresh base. Stage files by explicit path; commit with clean,
+- **You already run in your own isolated git worktree** — your agent declares `isolation: worktree`,
+  so the harness gives every worker a separate worktree (branched from fresh `master`)
+  automatically. **Verify it FIRST:** run `git rev-parse --show-toplevel`; if it equals
+  `lead_worktree_root`, isolation was **not** honored — **stop immediately, post
+  `WORKTREE_ISOLATION_FAILED` to the orchestrator, and do nothing else** (no checkout, no edits) so
+  you can never race the lead's tree. **Do not create another worktree** (no `using-git-worktrees`,
+  no `git worktree add`). Then work on an **attempt-scoped local branch** and push only to your
+  **per-attempt remote branch**: `git fetch origin`; if `adopt_from_branch` was given
+  `git checkout -B <local> origin/<adopt_from_branch>`, else `git checkout -B <local>` from the
+  fresh base; push with `git push origin HEAD:<branch>-attempt-<attempt_id>`. You write **only your
+  own** per-attempt branch — never a shared one. Stage files by explicit path; commit with clean,
   attribution-free text via `git commit -F`.
 - **No nested teams.** For intra-task parallelism use `Workflow` or inline subagents, never a
   sub-team.
 
 **Handoff (the end of your cycle):**
 When the rubric is green, the PR is open, and Codex review has no blocking issues, post a
-`MERGE_REQUEST` inbox event (carrying the PR head SHA and your `spawned_plan_revision`),
-send the orchestrator a one-line completion message, and **go idle**. The orchestrator
-validates and merges; it will mark your decision record complete.
+`MERGE_REQUEST` inbox event (carrying the PR head SHA, your `spawned_plan_revision`, and your
+`attempt_id`), send the orchestrator a one-line completion message, and **go idle**. The
+orchestrator validates and merges only if your `attempt_id` is still current; it then emits
+`MERGE_GRANTED` (your `NNN_<task>.md` record is already on `master`).
 
 **Edge cases:**
 - *Revision invalidated mid-cycle:* stop at the next boundary, record `stale_revision_blocked`,
   notify the orchestrator, shut down.
+- *Superseded by a later dispatch* (`attempt_id` != `current_attempt_id`): stop at the next fenced
+  boundary, record `superseded_attempt`, push nothing further, shut down — the current attempt owns
+  the task.
+- *Worktree isolation not honored* (`--show-toplevel` == `lead_worktree_root`): post
+  `WORKTREE_ISOLATION_FAILED` and stop before any edit.
 - *Rubric cannot go green:* fix, or descope honestly — file the descoped items as follow-up
   issues (never silently omit), record why, and reflect the reduced scope in the PR.
 - *Genuine human-only blocker* (compute/budget beyond this environment, missing licensed

--- a/task-loop/scripts/control_log.py
+++ b/task-loop/scripts/control_log.py
@@ -132,7 +132,11 @@ _STATUS_BY_TYPE = {
     "TASK_CREATED": "ready",
     "TASK_DISPATCHED": "active",
     "MERGE_GRANTED": "merged",
-    "MERGE_DENIED": "stale",
+    # MERGE_DENIED deliberately does NOT change task status: it acks the inbox
+    # MERGE_REQUEST but covers two cases — a *superseded-attempt* denial (the task
+    # is still active under the current attempt) and a genuinely-invalid merge (the
+    # gate emits an explicit TASK_STALE alongside it). Auto-staling here would wrongly
+    # stale an actively-worked task on a superseded-attempt denial.
     "TASK_STALE": "stale",
     "TASK_REVISION_COMPATIBLE": "active",
 }

--- a/task-loop/scripts/control_log.py
+++ b/task-loop/scripts/control_log.py
@@ -111,8 +111,8 @@ _SOURCE_FIELDS = ("source_issue", "source_comment_id", "source_comment_ts",
 # Required fields per control-event type (beyond kind/seq/type/ts).
 _REQUIRED_FIELDS = {
     "PLAN_REVISION_BUMP": ("plan_revision", "proposal_sha"),
-    "TASK_CREATED": ("task_id", "plan_revision", "issue_number"),
-    "TASK_DISPATCHED": ("task_id", "plan_revision"),
+    "TASK_CREATED": ("task_id", "plan_revision", "issue_number", "iteration"),
+    "TASK_DISPATCHED": ("task_id", "plan_revision", "attempt_id"),
     "TASK_STALE": ("task_id", "plan_revision"),
     "TASK_REVISION_COMPATIBLE": ("task_id", "plan_revision"),
     "INBOX_SCAN_CHECKPOINT": ("issue_number", "through_ts"),
@@ -120,7 +120,10 @@ _REQUIRED_FIELDS = {
     "MERGE_DENIED": ("task_id", "plan_revision", "pr_head_sha") + _SOURCE_FIELDS,
     "PLAN_FINDING_RECORDED": ("task_id",) + _SOURCE_FIELDS,
 }
-_INT_FIELDS = ("plan_revision", "issue_number", "source_issue")
+# `iteration` is the per-task chronological log index (zero-padded 001 in records,
+# stored as an int here). `attempt_id` is an opaque per-dispatch ownership token
+# (a uuid string), so it is validated only as required-non-empty, not as an int.
+_INT_FIELDS = ("plan_revision", "issue_number", "source_issue", "iteration")
 _TS_FIELDS = ("source_comment_ts", "through_ts")
 
 
@@ -210,16 +213,22 @@ def replay(control_events: list) -> dict:
             task = state["tasks"].setdefault(
                 event["task_id"],
                 {"status": None, "plan_revision": None, "issue_number": None,
-                 "pr_head_sha": None},
+                 "pr_head_sha": None, "iteration": None, "current_attempt_id": None},
             )
             task["status"] = _STATUS_BY_TYPE.get(etype, task["status"])
             if event.get("plan_revision") is not None:
                 task["plan_revision"] = event["plan_revision"]
             if etype == "TASK_CREATED":
                 task["issue_number"] = event["issue_number"]
+                task["iteration"] = event["iteration"]
                 # Discover the task issue so a cold resume scans it; "" = scan all
                 # until a checkpoint advances the floor.
                 state["scan_floor_ts_by_issue"].setdefault(event["issue_number"], "")
+            if etype == "TASK_DISPATCHED":
+                # Latest dispatch wins: the durable single-flight ownership token.
+                # A worker whose attempt_id != current_attempt_id is superseded and
+                # must stop before any side effect.
+                task["current_attempt_id"] = event["attempt_id"]
             if event.get("pr_head_sha"):
                 task["pr_head_sha"] = event["pr_head_sha"]
         # Source-tagged events rebuild the dedupe set (NOT the scan floor).

--- a/task-loop/scripts/control_log.py
+++ b/task-loop/scripts/control_log.py
@@ -30,7 +30,9 @@ import json
 import re
 
 EVENT_FENCE = "task-loop-event"
+RECOVERY_FENCE = "task-loop-recovery"
 _FENCE_RE = re.compile(r"```" + EVENT_FENCE + r"\s*\n(.*?)\n```", re.DOTALL)
+_RECOVERY_FENCE_RE = re.compile(r"```" + RECOVERY_FENCE + r"\s*\n(.*?)\n```", re.DOTALL)
 _TS_FORMAT = "%Y-%m-%dT%H:%M:%SZ"  # GitHub canonical UTC, second granularity
 
 
@@ -44,6 +46,35 @@ def format_event(event: dict) -> str:
 def parse_events(comment_body: str) -> list:
     """Extract all task-loop-event JSON objects from a comment body, in order."""
     return [json.loads(m.group(1)) for m in _FENCE_RE.finditer(comment_body)]
+
+
+def format_recovery(recovery: dict) -> str:
+    """Serialize one worker recovery record as a fenced ```task-loop-recovery JSON
+    block. Recovery records are worker state (append-only, attempt_id-tagged
+    comments), NOT sequenced control events — they are never validated or replayed
+    by the control log; the orchestrator only reads the latest one per attempt."""
+    return "```{fence}\n{body}\n```".format(
+        fence=RECOVERY_FENCE, body=json.dumps(recovery, sort_keys=True)
+    )
+
+
+def parse_recovery(comment_body: str) -> list:
+    """Extract all task-loop-recovery JSON objects from a comment body, in order."""
+    return [json.loads(m.group(1)) for m in _RECOVERY_FENCE_RE.finditer(comment_body)]
+
+
+def latest_recovery(comments: list, attempt_id):
+    """Return the most recent recovery record tagged with `attempt_id`, or None.
+
+    `comments` are (id, created_at, body) triples in GitHub's oldest-first order
+    (as returned by `gh_store.read_comments`); the LAST matching record wins, so
+    records tagged with a different (e.g. superseded) attempt_id are ignored."""
+    found = None
+    for (_id, _created_at, body) in comments:
+        for rec in parse_recovery(body):
+            if rec.get("attempt_id") == attempt_id:
+                found = rec
+    return found
 
 
 def filter_new_inbox(inbox_events: list, seen_uuids) -> list:
@@ -124,6 +155,9 @@ _REQUIRED_FIELDS = {
 # stored as an int here). `attempt_id` is an opaque per-dispatch ownership token
 # (a uuid string), so it is validated only as required-non-empty, not as an int.
 _INT_FIELDS = ("plan_revision", "issue_number", "source_issue", "iteration")
+# `attempt_id` is an opaque ownership token; it must be a non-empty string (a
+# numeric attempt_id would compare/serialize inconsistently across the protocol).
+_STR_FIELDS = ("attempt_id",)
 _TS_FIELDS = ("source_comment_ts", "through_ts")
 
 
@@ -160,6 +194,11 @@ def _validate(event):
             val = event.get(intf)
             if isinstance(val, bool) or not isinstance(val, int):
                 raise ValueError("%s.%s must be an int, got %r" % (etype, intf, val))
+    for sf in _STR_FIELDS:
+        if sf in required and not isinstance(event.get(sf), str):
+            raise ValueError(
+                "%s.%s must be a string, got %r" % (etype, sf, event.get(sf))
+            )
     for tsf in _TS_FIELDS:
         if tsf in required and not _is_canonical_utc(event.get(tsf)):
             raise ValueError(
@@ -210,8 +249,19 @@ def replay(control_events: list) -> dict:
                 )
             state["scan_floor_ts_by_issue"][issue] = through
         else:
+            tid = event["task_id"]
+            if etype == "TASK_CREATED":
+                if tid in state["tasks"]:
+                    raise ValueError(
+                        "duplicate TASK_CREATED for task %r (iteration is assigned once)"
+                        % (tid,)
+                    )
+            elif tid not in state["tasks"]:
+                raise ValueError(
+                    "%s for unestablished task %r (no prior TASK_CREATED)" % (etype, tid)
+                )
             task = state["tasks"].setdefault(
-                event["task_id"],
+                tid,
                 {"status": None, "plan_revision": None, "issue_number": None,
                  "pr_head_sha": None, "iteration": None, "current_attempt_id": None},
             )

--- a/task-loop/skills/create-cycle/SKILL.md
+++ b/task-loop/skills/create-cycle/SKILL.md
@@ -32,7 +32,10 @@ and (b) render them into the skeleton, then scaffold the rest.
   `assets/task-loop-skeleton.md`).
 - `docs/task-loop/directions.md` — the human steering file (from
   `assets/directions-template.md`).
-- `docs/task-loop/logs/` — the per-task decision-record directory (with a `.gitkeep`).
+- `docs/task-loop/logs/` — the iteration-indexed record directory (with a `.gitkeep`). Each cycle
+  writes **one git-tracked record** `<NNN>_<task>.md` with a **Rubric** section (binary acceptance)
+  and a **Decision log** section (decisions + evidence), where `<NNN>` is a zero-padded iteration
+  index from `001` (orchestrator-assigned; see the skeleton's operating principle 8).
 - `.gitignore` entry for `goal-rubric-*.md` scratch (the loop keeps **no** local runtime state — all
   of it lives in the GitHub control issue).
 - The `loop:in-progress` GitHub label (`gh label create loop:in-progress`).

--- a/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
+++ b/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
@@ -50,36 +50,39 @@ orchestrator (`run-cycle`) is the sole integrator and the sole editor of
 ## The cycle
 
 ### 1. Recover & anchor
-Read this task issue's **`RECOVERY` block** (see *RECOVERY ledger* below) and resume by the
-**GitHub-visible-artifact rule**: if a **remote branch and/or PR exists** (the ledger carries
-`attempt_id` + `pr_head_sha`), **adopt** it and resume by `status`; if there is **no remote branch
-and no PR**, any prior work was local-only pre-PR WIP and is **disposable** — abandon it (note the
-reason) and start a fresh attempt from clean `master`. Never depend on adopting a local worktree
-from another machine/session. Read `docs/task-loop/directions.md` first (human steering, highest
-priority). Re-read the source-of-truth docs at the **current `plan_revision`** (the value in
-`docs/task-loop/proposal.md` frontmatter on `master`).
+Read the **latest `task-loop-recovery` comment for your `attempt_id`** on this task issue (see
+*Recovery comments* below) and resume by the **GitHub-visible-artifact rule**: if a **per-attempt
+remote branch and/or PR exists** (the recovery comment carries `pr_head_sha`), **adopt** it and
+resume by `status`; if there is **no remote branch and no PR**, any prior work was local-only pre-PR
+WIP and is **disposable** — abandon it (note the reason) and start fresh from clean `master`. Never
+depend on adopting a local worktree from another machine/session. Read
+`docs/task-loop/directions.md` first (human steering, highest priority). Re-read the source-of-truth
+docs at the **current `plan_revision`** (the value in `docs/task-loop/proposal.md` frontmatter on
+`master`).
 
 ### 2. Confirm the task
-The orchestrator already chose and scoped this task and passed `task_id`,
-`spawned_plan_revision`, and the task issue number in the spawn prompt. Validate the scope
-against the issue; confirm `spawned_plan_revision` matches the proposal on `master`.
+The orchestrator passed `task_id`, `spawned_plan_revision`, `iteration`, `attempt_id`, the
+`control_issue` number, your per-attempt branch, `lead_worktree_root`, and the task issue number.
+Validate the scope against the issue; confirm `spawned_plan_revision` matches the proposal on
+`master` **and** that `attempt_id == current_attempt_id` for your task (replay the `control_issue`).
+If your attempt was superseded, stop now (`superseded_attempt`).
 
-### 3. Create your task branch (you are already in an isolated worktree)
-Your `cycle-worker` agent declares `isolation: worktree`, so the harness **already placed you in
-your own worktree** branched from fresh `master`. **Do not create another** (no
-`using-git-worktrees`, no `git worktree add`) — that nests a redundant tree. Use the
-**deterministic branch name the orchestrator passed** (stable per task, so a respawn reuses it
-rather than forking a duplicate): `git fetch origin`, then **adopt** the remote branch if it
-already exists (`git checkout -B <deterministic-branch> origin/<deterministic-branch>`), else
-create it from the worktree's fresh base (`git checkout -B <deterministic-branch>`) — prefix from
-{{BRANCH_PREFIXES}}. Open the per-cycle record `docs/task-loop/logs/<NNN>_<task>.md` (`<NNN>` =
-the **iteration index** from your spawn prompt, zero-padded from `001`; see operating principle 8)
-with frontmatter `status: in_progress`, `iteration`, `task`, `issue`, `branch`, `attempt_id`,
-`spawned_plan_revision` and an empty **Rubric** + **Decision log** section, and write the initial
-**`RECOVERY` block** to the issue body:
-`status=in_progress`, `resume_from=<step>`, `branch`, `attempt_id`, `spawned_plan_revision`,
-`dirty_tree_expected=yes`. Local pre-PR WIP is **disposable** (not recoverable off-machine) —
-durability begins at the first push (step 9).
+### 3. Verify isolation, then create your attempt branch
+You run in your **own** isolated worktree (your agent declares `isolation: worktree`). **Verify it
+first:** `git rev-parse --show-toplevel`; if it equals `lead_worktree_root`, isolation was **not**
+honored — **stop and post `WORKTREE_ISOLATION_FAILED`**, do nothing else (no checkout, no edits).
+**Do not create another worktree** (no `using-git-worktrees`, no `git worktree add`). Then check out
+an **attempt-scoped local branch** and bind it to your **per-attempt remote branch**
+`<branch>-attempt-<attempt_id>` (so two attempts never write the same ref): `git fetch origin`; if
+`adopt_from_branch` was given, `git checkout -B <local> origin/<adopt_from_branch>`, else
+`git checkout -B <local>` from the fresh base (prefix from {{BRANCH_PREFIXES}}). Open the per-cycle
+record `docs/task-loop/logs/<NNN>_<task>.md` (`<NNN>` = the iteration index from your spawn prompt,
+zero-padded from `001`; see operating principle 8) with frontmatter `status: in_progress`,
+`iteration`, `task`, `issue`, `branch`, `attempt_id`, `spawned_plan_revision` and empty **Rubric** +
+**Decision log** sections, and post your first **`task-loop-recovery` comment** (append-only,
+`attempt_id`-tagged): `status=in_progress`, `resume_from=<step>`, `branch`,
+`worktree=<show-toplevel>`, `attempt_id`, `spawned_plan_revision`. Local pre-PR WIP is **disposable**
+(not recoverable off-machine) — durability begins at the first push (step 9).
 
 ### 4. Define the rubric (binary)
 Use `dev-skills:goal-rubric` to draft a binary pass/fail rubric (each item a test name, a
@@ -116,78 +119,85 @@ docstrings, the relevant source-of-truth sections, stage notes). Route substanti
 history to `docs/CHANGELOG.md`. Commit doc updates **with** the implementation.
 
 ### 9. Open the PR and review with Codex
-Commit with clean, attribution-free text (write the message to a file, `git commit -F`;
-stage files by explicit path). **Before `gh pr create`**, write `RECOVERY: status=creating_pr`
-+ `head_sha=<commit>` to the issue body (see *RECOVERY ledger*). Push and open the PR with a
-clean body file (`gh pr create --body-file`), titled clearly, linking the issue, listing the
-rubric with evidence, and carrying a `Plan-Revision: <spawned_plan_revision>` line.
-**Immediately after**, write `RECOVERY: status=pr_open, pr=#M, pr_head_sha=<sha>,
+Commit with clean, attribution-free text (write the message to a file, `git commit -F`; stage
+files by explicit path). **Before `gh pr create`**, post a `task-loop-recovery` comment
+`status=creating_pr, head_sha=<commit>`. **Push to YOUR per-attempt branch**
+(`git push origin HEAD:<branch>-attempt-<attempt_id>`) and open the PR **from it** with a clean
+body file (`gh pr create --body-file`), titled clearly, linking the issue, listing the rubric with
+evidence, and carrying `Plan-Revision: <spawned_plan_revision>` + `Attempt: <attempt_id>` lines.
+**Immediately after**, post a recovery comment `status=pr_open, pr=#M, pr_head_sha=<sha>,
 resume_from=pr_review`. **Review the PR adversarially with `discuss-with-codex` — every PR** —
-feeding Codex the actual diff; treat the review with `superpowers:receiving-code-review` rigor;
-fix or rebut each point; re-review until no blocking issues. Each review push that changes the
-head updates `pr_head_sha` and stays `status=pr_open`.
+feeding Codex the actual diff; treat the review with `superpowers:receiving-code-review` rigor; fix
+or rebut each point; re-review until no blocking issues. Each review push that changes the head
+posts a recovery comment updating `pr_head_sha` (still `status=pr_open`).
 
 ### 10. Request merge — do NOT merge
-Re-check `spawned_plan_revision` validity at **every irreversible boundary** — before
-finalizing the spec (step 5), before opening the PR (step 9), and before requesting merge here
-— because the orchestrator may have invalidated it. If invalidated at any boundary, write
-`RECOVERY: status=stale_revision_blocked`, post nothing further, and shut down.
+Re-check **both `spawned_plan_revision` AND `attempt_id`** at **every irreversible boundary** —
+before finalizing the spec (step 5), before each push, before opening the PR (step 9), and before
+requesting merge here (replay the `control_issue`). If your revision was invalidated, post a
+recovery comment `status=stale_revision_blocked` and shut down; if `attempt_id != current_attempt_id`
+(a later dispatch superseded you), post `status=superseded_attempt` and shut down — push nothing
+further either way.
 
-If still valid, request merge as an **immutable attempt** (see *RECOVERY ledger*):
-**freeze the branch** (push no more commits), generate a fresh `merge_request_uuid`, write
-`RECOVERY: status=merge_requesting, merge_request_uuid=<u>, merge_request_head_sha=<current
-pr_head_sha>`, then post the **`MERGE_REQUEST` inbox event** (carrying that `pr_head_sha`,
-`uuid`, and `spawned_plan_revision`), then write `RECOVERY: status=merge_requested` and **go
-idle**. The **orchestrator** validates (head-SHA-bound) and merges — it is the sole integrator.
-If a fix is unavoidable after freezing, the attempt is void: return to `status=pr_open`, push
-the fix (new head), and start a **new** attempt with a **new** `uuid` — never reuse a UUID for a
+If still valid **and** current, request merge as an **immutable attempt**: **freeze the branch**
+(push no more commits), generate a fresh `merge_request_uuid`, post a recovery comment
+`status=merge_requesting, merge_request_uuid=<u>, merge_request_head_sha=<current pr_head_sha>`, then
+post the **`MERGE_REQUEST` inbox event** (carrying that `pr_head_sha`, `uuid`,
+`spawned_plan_revision`, and `attempt_id`), then post `status=merge_requested` and **go idle**. The
+**orchestrator** validates (head-SHA-bound, attempt-current) and merges — it is the sole integrator.
+If a fix is unavoidable after freezing, the attempt is void: return to `status=pr_open`, push the fix
+(new head), and start a **new** merge attempt with a **new** `uuid` — never reuse a UUID for a
 different head.
 
 ### 11. Finalize the record
 Finalize the **Decision log** section of `docs/task-loop/logs/<NNN>_<task>.md`: task chosen,
 steering consumed, contracts
 honored, rubric items + pass/fail evidence, Codex dispositions (objections + how each
-resolved), run records for any background jobs, follow-ups filed, and what's next. The
-orchestrator sets the record to `status: complete` after it merges.
+resolved), run records for any background jobs, follow-ups filed, and what's next. After merge the
+orchestrator emits `MERGE_GRANTED` (the durable completion marker); your record is already on
+`master`.
 
-## RECOVERY ledger (so a dead worker is recoverable)
+## Recovery comments (so a dead worker is recoverable)
 
-`RECOVERY` is a fenced block in the **task issue body** (one canonical location, last-write-wins
-via `gh issue edit <task_issue> --body-file <file>`) — **not** a comment and **not** a sequenced
-control event. It is updated as an **ordered pre/post-condition around every irreversible
-external action**, so the orchestrator can always tell *ready-but-unannounced* from
-*still-working*. Fields:
+Recovery state is a series of **append-only, `attempt_id`-tagged `task-loop-recovery` comments** on
+the task issue (`gh issue comment <task_issue> --body-file <file>`) — **never** a mutated issue body
+(two attempts must never write the same surface), and **not** a sequenced control event. Post one at
+each **ordered transition around an irreversible external action**, so the orchestrator (or a cold
+resume) reads the **latest comment for the current `attempt_id`** to tell *ready-but-unannounced*
+from *still-working*. Each is a fenced `task-loop-recovery` JSON block with fields:
 
 ```
-RECOVERY
-status: in_progress | creating_pr | pr_open | merge_requesting | merge_requested | stale_revision_blocked | abandoned
+status: in_progress | creating_pr | pr_open | merge_requesting | merge_requested | stale_revision_blocked | superseded_attempt | abandoned
+attempt_id: <uuid>                        # which attempt this comment belongs to (ALWAYS)
 resume_from: <step>
-branch: <branch>
+branch: <branch>-attempt-<attempt_id>     # your per-attempt remote branch (never shared)
+worktree: <git rev-parse --show-toplevel> # so the orchestrator can clean it after merge
 spawned_plan_revision: <N>
-head_sha: <commit to be PR'd>           # at creating_pr
-pr: "#M"                                  # at pr_open
-pr_head_sha: <sha>                        # at pr_open; updated on each review push
-merge_request_uuid: <uuid>               # at merge_requesting (immutable, bound to next field)
-merge_request_head_sha: <sha>            # at merge_requesting (== pr_head_sha at attempt time)
-dirty_tree_expected: yes|no
+head_sha: <commit to be PR'd>             # at creating_pr
+pr: "#M"                                   # at pr_open
+pr_head_sha: <sha>                         # at pr_open; updated on each review push
+merge_request_uuid: <uuid>                # at merge_requesting (immutable, bound to next field)
+merge_request_head_sha: <sha>             # at merge_requesting (== pr_head_sha at attempt time)
 ```
 
 **Immutable merge-request attempt.** A `merge_request_uuid` is bound to `merge_request_head_sha`.
-Once `status=merge_requesting`, **freeze the branch** — push no more commits. Because the
-control protocol dedupes by `uuid` only, a UUID must never be reused for a different head (a
-later head would be stranded behind the already-seen UUID). If a fix is unavoidable, the attempt
-is void: return to `pr_open`, push the fix (new head), and mint a **new** UUID.
+Once `status=merge_requesting`, **freeze the branch** — push no more commits. Because the control
+protocol dedupes by `uuid` only, a UUID must never be reused for a different head (a later head
+would be stranded behind the already-seen UUID). If a fix is unavoidable, the attempt is void:
+return to `pr_open`, push the fix (new head), and mint a **new** UUID.
 
-**Resume rules** (step 1, by `status`):
+**Resume rules** (step 1, read the latest recovery comment for your `attempt_id`, then by `status`):
 - `in_progress` → resume at `resume_from`.
-- `creating_pr` → check whether a PR already exists for `branch`/`head_sha`
-  (`gh pr list --head <branch>`) before creating one (the post-create write may have been lost).
+- `creating_pr` → check whether a PR already exists for your per-attempt branch
+  (`gh pr list --head <branch>-attempt-<attempt_id>`) before creating one (the post-create comment
+  may have been lost).
 - `pr_open` → resume PR review, or proceed to the merge request.
 - `merge_requesting` → if the current PR head **==** `merge_request_head_sha`, **repost the same
   `merge_request_uuid`** (the orchestrator's UUID dedupe makes the repost a no-op); if the head
   **differs**, discard that UUID, set `status=pr_open` with the new `pr_head_sha`, and start a
   fresh attempt.
 - `merge_requested` → done; await the orchestrator's merge.
+- `superseded_attempt` → a later dispatch owns the task; do nothing.
 
 ## Control-protocol events (how the worker talks to the orchestrator)
 
@@ -199,7 +209,7 @@ attribution hooks). The body is exactly one fenced block:
 
 ````markdown
 ```task-loop-event
-{"kind": "inbox", "uuid": "<fresh-uuid>", "task_id": "<task_id>", "spawned_plan_revision": <N>, "type": "MERGE_REQUEST", "pr_head_sha": "<sha>", "ts": "<YYYY-MM-DDTHH:MM:SSZ>"}
+{"kind": "inbox", "uuid": "<fresh-uuid>", "task_id": "<task_id>", "spawned_plan_revision": <N>, "attempt_id": "<attempt_id>", "type": "MERGE_REQUEST", "pr_head_sha": "<sha>", "ts": "<YYYY-MM-DDTHH:MM:SSZ>"}
 ```
 ````
 
@@ -207,10 +217,11 @@ attribution hooks). The body is exactly one fenced block:
 gh issue comment <task_issue> --body-file <path-to-event-file>
 ```
 
-- `MERGE_REQUEST` — step 10 (carries `pr_head_sha`). The orchestrator answers with a
-  `MERGE_GRANTED`/`MERGE_DENIED` control event on the control issue.
+- `MERGE_REQUEST` — step 10 (carries `pr_head_sha` + `attempt_id`). The orchestrator answers with a
+  `MERGE_GRANTED`/`MERGE_DENIED` control event on the control issue, and **denies it outright if its
+  `attempt_id` is no longer current** (a superseded attempt can never merge).
 - `PLAN_FINDING` — step 7, when a fact invalidates a hypothesis. Same shape **minus**
-  `pr_head_sha` (still include `kind`, `uuid`, `task_id`, `spawned_plan_revision`,
+  `pr_head_sha` (still include `kind`, `uuid`, `task_id`, `spawned_plan_revision`, `attempt_id`,
   `type: "PLAN_FINDING"`, `ts`).
 
 Each inbox event needs a fresh `uuid` (e.g. `uuidgen`) and a `ts`

--- a/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
+++ b/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
@@ -37,6 +37,15 @@ orchestrator (`run-cycle`) is the sole integrator and the sole editor of
    files numbered (`NN_name.ext`) under its feature folder.
 7. **One reviewable unit.** The task is one PR. If it is too big to review in one sitting,
    split it and file the remainder as follow-up issues.
+8. **Per-cycle record & iteration index.** Each cycle writes **one** git-tracked record at
+   `docs/task-loop/logs/<NNN>_<task>.md` with two sections: a **Rubric** (binary acceptance, written
+   in step 4) and a **Decision log** (decisions + evidence, opened in step 3 and finalized in step
+   11). `<NNN>` is the **iteration index** the orchestrator passed in your spawn prompt — a
+   zero-padded 3-digit counter starting at `001` that tracks cycles **chronologically** (one index
+   per task, reused if you are re-dispatched). Create the file in step 3, fill its Rubric in step 4
+   (and also **post the rubric to the issue** as the acceptance interface), keep appending the
+   Decision log through the cycle, and **commit it with your implementation** — it is durable git
+   state, part of your PR. Never skip the Rubric section.
 
 ## The cycle
 
@@ -55,23 +64,30 @@ The orchestrator already chose and scoped this task and passed `task_id`,
 `spawned_plan_revision`, and the task issue number in the spawn prompt. Validate the scope
 against the issue; confirm `spawned_plan_revision` matches the proposal on `master`.
 
-### 3. Branch into an isolated worktree
-Use `superpowers:using-git-worktrees`. Branch from fresh `master` using the **deterministic branch
-name the orchestrator passed** (stable per task, so a respawn reuses it rather than forking a
-duplicate): `git checkout master && git pull && git checkout -B <deterministic-branch>` (prefix
-from {{BRANCH_PREFIXES}}). Open the decision record `docs/task-loop/logs/NNN_<task>_log.md` with
-frontmatter `status: in_progress`, `task`, `issue`, `branch`, `attempt_id`, `spawned_plan_revision`,
-and write the initial **`RECOVERY` block** to the issue body: `status=in_progress`,
-`resume_from=<step>`, `branch`, `attempt_id`, `spawned_plan_revision`, `dirty_tree_expected=yes`.
-Local pre-PR WIP is **disposable** (not recoverable off-machine) — durability begins at the first
-push (step 9).
+### 3. Create your task branch (you are already in an isolated worktree)
+Your `cycle-worker` agent declares `isolation: worktree`, so the harness **already placed you in
+your own worktree** branched from fresh `master`. **Do not create another** (no
+`using-git-worktrees`, no `git worktree add`) — that nests a redundant tree. Use the
+**deterministic branch name the orchestrator passed** (stable per task, so a respawn reuses it
+rather than forking a duplicate): `git fetch origin`, then **adopt** the remote branch if it
+already exists (`git checkout -B <deterministic-branch> origin/<deterministic-branch>`), else
+create it from the worktree's fresh base (`git checkout -B <deterministic-branch>`) — prefix from
+{{BRANCH_PREFIXES}}. Open the per-cycle record `docs/task-loop/logs/<NNN>_<task>.md` (`<NNN>` =
+the **iteration index** from your spawn prompt, zero-padded from `001`; see operating principle 8)
+with frontmatter `status: in_progress`, `iteration`, `task`, `issue`, `branch`, `attempt_id`,
+`spawned_plan_revision` and an empty **Rubric** + **Decision log** section, and write the initial
+**`RECOVERY` block** to the issue body:
+`status=in_progress`, `resume_from=<step>`, `branch`, `attempt_id`, `spawned_plan_revision`,
+`dirty_tree_expected=yes`. Local pre-PR WIP is **disposable** (not recoverable off-machine) —
+durability begins at the first push (step 9).
 
 ### 4. Define the rubric (binary)
 Use `dev-skills:goal-rubric` to draft a binary pass/fail rubric (each item a test name, a
 numeric tolerance, a gate verdict, or an artifact path). **Finalize it via a
 `discuss-with-codex` pass** so it is neither under- nor over-scoped — do not skip this even
-when it looks obvious. Write the durable rubric to `docs/task-loop/logs/NNN_<task>_rubric.md`
-and post it to the issue as acceptance criteria.
+when it looks obvious. Write the durable rubric into the **Rubric section** of
+`docs/task-loop/logs/<NNN>_<task>.md` (the per-cycle record — see operating principle 8), **commit
+it** (it is git-tracked, not scratch), and post the same rubric to the issue as acceptance criteria.
 
 ### 5. Spec → plan → implement
 - Invoke `superpowers:brainstorming` to design — but **decline its user-question and
@@ -128,7 +144,8 @@ the fix (new head), and start a **new** attempt with a **new** `uuid` — never 
 different head.
 
 ### 11. Finalize the record
-Update `docs/task-loop/logs/NNN_<task>_log.md`: task chosen, steering consumed, contracts
+Finalize the **Decision log** section of `docs/task-loop/logs/<NNN>_<task>.md`: task chosen,
+steering consumed, contracts
 honored, rubric items + pass/fail evidence, Codex dispositions (objections + how each
 resolved), run records for any background jobs, follow-ups filed, and what's next. The
 orchestrator sets the record to `status: complete` after it merges.

--- a/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
+++ b/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
@@ -75,7 +75,7 @@ honored — **stop and post `WORKTREE_ISOLATION_FAILED`**, do nothing else (no c
 an **attempt-scoped local branch** and bind it to your **per-attempt remote branch**
 `<branch>-attempt-<attempt_id>` (so two attempts never write the same ref): `git fetch origin`; if
 `adopt_from_branch` was given, `git checkout -B <local> origin/<adopt_from_branch>`, else
-`git checkout -B <local>` from the fresh base (prefix from {{BRANCH_PREFIXES}}). Open the per-cycle
+`git checkout -B <local> origin/master` (the fresh base; prefix from {{BRANCH_PREFIXES}}). Open the per-cycle
 record `docs/task-loop/logs/<NNN>_<task>.md` (`<NNN>` = the iteration index from your spawn prompt,
 zero-padded from `001`; see operating principle 8) with frontmatter `status: in_progress`,
 `iteration`, `task`, `issue`, `branch`, `attempt_id`, `spawned_plan_revision` and empty **Rubric** +
@@ -122,8 +122,9 @@ history to `docs/CHANGELOG.md`. Commit doc updates **with** the implementation.
 Commit with clean, attribution-free text (write the message to a file, `git commit -F`; stage
 files by explicit path). **Before `gh pr create`**, post a `task-loop-recovery` comment
 `status=creating_pr, head_sha=<commit>`. **Push to YOUR per-attempt branch**
-(`git push origin HEAD:<branch>-attempt-<attempt_id>`) and open the PR **from it** with a clean
-body file (`gh pr create --body-file`), titled clearly, linking the issue, listing the rubric with
+(`git push origin HEAD:<branch>-attempt-<attempt_id>`) and open the PR **from it with an explicit
+head**: `gh pr create --head <branch>-attempt-<attempt_id> --base master --body-file <body>`
+(never let `gh` infer the head) — titled clearly, linking the issue, listing the rubric with
 evidence, and carrying `Plan-Revision: <spawned_plan_revision>` + `Attempt: <attempt_id>` lines.
 **Immediately after**, post a recovery comment `status=pr_open, pr=#M, pr_head_sha=<sha>,
 resume_from=pr_review`. **Review the PR adversarially with `discuss-with-codex` — every PR** —
@@ -164,21 +165,24 @@ the task issue (`gh issue comment <task_issue> --body-file <file>`) — **never*
 (two attempts must never write the same surface), and **not** a sequenced control event. Post one at
 each **ordered transition around an irreversible external action**, so the orchestrator (or a cold
 resume) reads the **latest comment for the current `attempt_id`** to tell *ready-but-unannounced*
-from *still-working*. Each is a fenced `task-loop-recovery` JSON block with fields:
+from *still-working*. Each comment body is **exactly one fenced `task-loop-recovery` JSON block**
+(post it with `gh issue comment <task_issue> --body-file <file>` to keep JSON out of the command
+text). Example at `pr_open`:
 
+````markdown
+```task-loop-recovery
+{"attempt_id": "<attempt_id>", "status": "pr_open", "resume_from": "pr_review", "branch": "<branch>-attempt-<attempt_id>", "worktree": "<toplevel>", "spawned_plan_revision": 3, "pr": "#M", "pr_head_sha": "<sha>", "ts": "<YYYY-MM-DDTHH:MM:SSZ>"}
 ```
-status: in_progress | creating_pr | pr_open | merge_requesting | merge_requested | stale_revision_blocked | superseded_attempt | abandoned
-attempt_id: <uuid>                        # which attempt this comment belongs to (ALWAYS)
-resume_from: <step>
-branch: <branch>-attempt-<attempt_id>     # your per-attempt remote branch (never shared)
-worktree: <git rev-parse --show-toplevel> # so the orchestrator can clean it after merge
-spawned_plan_revision: <N>
-head_sha: <commit to be PR'd>             # at creating_pr
-pr: "#M"                                   # at pr_open
-pr_head_sha: <sha>                         # at pr_open; updated on each review push
-merge_request_uuid: <uuid>                # at merge_requesting (immutable, bound to next field)
-merge_request_head_sha: <sha>             # at merge_requesting (== pr_head_sha at attempt time)
-```
+````
+
+Fields: `attempt_id` (**always** — which attempt this comment belongs to); `status` ∈
+`in_progress | creating_pr | pr_open | merge_requesting | merge_requested | stale_revision_blocked |
+superseded_attempt | abandoned`; `resume_from` (step); `branch` (your per-attempt remote branch);
+`worktree` (`git rev-parse --show-toplevel`, so the orchestrator can clean it after merge);
+`spawned_plan_revision`; `head_sha` (at `creating_pr`); `pr` / `pr_head_sha` (at `pr_open`, updated
+on each review push); `merge_request_uuid` + `merge_request_head_sha` (at `merge_requesting`,
+immutable, bound). The orchestrator parses these with `control_log.parse_recovery` /
+`latest_recovery` — the worker only posts the fenced block.
 
 **Immutable merge-request attempt.** A `merge_request_uuid` is bound to `merge_request_head_sha`.
 Once `status=merge_requesting`, **freeze the branch** — push no more commits. Because the control

--- a/task-loop/skills/preflight/SKILL.md
+++ b/task-loop/skills/preflight/SKILL.md
@@ -32,10 +32,11 @@ available-skills list** (that list reflects an installed *and enabled* plugin). 
 a skill to test it** — invoking `brainstorming` / `discuss-with-codex` (etc.) would actually
 *start* it. Check each name against the available skills instead.
 
-Required (10 skills across 2 plugins):
+Required (9 skills across 2 plugins):
 
 - **`superpowers`** — `brainstorming`, `writing-plans`, `test-driven-development`,
-  `verification-before-completion`, `using-git-worktrees`, `finishing-a-development-branch`.
+  `verification-before-completion`, `finishing-a-development-branch`. (Worker isolation is handled
+  by the `cycle-worker` agent's `isolation: worktree` declaration, **not** `using-git-worktrees`.)
 - **`dev-skills`** — `discuss-with-codex`, `goal-rubric`, `doc-update`, `step-workflow`.
 
 **Matching (owner-verified preferred):** the task-loop depends on these *specific plugins'*

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -132,10 +132,13 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
    then emit `PLAN_REVISION_BUMP`), recompute the frontier, and halt dispatch of the stale
    subgraph.
 5. **Dispatch** (unless draining): for each ready task (deps satisfied, not active,
-   revision-compatible), up to the frontier-width cap, emit `TASK_CREATED`/`TASK_DISPATCHED` and
-   spawn **one** `cycle-worker` teammate (`agentType: cycle-worker`) with `task_id`, the task
-   issue number, `spawned_plan_revision` (= current), and the scope.
-6. **Merge** (sole integrator): on a revision-compatible `MERGE_REQUEST`, validate against the
+   revision-compatible), up to the frontier-width cap, emit `TASK_CREATED{…, iteration}` (first time
+   only) + `TASK_DISPATCHED{…, attempt_id}` (every dispatch) and spawn **one** `cycle-worker`
+   teammate (`agentType: cycle-worker`) with `task_id`, the task issue number, `control_issue`,
+   `spawned_plan_revision` (= current), `iteration`, a fresh `attempt_id`, the per-attempt branch
+   `<branch>-attempt-<attempt_id>`, `lead_worktree_root`, and the scope.
+6. **Merge** (sole integrator): on a `MERGE_REQUEST` that is **attempt-current** (`attempt_id ==
+   current_attempt_id`, else `MERGE_DENIED`) and revision-compatible, validate against the
    freshly-drained state and `gh pr merge --squash --delete-branch --match-head-commit <SHA>`;
    emit `MERGE_GRANTED` (or `MERGE_DENIED` + `TASK_STALE`).
 7. **Wait / idle / exit:** wait on teammate idle notifications while workers are active; **idle**
@@ -163,7 +166,8 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
 The control protocol is implemented in the plugin's `scripts/` (`${CLAUDE_PLUGIN_ROOT}/scripts`
 when set, else the installed `task-loop/scripts/`):
 `control_log` (`format_event`, `parse_events`, `filter_new_inbox`, `assign_seq`,
-`unacknowledged_uuids`, `comments_at_or_after_watermark`, `replay`) and `gh_store`
+`unacknowledged_uuids`, `comments_at_or_after_watermark`, `replay`; plus `parse_recovery` /
+`latest_recovery` for reading a worker's per-attempt recovery comments) and `gh_store`
 (`read_comments`, `post_comment`). Use them — do not re-derive sequencing/dedupe/replay by hand.
 
 ## Additional resources

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -118,11 +118,17 @@ For each known task issue (every `tasks[*].issue_number`):
   - Ensure its GitHub task issue exists (`gh issue create`, label `loop:in-progress`).
   - Emit `TASK_CREATED{task_id, plan_revision, issue_number}` and `TASK_DISPATCHED{task_id,
     plan_revision}`.
+  - Assign the task's **iteration index** `NNN` — a zero-padded 3-digit counter from `001`,
+    monotonic across the loop, assigned once at `TASK_CREATED` and **reused on every re-dispatch**
+    of the same task (carry it on `TASK_CREATED`; on recovery rebuild it from the control log /
+    `docs/task-loop/logs/`). It names the worker's `NNN_<task>.md` per-cycle record.
   - Spawn **one** `cycle-worker` teammate (`agentType: cycle-worker`) with a prompt carrying
-    `task_id`, `issue=<n>`, `spawned_plan_revision=<current>`, a fresh `attempt_id`, the
-    **deterministic branch name** (e.g. `<type>-<issue>-<task>`), and the task scope. Record its id
-    in `active_worker_ids`. On a respawn, reuse the deterministic branch so the worker adopts any
-    existing remote branch/PR rather than opening a duplicate (see *Recovery*).
+    `task_id`, `issue=<n>`, `spawned_plan_revision=<current>`, a fresh `attempt_id`, `iteration=NNN`,
+    the **deterministic branch name** (e.g. `<type>-<issue>-<task>`), and the task scope. Record its
+    id in `active_worker_ids`. The teammate declares `isolation: worktree`, so the harness gives it
+    its **own** worktree automatically — do not ask it to create one. On a respawn, reuse the
+    deterministic branch + `iteration` so the worker adopts any existing remote branch/PR rather
+    than opening a duplicate (see *Recovery*).
 
 ### 6. Merge (sole integrator, on a pending `MERGE_REQUEST`)
 A `MERGE_REQUEST` is pending (un-acked) from §3. This step is the **only** place it is acked,
@@ -147,7 +153,7 @@ pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order
   re-drain and re-validate (the worker will have minted a fresh attempt UUID).
 - Emit `MERGE_GRANTED{task_id, plan_revision, pr_head_sha, source_*}`. If invalid, emit
   `MERGE_DENIED{... source_*}` + `TASK_STALE`, and message the worker to stop/rescope.
-- After merge, set the task's `RECOVERY` / `NNN_log.md` to complete and remove the worker from
+- After merge, set the task's `RECOVERY` / `NNN_<task>.md` record to complete and remove the worker from
   `active_worker_ids`.
 
 ### 7. Wait / idle / exit

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -170,13 +170,14 @@ pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order
 - Merge bound to the validated head: `gh pr merge <N> --squash --delete-branch
   --match-head-commit <pr_head_sha>`. If the head changed since validation, the guard fails →
   re-drain and re-validate (the worker will have minted a fresh attempt UUID).
-- Emit `MERGE_GRANTED{task_id, plan_revision, pr_head_sha, source_*}`. If invalid, emit
-  `MERGE_DENIED{... source_*}` + `TASK_STALE`, and message the worker to stop/rescope.
-- After merge, emit `MERGE_GRANTED` (the durable completion marker; the worker's `NNN_<task>.md`
-  record is already on `master`) and remove the worker from `active_worker_ids`. **Worktree
-  cleanup:** if the worker recorded its worktree path (in its recovery comments) and it is local,
-  clean, and matches this task/attempt, remove it (`git worktree remove`); **never** remove a path
-  equal to `lead_worktree_root`.
+- Emit `MERGE_GRANTED{task_id, plan_revision, pr_head_sha, source_*}` — **exactly once** per
+  merged request (it is the durable completion marker, and re-emitting it would duplicate the
+  request's `source_uuid`, which `replay` rejects). If invalid, emit `MERGE_DENIED{... source_*}` +
+  `TASK_STALE`, and message the worker to stop/rescope.
+- After that emit, remove the worker from `active_worker_ids` (the worker's `NNN_<task>.md` record
+  is already on `master`). **Worktree cleanup:** if the worker recorded its worktree path (in its
+  recovery comments) and it is local, clean, and matches this task/attempt, remove it
+  (`git worktree remove`); **never** remove a path equal to `lead_worktree_root`.
 
 ### 7. Wait / idle / exit
 - **Active workers exist** → `waiting`: rely on automatic idle notifications; set a long

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -150,6 +150,9 @@ pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order
   `MERGE_DENIED` (stale attempt) and stop. A superseded attempt could only have written its own
   per-attempt branch, so it can never affect the current attempt's branch/PR. (Every worker inbox
   event carries `attempt_id`; this is the gate that makes the durable single-flight token binding.)
+  **`MERGE_DENIED` only acks the request — it does NOT stale the task** (`replay` no longer maps
+  `MERGE_DENIED → stale`); the task stays `active` under the current attempt. Only the
+  genuine-invalid path (below) pairs `MERGE_DENIED` with an explicit `TASK_STALE`.
 - **Inspect PR state first** (`gh pr view <N> --json state,mergedAt,mergedBy,headRefOid`).
   - **Already merged by this orchestrator** at the recorded head (`mergedBy` == the orchestrator's
     own identity **and** `headRefOid`/merge commit == the validated `pr_head_sha`): a prior turn

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -116,24 +116,39 @@ For each known task issue (every `tasks[*].issue_number`):
   (`spawned_plan_revision` would be the current `plan_revision`). Honor `directions.md` priority.
 - Cap concurrency at the **frontier width** (a small bound, e.g. ≤5). For each chosen task:
   - Ensure its GitHub task issue exists (`gh issue create`, label `loop:in-progress`).
-  - Emit `TASK_CREATED{task_id, plan_revision, issue_number}` and `TASK_DISPATCHED{task_id,
-    plan_revision}`.
-  - Assign the task's **iteration index** `NNN` — a zero-padded 3-digit counter from `001`,
-    monotonic across the loop, assigned once at `TASK_CREATED` and **reused on every re-dispatch**
-    of the same task (carry it on `TASK_CREATED`; on recovery rebuild it from the control log /
-    `docs/task-loop/logs/`). It names the worker's `NNN_<task>.md` per-cycle record.
+  - **Iteration index** `NNN` — a zero-padded 3-digit counter from `001`, monotonic across the
+    loop, **assigned once at `TASK_CREATED`** and reused on every re-dispatch. It is a **required
+    `TASK_CREATED` field**; `replay` stores `tasks[task_id].iteration`, so it is recovered from the
+    **control log**, never reconstructed from `docs/task-loop/logs/` (audit-only). It names the
+    worker's `NNN_<task>.md` record.
+  - **Attempt ownership** — mint a fresh `attempt_id` (uuid) for **this** dispatch. It is a
+    **required `TASK_DISPATCHED` field**; `replay` stores `tasks[task_id].current_attempt_id`
+    (latest dispatch wins) — the **durable single-flight token**. Each attempt writes only its own
+    **per-attempt remote branch** `<branch>-attempt-<attempt_id>`, so two attempts can never write
+    the same ref; a superseded worker can touch only its own dead branch.
+  - Emit `TASK_CREATED{task_id, plan_revision, issue_number, iteration}` (only the first time the
+    task enters the system) and `TASK_DISPATCHED{task_id, plan_revision, attempt_id}` (every
+    dispatch).
   - Spawn **one** `cycle-worker` teammate (`agentType: cycle-worker`) with a prompt carrying
-    `task_id`, `issue=<n>`, `spawned_plan_revision=<current>`, a fresh `attempt_id`, `iteration=NNN`,
-    the **deterministic branch name** (e.g. `<type>-<issue>-<task>`), and the task scope. Record its
-    id in `active_worker_ids`. The teammate declares `isolation: worktree`, so the harness gives it
-    its **own** worktree automatically — do not ask it to create one. On a respawn, reuse the
-    deterministic branch + `iteration` so the worker adopts any existing remote branch/PR rather
-    than opening a duplicate (see *Recovery*).
+    `task_id`, `issue=<n>`, `control_issue=<#>`, `spawned_plan_revision=<current>`, `iteration=NNN`,
+    `attempt_id`, the per-attempt branch `<branch>-attempt-<attempt_id>`, your
+    **`lead_worktree_root`** (`git rev-parse --show-toplevel`, for the worker's isolation
+    self-check), and — when re-dispatching a task that already has a GitHub-visible attempt —
+    `adopt_from_branch=`the latest pushed attempt branch (the new attempt branches *from* it;
+    Option-1: local-only pre-PR WIP is disposable). Record its id in `active_worker_ids`. The
+    teammate declares `isolation: worktree`, so the harness gives it its **own** worktree — never
+    ask it to create one; the worker self-checks isolation and aborts
+    (`WORKTREE_ISOLATION_FAILED`) if its toplevel equals `lead_worktree_root`.
 
 ### 6. Merge (sole integrator, on a pending `MERGE_REQUEST`)
 A `MERGE_REQUEST` is pending (un-acked) from §3. This step is the **only** place it is acked,
 and a `MERGE_GRANTED`/`MERGE_DENIED` is emitted **only after the outcome is durable** — never a
 pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order:
+- **Reject stale attempts first:** if the `MERGE_REQUEST`'s `attempt_id` !=
+  `tasks[task_id].current_attempt_id`, the worker was superseded by a later dispatch → emit
+  `MERGE_DENIED` (stale attempt) and stop. A superseded attempt could only have written its own
+  per-attempt branch, so it can never affect the current attempt's branch/PR. (Every worker inbox
+  event carries `attempt_id`; this is the gate that makes the durable single-flight token binding.)
 - **Inspect PR state first** (`gh pr view <N> --json state,mergedAt,mergedBy,headRefOid`).
   - **Already merged by this orchestrator** at the recorded head (`mergedBy` == the orchestrator's
     own identity **and** `headRefOid`/merge commit == the validated `pr_head_sha`): a prior turn
@@ -153,8 +168,11 @@ pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order
   re-drain and re-validate (the worker will have minted a fresh attempt UUID).
 - Emit `MERGE_GRANTED{task_id, plan_revision, pr_head_sha, source_*}`. If invalid, emit
   `MERGE_DENIED{... source_*}` + `TASK_STALE`, and message the worker to stop/rescope.
-- After merge, set the task's `RECOVERY` / `NNN_<task>.md` record to complete and remove the worker from
-  `active_worker_ids`.
+- After merge, emit `MERGE_GRANTED` (the durable completion marker; the worker's `NNN_<task>.md`
+  record is already on `master`) and remove the worker from `active_worker_ids`. **Worktree
+  cleanup:** if the worker recorded its worktree path (in its recovery comments) and it is local,
+  clean, and matches this task/attempt, remove it (`git worktree remove`); **never** remove a path
+  equal to `lead_worktree_root`.
 
 ### 7. Wait / idle / exit
 - **Active workers exist** → `waiting`: rely on automatic idle notifications; set a long
@@ -198,9 +216,10 @@ an already-stale heartbeat, so two live orchestrators are rare by construction).
 raises on a seq gap/dup or duplicate `source_uuid`, that is **detectable corruption → halt and
 escalate to a human**, never continue.
 
-Event types — **orchestrator-originated** (no source): `TASK_CREATED` (carries `issue_number`),
-`TASK_DISPATCHED`, `PLAN_REVISION_BUMP` (carries `proposal_sha`), `TASK_STALE`,
-`TASK_REVISION_COMPATIBLE`, `INBOX_SCAN_CHECKPOINT` (carries `issue_number` + `through_ts`).
+Event types — **orchestrator-originated** (no source): `TASK_CREATED` (carries `issue_number` +
+`iteration`), `TASK_DISPATCHED` (carries `attempt_id`), `PLAN_REVISION_BUMP` (carries
+`proposal_sha`), `TASK_STALE`, `TASK_REVISION_COMPATIBLE`, `INBOX_SCAN_CHECKPOINT` (carries
+`issue_number` + `through_ts`).
 **Inbox-derived** (carry `source_*`): `MERGE_GRANTED`, `MERGE_DENIED`, `PLAN_FINDING_RECORDED`.
 `replay` validates the schema and raises on a seq gap/dup, a duplicate `source_uuid`, a
 checkpoint for an unknown/regressing issue, or a non-canonical timestamp.
@@ -216,24 +235,31 @@ acknowledged` (every blocked/stale task has a follow-up), `unmerged == 0` (no op
 ## Recovery (cold resume)
 
 A fresh orchestrator on clean `master` rebuilds entirely from GitHub: the control issue (replay →
-revision, dedupe set, scan floors, task statuses), per-task `RECOVERY` ledgers (issue bodies),
-open PRs, and `docs/task-loop/logs/`. Ephemeral teammates and `~/.claude/tasks/` are **not** relied
-upon, and because teammates die with the lead's session a crashed loop 1 leaves **no surviving
-workers** — so respawn is safe. Respawn follows **one rule, the GitHub-visible-artifact line:**
+revision, dedupe set, scan floors, task statuses, **`iteration`**, **`current_attempt_id`**), the
+per-task **append-only recovery comments** (the latest for each task's `current_attempt_id`), open
+PRs, and `docs/task-loop/logs/` (audit only). Ephemeral teammates and `~/.claude/tasks/` are **not**
+relied upon. Because teammates die with the lead's session a crashed loop 1 *usually* leaves no
+surviving workers — but a watchdog **false-positive** (lead alive, heartbeat merely stale) can spawn
+a second lead while a worker still lives, so safety must **not** depend on that: it comes from the
+durable `current_attempt_id` + **per-attempt branches** (below), with ephemerality only making the
+window rare. Respawn follows **one rule, the GitHub-visible-artifact line:**
 
 - **No remote branch and no PR** for a dispatched task → any work was local-only pre-PR WIP, which
   is **disposable**: abandon it and **re-dispatch a fresh attempt** (new `attempt_id`) from clean
   `master`. At most one in-flight task's un-pushed WIP is lost and simply redone — zero correctness
   loss. This is what makes "resume from any session / clean checkout" honest.
-- **A remote branch and/or PR exists** (recorded as `attempt_id` + head SHA in the `RECOVERY`
-  ledger) → **adopt** it via GitHub and drive it to merge. A worker in `pr_open` /
-  `merge_requesting` is *ready but unannounced*.
+- **A per-attempt branch and/or PR exists** → re-dispatch with `adopt_from_branch=`that branch so
+  the new attempt branches **from** it (a *read*, never a write to it) and drives it to merge. The
+  latest recovery comment for `current_attempt_id` tells *ready-but-unannounced* (`pr_open` /
+  `merge_requesting`) from *still-working*.
 
-Dispatch uses **deterministic per-task branch/worktree naming** + an `attempt_id`, so re-dispatch
-and adoption are idempotent: a respawned worker that finds the branch/PR already present adopts or
-aborts — it never opens a second PR. Local-worktree adoption is **only a same-machine
-optimization**, never a correctness requirement. The planning step is idempotent — the same
-frontier is recomputed and only missing workers respawn.
+Each attempt writes **only** its own per-attempt remote branch `<branch>-attempt-<attempt_id>` and
+its own append-only recovery comments — there is **no shared writable ref or body** two attempts can
+race on. A superseded worker (its `attempt_id` != `current_attempt_id`) is harmless: it can touch
+only its own dead branch, and the merge gate denies its `MERGE_REQUEST`. The orchestrator merges
+**only** the current attempt's PR; the durable `current_attempt_id` makes "which attempt owns this
+task" a pure function of the control log, not of a fragile "one worker at a time" assumption. The
+planning step is idempotent — the same frontier is recomputed and only missing workers respawn.
 
 ## Deliberate with Codex
 

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -17,7 +17,8 @@ events = [e for (_id, _ts, body) in raw for e in control_log.parse_events(body)
           if e.get("kind") == "control"]
 state = control_log.replay(events)
 # -> current_plan_revision, current_proposal_sha, last_seq, tasks{task_id:{status,issue_number,
-#    plan_revision,pr_head_sha}}, seen_source_uuids, source_uuid_to_seq, scan_floor_ts_by_issue
+#    plan_revision,pr_head_sha,iteration,current_attempt_id}}, seen_source_uuids,
+#    source_uuid_to_seq, scan_floor_ts_by_issue
 ```
 
 **No local files.** The only mutable runtime cell is the **control-issue body runtime header** — a
@@ -236,7 +237,8 @@ acknowledged` (every blocked/stale task has a follow-up), `unmerged == 0` (no op
 
 A fresh orchestrator on clean `master` rebuilds entirely from GitHub: the control issue (replay →
 revision, dedupe set, scan floors, task statuses, **`iteration`**, **`current_attempt_id`**), the
-per-task **append-only recovery comments** (the latest for each task's `current_attempt_id`), open
+per-task **append-only recovery comments** (read via `control_log.latest_recovery(comments,
+current_attempt_id)`), open
 PRs, and `docs/task-loop/logs/` (audit only). Ephemeral teammates and `~/.claude/tasks/` are **not**
 relied upon. Because teammates die with the lead's session a crashed loop 1 *usually* leaves no
 surviving workers — but a watchdog **false-positive** (lead alive, heartbeat merely stale) can spawn

--- a/task-loop/tests/test_control_log.py
+++ b/task-loop/tests/test_control_log.py
@@ -237,12 +237,27 @@ class TestReplay(unittest.TestCase):
         self.assertEqual(state["current_plan_revision"], 2)
         self.assertEqual(state["tasks"]["T2"]["status"], "stale")
 
-    def test_merge_denied_status_stale(self):
+    def test_merge_denied_alone_does_not_stale_task(self):
+        # A superseded-attempt denial ACKs the request but leaves the task ACTIVE
+        # (the current attempt is still working); only an explicit TASK_STALE stales it.
         events = [_bump(1), _created(2), _dispatched(3),
                   {"kind": "control", "seq": 4, "type": "MERGE_DENIED", "task_id": "T1",
                    "plan_revision": 1, "pr_head_sha": "abc", "source_issue": 12,
                    "source_comment_id": "IC", "source_comment_ts": TS_A,
                    "source_uuid": "u1", "ts": "t"}]
+        state = control_log.replay(events)
+        self.assertEqual(state["tasks"]["T1"]["status"], "active")
+        self.assertEqual(state["seen_source_uuids"], {"u1"})  # still acked (dedupe)
+
+    def test_merge_denied_plus_task_stale_marks_stale(self):
+        # A genuinely-invalid merge: the gate emits MERGE_DENIED (ack) + TASK_STALE.
+        events = [_bump(1), _created(2), _dispatched(3),
+                  {"kind": "control", "seq": 4, "type": "MERGE_DENIED", "task_id": "T1",
+                   "plan_revision": 1, "pr_head_sha": "abc", "source_issue": 12,
+                   "source_comment_id": "IC", "source_comment_ts": TS_A,
+                   "source_uuid": "u1", "ts": "t"},
+                  {"kind": "control", "seq": 5, "type": "TASK_STALE", "task_id": "T1",
+                   "plan_revision": 1, "ts": "t"}]
         self.assertEqual(control_log.replay(events)["tasks"]["T1"]["status"], "stale")
 
     def test_revision_compatible_status_active(self):

--- a/task-loop/tests/test_control_log.py
+++ b/task-loop/tests/test_control_log.py
@@ -118,14 +118,15 @@ def _bump(seq=1, rev=1, sha="deadbeef"):
             "plan_revision": rev, "proposal_sha": sha, "ts": "t"}
 
 
-def _created(seq, task="T1", issue=12, rev=1):
+def _created(seq, task="T1", issue=12, rev=1, iteration=1):
     return {"kind": "control", "seq": seq, "type": "TASK_CREATED", "task_id": task,
-            "plan_revision": rev, "issue_number": issue, "ts": "t"}
+            "plan_revision": rev, "issue_number": issue, "iteration": iteration,
+            "ts": "t"}
 
 
-def _dispatched(seq, task="T1", rev=1):
+def _dispatched(seq, task="T1", rev=1, attempt="att-1"):
     return {"kind": "control", "seq": seq, "type": "TASK_DISPATCHED",
-            "task_id": task, "plan_revision": rev, "ts": "t"}
+            "task_id": task, "plan_revision": rev, "attempt_id": attempt, "ts": "t"}
 
 
 def _checkpoint(seq, issue=12, through=TS_A):
@@ -150,6 +151,37 @@ class TestReplay(unittest.TestCase):
         state = control_log.replay(self._events())
         self.assertEqual(state["seen_source_uuids"], {"u1"})
         self.assertEqual(state["source_uuid_to_seq"]["u1"], 4)
+
+    def test_cold_replay_preserves_iteration(self):
+        # The per-task iteration index must survive a cold replay (it is NOT
+        # reconstructed from docs/task-loop/logs/, which is audit-only).
+        state = control_log.replay([_bump(1), _created(2, iteration=7)])
+        self.assertEqual(state["tasks"]["T1"]["iteration"], 7)
+
+    def test_task_created_requires_iteration(self):
+        bad = _created(2)
+        del bad["iteration"]
+        with self.assertRaises(ValueError):
+            control_log.replay([_bump(1), bad])
+
+    def test_task_created_non_int_iteration_raises(self):
+        bad = _created(2, iteration="001")  # string would not compare/sort as int
+        with self.assertRaises(ValueError):
+            control_log.replay([_bump(1), bad])
+
+    def test_dispatch_stores_current_attempt_id_latest_wins(self):
+        # attempt_id is the durable single-flight ownership token; a re-dispatch
+        # supersedes the prior attempt (latest TASK_DISPATCHED wins).
+        events = [_bump(1), _created(2), _dispatched(3, attempt="att-A"),
+                  _dispatched(4, attempt="att-B")]
+        state = control_log.replay(events)
+        self.assertEqual(state["tasks"]["T1"]["current_attempt_id"], "att-B")
+
+    def test_task_dispatched_requires_attempt_id(self):
+        bad = _dispatched(3)
+        del bad["attempt_id"]
+        with self.assertRaises(ValueError):
+            control_log.replay([_bump(1), _created(2), bad])
 
     def test_acked_event_does_not_advance_scan_floor(self):
         # A merge ack must NOT move the floor (only checkpoints do).

--- a/task-loop/tests/test_control_log.py
+++ b/task-loop/tests/test_control_log.py
@@ -252,12 +252,32 @@ class TestReplay(unittest.TestCase):
         self.assertEqual(control_log.replay(events)["tasks"]["T1"]["status"], "active")
 
     def test_plan_finding_recorded_dedupe_and_status(self):
-        events = [{"kind": "control", "seq": 1, "type": "PLAN_FINDING_RECORDED",
+        events = [_bump(1), _created(2),
+                  {"kind": "control", "seq": 3, "type": "PLAN_FINDING_RECORDED",
                    "task_id": "T1", "source_issue": 12, "source_comment_id": "IC",
                    "source_comment_ts": TS_EARLY, "source_uuid": "uf", "ts": "t"}]
         state = control_log.replay(events)
         self.assertEqual(state["seen_source_uuids"], {"uf"})
-        self.assertIsNone(state["tasks"]["T1"]["status"])
+        # PLAN_FINDING_RECORDED does not change task status (stays "ready").
+        self.assertEqual(state["tasks"]["T1"]["status"], "ready")
+
+    def test_non_string_attempt_id_raises(self):
+        bad = _dispatched(3, attempt=7)  # int, not an opaque uuid string
+        with self.assertRaises(ValueError):
+            control_log.replay([_bump(1), _created(2), bad])
+
+    def test_dispatch_before_create_raises(self):
+        # TASK_DISPATCHED with no prior TASK_CREATED would yield an active task
+        # with issue_number=None / iteration=None — reject it.
+        with self.assertRaises(ValueError):
+            control_log.replay([_bump(1), _dispatched(2)])
+
+    def test_duplicate_task_created_raises(self):
+        # iteration/issue_number are assigned once; a second TASK_CREATED for the
+        # same task_id must not overwrite them.
+        with self.assertRaises(ValueError):
+            control_log.replay([_bump(1), _created(2, iteration=1),
+                                _created(3, iteration=9)])
 
     def test_plan_finding_recorded_requires_source_uuid(self):
         events = [{"kind": "control", "seq": 1, "type": "PLAN_FINDING_RECORDED",
@@ -344,6 +364,36 @@ class TestReplay(unittest.TestCase):
         del bad["source_uuid"]
         with self.assertRaises(ValueError):
             control_log.replay([bad])
+
+
+class TestRecoveryComments(unittest.TestCase):
+    def test_format_parse_round_trip(self):
+        rec = {"attempt_id": "att-1", "status": "pr_open", "pr": "#42",
+               "pr_head_sha": "abc"}
+        body = control_log.format_recovery(rec)
+        self.assertIn("```task-loop-recovery", body)
+        self.assertEqual(control_log.parse_recovery(body), [rec])
+
+    def test_parse_recovery_ignores_event_fences(self):
+        # A task-loop-event block must NOT be parsed as a recovery record.
+        ev = control_log.format_event({"kind": "inbox", "uuid": "u1"})
+        self.assertEqual(control_log.parse_recovery(ev), [])
+
+    def test_latest_recovery_picks_last_for_attempt(self):
+        c1 = ("IC1", TS_EARLY,
+              control_log.format_recovery({"attempt_id": "A", "status": "in_progress"}))
+        c2 = ("IC2", TS_A,
+              control_log.format_recovery({"attempt_id": "A", "status": "pr_open"}))
+        self.assertEqual(control_log.latest_recovery([c1, c2], "A")["status"], "pr_open")
+
+    def test_latest_recovery_ignores_other_attempts(self):
+        c1 = ("IC1", TS_EARLY,
+              control_log.format_recovery({"attempt_id": "A", "status": "pr_open"}))
+        c2 = ("IC2", TS_A,
+              control_log.format_recovery({"attempt_id": "B", "status": "merge_requested"}))
+        # A later comment for a DIFFERENT attempt must not shadow A's record.
+        self.assertEqual(control_log.latest_recovery([c1, c2], "A")["status"], "pr_open")
+        self.assertIsNone(control_log.latest_recovery([c1, c2], "C"))
 
 
 class TestEndToEnd(unittest.TestCase):

--- a/task-loop/tests/test_control_log.py
+++ b/task-loop/tests/test_control_log.py
@@ -399,10 +399,10 @@ class TestRecoveryComments(unittest.TestCase):
 class TestEndToEnd(unittest.TestCase):
     def test_ingest_emit_replay_and_cold_resume_dedupe(self):
         inbox = [
-            {"kind": "inbox", "uuid": "u1", "task_id": "T1", "type": "MERGE_REQUEST",
-             "pr_head_sha": "abc", "ts": "t"},
-            {"kind": "inbox", "uuid": "u1", "task_id": "T1", "type": "MERGE_REQUEST",
-             "pr_head_sha": "abc", "ts": "t"},
+            {"kind": "inbox", "uuid": "u1", "task_id": "T1", "spawned_plan_revision": 1,
+             "attempt_id": "att-1", "type": "MERGE_REQUEST", "pr_head_sha": "abc", "ts": "t"},
+            {"kind": "inbox", "uuid": "u1", "task_id": "T1", "spawned_plan_revision": 1,
+             "attempt_id": "att-1", "type": "MERGE_REQUEST", "pr_head_sha": "abc", "ts": "t"},
         ]
         seeded = [_bump(1), _created(2), _dispatched(3)]
         state = control_log.replay(seeded)


### PR DESCRIPTION
Started as a worktree + log-naming fix; a 6-round discuss-with-codex review (converged, `NO FURTHER OBJECTIONS`) surfaced real worker-concurrency holes, all fixed here.

**Worktree isolation (declared + verified).** `cycle-worker` declares `isolation: worktree` (uniform, automatic — fixes the "some workers got a worktree, some didn't" non-determinism) and **self-checks** it at runtime (`git rev-parse --show-toplevel` != `lead_worktree_root` → `WORKTREE_ISOLATION_FAILED`). Phase-0 adds a hard isolation probe; `using-git-worktrees` dropped from required skills.

**Per-attempt concurrency (no shared writable surfaces).** `attempt_id` is a durable single-flight token (required on `TASK_DISPATCHED`, replay-stored `current_attempt_id`, latest wins). Each attempt writes only its own per-attempt remote branch `<branch>-attempt-<id>`; the orchestrator merges only the current attempt and denies stale-attempt `MERGE_REQUEST`s. RECOVERY moves from a last-writer-wins issue body to append-only, `attempt_id`-tagged recovery comments. Workers fence every side effect on both `spawned_plan_revision` and `attempt_id`. Phase-0 ephemerality is now a hard READY gate.

**Records.** `NNN` is a real required/int/replay-stored `TASK_CREATED` field (zero-padded iteration index from `001`, orchestrator-assigned, reused on re-dispatch); `logs/` is audit-only. Rubric + log consolidated into one git-tracked `<NNN>_<task>.md` (Rubric + Decision-log sections).

Bumps task-loop to 0.7.0 (protocol schema change). 50 unit tests pass. Design: `docs/superpowers/specs/2026-06-13-task-loop-worker-concurrency-conclusion.md`.