### PR TITLE
task-loop: proactive seat-capped dispatch

### DIFF
--- a/docs/superpowers/specs/2026-06-13-cycle-loop-mechanism-conclusion.md
+++ b/docs/superpowers/specs/2026-06-13-cycle-loop-mechanism-conclusion.md
@@ -39,8 +39,15 @@ rather than an iteration count.
   backlog then exit" mode is an optional flag, not the default.)
 
 ### Orchestrator state machine
-- `dispatching` — ready work exists, no stop signal → create/assign tasks.
-- `waiting` — active workers exist → wait on idle notifications.
+**Dispatch is proactive and seat-capped, not a phase:** each turn merges completions **first**, then
+dispatches ready tasks into free seats **up to a cap of 5 concurrent workers** (documented guideline,
+not enforced) — active workers never suppress dispatch of newly-unblocked work while a seat is free
+(a merge unblocks dependents the same turn).
+- `dispatching` — ready work exists, no stop signal → create/assign tasks into free seats, ≤5 in
+  flight per lead session (best-effort; a stale-lead false positive may transiently exceed it,
+  correctness-safe via `attempt_id` fencing; entered even while other workers are active).
+- `waiting` — after filling every free seat, work is in flight → idle notifications + a **bounded,
+  jittered** fallback wake; never a reason to stop dispatching, never a busy-loop.
 - `idle` — no ready work, no active workers, no stop signal → long `ScheduleWakeup` /
   Monitor; **do not exit**.
 - `draining` — stop signal observed → no new dispatch; wait for active workers, bounded

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -207,10 +207,25 @@ purely through the GitHub control issue.
   orchestrator); on resume detect a stale lease and rebuild fast state from the GitHub append-only
   comment log.
 - **check `stop_at` first** → if the clock has reached it, go to `draining`.
-- `dispatching` — read `directions.md` + repo + GitHub; run the **replan barrier** (§8);
-  `TaskCreate` ready tasks with dependency edges; spawn **one `cycle-worker` per ready
-  task** (capped to frontier width).
-- `waiting` — wait on automatic teammate idle notifications.
+- **Merge-first, then proactive seat-capped dispatch** (each turn, after the replan barrier):
+  integrate completed `MERGE_REQUEST`s **before** dispatching, so a merge that finishes a dependency
+  unblocks its dependents the **same turn**. Dispatch is proactive (not a phase) but **bounded** —
+  fill free seats up to a **cap of 5 concurrent workers** (documented guideline, not enforced;
+  best-effort **per lead session** — a watchdog false-positive takeover can transiently exceed it,
+  correctness-safe via durable `attempt_id` fencing); active workers never suppress dispatch of
+  newly-ready work while a seat is free. A long
+  merge-then-multi-dispatch turn re-reads the soft lease before each side-effect group so a busy
+  lead is not mistaken for a dead one.
+- `dispatching` — read `directions.md` + repo + GitHub; run the **replan barrier** (§8); then
+  **select → dispatch** with a **log-derived aging key** (`ready_since` = last-dependency
+  `MERGE_GRANTED` seq, no per-task side effect): spawn **one `cycle-worker`** into each free seat, up
+  to 5 in flight per lead session, **only the selected ≤5 touching GitHub** (entered even while other workers are
+  active; priority → oldest `ready_since` → `proposal.md` Roadmap order, ≥1 seat reserved for the oldest). Dispatchable
+  includes a crashed task (status `active`, no live worker) so recovery uses the same frontier. Issue
+  creation is idempotent (reuse a `Task-Loop-Task: <task_id>`-marked issue) so a crash before
+  `TASK_CREATED` never duplicates.
+- `waiting` — after filling every free seat, rely on automatic teammate idle notifications plus a
+  **bounded, jittered** fallback wake (never a reason to stop dispatching, never a busy-loop).
 - `idle` — frontier empty, nothing active, **no** stop signal → long `ScheduleWakeup`/
   `Monitor`; **does not exit** (continuous service).
 - `draining` — stop signal observed → no new dispatch; let active workers finish, bounded

--- a/docs/superpowers/specs/2026-06-13-task-loop-proactive-dispatch-conclusion.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-proactive-dispatch-conclusion.md
@@ -1,0 +1,103 @@
+# Task-loop proactive seat-capped dispatch — Codex deliberation conclusion
+
+**Date:** 2026-06-13 · **Method:** `dev-skills:discuss-with-codex` (adversarial), 6 rounds (round cap).
+**Outcome:** Goal converged — Codex never disputed the thesis, only hardened the implementation;
+every objection was applied. No `control_log.py` change; **58 unit tests pass** throughout.
+
+## Problem
+
+The orchestrator was "reluctant" to dispatch newly-unblocked tasks: it dispatched **before** merging
+and framed `waiting` (active workers exist) as an alternative to `dispatching`. Because
+`MERGE_GRANTED` is the only event that flips a dependency to `merged` (`control_log.py` status map),
+a task unblocked by a merge could not be dispatched until the *next* turn, and the loop preferred to
+wait on in-flight workers. User directive: when a task is unblocked, submit all possible unblocked
+jobs — but cap concurrency at **5** team agents, as a **documented, not-enforced** guideline.
+
+## Settled position
+
+- **Merge-first → proactive, seat-capped dispatch.** Each turn merges completions (§5) **before**
+  dispatch (§6), so a merge that finishes a dependency unblocks its dependents the **same turn**.
+  Dispatch is proactive (fills free seats with newly-ready tasks, active workers never suppress it)
+  but bounded by a **best-effort, per-lead-session, documented-not-enforced cap of 5** concurrent
+  `cycle-worker` teammates.
+- **`select → dispatch` with a log-derived aging key** (no materialize-first): the frontier and
+  `ready_since(task)` (= seq of the task's last-dependency `MERGE_GRANTED`; `0` for a root) are
+  computed from the replayed log, so **only the ≤5 selected tasks touch GitHub** (a 200-ready
+  frontier still creates ≤5 issues/turn). Order: `directions.md` priority → oldest `ready_since` →
+  `proposal.md` Roadmap declaration order; **reserve ≥1 seat for the oldest** (starvation-free,
+  identical across resumes).
+- **Lease fences within the (now-longer) turn:** re-read + re-confirm the lease before the merge
+  side-effect, **again immediately before `gh pr merge`** (the irreversible action — a same-identity
+  second lead defeats the `mergedBy==self` reconcile, so the only defense is not merging once the
+  lease is lost), and before the dispatch batch. The per-emit check-then-append seq guard still
+  fences each `CONTROL_EVENT`.
+- **Idempotent issue creation:** reuse a `Task-Loop-Task: <task_id>`-marked issue before creating, so
+  a crash between `gh issue create` and the `issue_number`-bearing `TASK_CREATED` never duplicates.
+- **Recovery unified with selection:** orphaned-active tasks (status `active`, no live worker for
+  `current_attempt_id`) are **Dispatchable** through the same frontier. **Takeover damping** defers
+  their re-dispatch by one bounded recovery-probe interval on the first post-takeover turn; §7 has an
+  explicit **deferred-recovery wait state** (bounded jittered probe wake, never long-idle); the
+  pre-exit audit **fails** on deferred recovery candidates so the loop cannot declare false
+  quiescence.
+- **Waking:** idle notifications are primary; fallback is a **bounded, jittered** wake (no aggressive
+  polling) — shorter (still floored/jittered) only for a capped backlog.
+
+## Key decisions
+
+1. Reorder the turn to **merge-before-dispatch** (was dispatch-before-merge).
+2. Dispatch reframed from a *phase* to a *proactive seat-capped action* — active workers never
+   suppress dispatch of newly-ready work while a seat is free.
+3. Cap = **5, documented-not-enforced, best-effort per-lead-session** (user directive). It is a
+   **cost** guideline, not a correctness invariant.
+4. Aging key is **log-derived `ready_since`** — rejected both materialize-first (unbounds GitHub
+   writes + create-before-event hazard) and a new `TASK_READY` event (control-log noise + code).
+5. Correctness under the two-lead window rests on durable `attempt_id` + per-attempt branches, **not**
+   on the worker count.
+
+## Objections raised and how each resolved
+
+1. **(R1) "No new races" too strong — merge-first lengthens the turn, stressing the soft lease.**
+   Applied: intra-turn lease fence before each side-effect group (not just turn start) + end-of-turn
+   heartbeat note.
+2. **(R1) §7 short-wake on active-only = aggressive polling.** Applied: idle-primary + bounded
+   jittered fallback; short wake reserved for a capped backlog.
+3. **(R1) Priority needs a deterministic tie-break/aging.** Applied: priority → oldest `ready_since`
+   → Roadmap order, reserved seat.
+4. **(R2) The claimed §5 merge lease-fence wasn't actually in §5** — `gh pr merge` protected only by
+   the turn-start lease; same-identity reconcile can't tell a stale merge from a valid one. Applied:
+   real §5 fence at step start **and** immediately before `gh pr merge`.
+5. **(R2) Starvation key undefined** — `TASK_CREATED` seq doesn't exist for unchosen tasks. Initially
+   adopted Codex's materialize-first suggestion…
+6. **(R3) …which overcorrected:** materialize-first bounds workers but **unbounds** GitHub issue
+   creation (200 ready → 200 issues) and adds a create-before-`TASK_CREATED` duplicate hazard.
+   Applied: **reverted** to a log-derived `ready_since` key (zero side effect for unselected tasks) +
+   idempotent issue creation.
+7. **(R3) Recovery/selection misalign** — a crashed task stays status `active`; §6 selected only
+   `ready`. Applied: **Dispatchable** explicitly includes "active with no live worker"; Recovery
+   section links to it.
+8. **(R4) "Never exceed 5" is false in the documented watchdog-false-positive window** (two leads,
+   each can't see the other's ephemeral teammates → transient ~2×). Applied: reframed the cap as
+   **best-effort per-lead-session**, correctness-safe via attempt fencing; added **takeover damping**;
+   declined durable worker-heartbeat enforcement as out-of-scope (user set the cap not-enforced).
+9. **(R5) Takeover damping had no §7 wait state** — deferred recovery candidates could fall through to
+   long idle / pass the pre-exit audit. Applied: explicit §7 deferred-recovery case + audit gate.
+10. **(R6) Tie-break cited the wrong file** — `task-loop.md` is the per-task worker playbook, not the
+    task roadmap. Applied: tie-break now uses the **`proposal.md` Roadmap** declaration order (the
+    source §4 already computes the frontier from); SKILL.md + design spec updated to match.
+
+## Accepted (residual) tension
+
+The 5-worker cap is **not globally enforced**: a watchdog false-positive takeover can transiently run
+up to ~2× the cap until the superseded attempts hit their merge-gate/lease fences and stop. This is
+accepted as a **correctness-safe, transient cost overrun** (only one attempt can ever merge, by
+durable `current_attempt_id` + per-attempt branches), consistent with the user's directive that the
+cap be a documented-not-enforced guideline. Takeover damping shrinks but does not eliminate the
+window. A true global cap would require durable per-worker liveness heartbeats — deliberately out of
+scope.
+
+## How it ended
+
+Round cap (6) reached. Objections narrowed monotonically from broad hardening (R1) to a single
+file-reference correction (R6); the thesis (merge-first proactive seat-capped dispatch) was never
+disputed. The final objection was applied, so the goal is considered **converged**, with the residual
+cap tension explicitly recorded above.

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.7.0"
+  "version": "0.8.0"
 }

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -124,27 +124,43 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
 3. **Event-drain & ingest:** read each task issue's comments at/after its scan floor, dedupe by
    UUID, **process findings before merge requests**. Ack a fresh `PLAN_FINDING` here (one
    `PLAN_FINDING_RECORDED`); a fresh `MERGE_REQUEST` is **not** acked here — it is collected as a
-   *pending decision* acked only by the merge gate (§6). Advance a per-issue scan checkpoint only
+   *pending decision* acked only by the merge gate (§5). Advance a per-issue scan checkpoint only
    through a fully-acked prefix, so a pending merge request pins the floor and is re-ingested
    until decided.
 4. **Replan barrier:** read `directions.md` (highest priority); if a finding invalidated a
    hypothesis, **materialize** a new `plan_revision` (merge the proposal-update PR to `master`,
    then emit `PLAN_REVISION_BUMP`), recompute the frontier, and halt dispatch of the stale
    subgraph.
-5. **Dispatch** (unless draining): for each ready task (deps satisfied, not active,
-   revision-compatible), up to the frontier-width cap, emit `TASK_CREATED{…, iteration}` (first time
-   only) + `TASK_DISPATCHED{…, attempt_id}` (every dispatch) and spawn **one** `cycle-worker`
-   teammate (`agentType: cycle-worker`) with `task_id`, the task issue number, `control_issue`,
-   `spawned_plan_revision` (= current), `iteration`, a fresh `attempt_id`, the per-attempt branch
-   `<branch>-attempt-<attempt_id>`, `lead_worktree_root`, and the scope.
-6. **Merge** (sole integrator): on a `MERGE_REQUEST` that is **attempt-current** (`attempt_id ==
-   current_attempt_id`, else `MERGE_DENIED`) and revision-compatible, validate against the
-   freshly-drained state and `gh pr merge --squash --delete-branch --match-head-commit <SHA>`;
-   emit `MERGE_GRANTED` (or `MERGE_DENIED` + `TASK_STALE`).
-7. **Wait / idle / exit:** wait on teammate idle notifications while workers are active; **idle**
-   (long `ScheduleWakeup`, do **not** exit) when the frontier is empty with no stop signal;
-   when draining completes, run the recorded **pre-exit audit** and a **two-phase quiescence
-   exit** (cooldown + re-audit) before stopping.
+5. **Merge first** (sole integrator): integrate completions **before** dispatching so a merge that
+   finishes a dependency unblocks its dependents this same turn. **Re-confirm the lease before `gh pr
+   merge` — never merge after losing it** (a same-identity second lead makes the reconcile path
+   unable to tell a stale merge from a valid one). On a `MERGE_REQUEST` that is **attempt-current**
+   (`attempt_id == current_attempt_id`, else `MERGE_DENIED`) and revision-compatible, validate
+   against the freshly-drained state and `gh pr merge --squash --delete-branch --match-head-commit
+   <SHA>`; emit `MERGE_GRANTED` (or `MERGE_DENIED` + `TASK_STALE`).
+6. **Dispatch — proactive, seat-capped** (unless draining): re-confirm the lease, then from the
+   **post-merge** state **select → dispatch**. The frontier and the **aging key are log-derived**
+   (`ready_since` = the seq of a task's last-dependency `MERGE_GRANTED`), so **only the ≤5 selected
+   tasks touch GitHub** — a 200-task frontier still creates ≤5 issues. **Dispatchable** = deps merged
+   + revision-compatible + (status `ready` **or** `active` with no live worker — an orphaned attempt
+   recovered via `adopt_from_branch`); a **live** worker, `merged`, or `stale` is excluded. **Select**
+   up to **5 concurrent `cycle-worker` teammates** (documented guideline, not enforced) by
+   `directions.md` priority, then oldest `ready_since`, then `proposal.md` Roadmap order, reserving ≥1
+   seat for the oldest (starvation-free). **Active workers never suppress dispatch, but a lead never
+   *intentionally* exceeds 5 in flight** (best-effort per-session cap; a watchdog false-positive
+   takeover may transiently exceed it, correctness-safe via attempt fencing). **Dispatch** each
+   selected task: idempotently create/reuse its `Task-Loop-Task:
+   <task_id>`-marked issue, emit `TASK_CREATED{…, iteration}` (first dispatch) + `TASK_DISPATCHED{…,
+   attempt_id}`, and spawn **one** `cycle-worker` teammate (`agentType: cycle-worker`) with `task_id`,
+   the task issue number, `control_issue`, `spawned_plan_revision` (= current), `iteration`, a fresh
+   `attempt_id`, the per-attempt branch `<branch>-attempt-<attempt_id>`, `lead_worktree_root`, and
+   the scope.
+7. **Wait / idle / exit:** reached only after §6 has filled every free seat it can. Teammate **idle
+   notifications are the primary wake**; add a **bounded, jittered** fallback `ScheduleWakeup`
+   (shorter when a capped backlog waits on a freeing seat, never a busy-loop); **idle** (long
+   `ScheduleWakeup`, do **not** exit) only when the frontier is empty with no stop signal; when
+   draining completes, run the recorded **pre-exit audit** and a **two-phase quiescence exit**
+   (cooldown + re-audit) before stopping.
 
 ## Hard invariants
 
@@ -155,6 +171,12 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
 - **Merge gates:** every merge passes the **pre-merge event-drain barrier** and is
   **head-SHA-bound** (`--match-head-commit`); no revision becomes current until its
   proposal-update PR is merged to `master` (materialization).
+- **Proactive, seat-capped dispatch:** each turn merges completions **first**, then dispatches ready
+  tasks into free seats **up to 5 concurrent workers** (documented guideline, not enforced). Active
+  workers never suppress dispatch — a task unblocked by a merge is submitted the **same turn** if a
+  seat is free — but a lead never *intentionally* runs >5 (best-effort per-session cap; a watchdog
+  false-positive may transiently exceed it, bounded by attempt fencing); selection is
+  priority-then-oldest-ready (starvation-free).
 - **Continuous service:** "no ready work" is `idle`, never exit. Termination is a scheduled
   **drain-signal**, with a bounded, non-destructive drain (overdue workers →
   `orphaned_acknowledged`).

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -49,8 +49,23 @@ because the lease loser exits — but two near-simultaneous writers are possible
 
 ## State machine
 
-- **dispatching** — ready work exists, `stop_at` not reached → create tasks + spawn workers.
-- **waiting** — active workers exist → wait on automatic teammate idle notifications.
+**Dispatch is a seat-capped action, not a phase.** Every turn — *after* merging completions (§5) —
+the orchestrator fills every **free worker seat** with a ready task, up to a **fixed cap of 5**
+concurrent `cycle-worker` teammates (5 tasks in flight), **whether or not other workers are still
+active**. It is **proactive** (a task unblocked this turn is dispatched this turn) but **bounded**
+(never more than 5 *intentionally* per lead session — see §6 for the watchdog-false-positive caveat)
+— active workers never suppress dispatch of newly-ready work *as long as a seat is free*. `waiting` is what the orchestrator does *after* it has filled every seat it
+can, not an alternative to dispatching. Re-entering a turn always re-runs merge→dispatch first.
+The 5-seat cap is a **documented guideline in this prompt, not a programmatically enforced limit**.
+The phases:
+
+- **dispatching** — creating tasks + spawning workers for ready tasks this turn. Entered whenever
+  any ready task exists and `stop_at` is not reached — **including while other workers are active**
+  (a §5 merge or a freed concurrency slot just unblocked it).
+- **waiting** — after filling every free seat, work is in flight. Teammate idle notifications are
+  the **primary** wake; add a **bounded, jittered** fallback `ScheduleWakeup` — shorter only when a
+  capped backlog waits on a freeing seat, never aggressive polling, never a busy-loop (see §7).
+  `waiting` never means "stop dispatching" — the next turn re-runs §5→§6 first.
 - **idle** — no ready work, no active workers, `stop_at` not reached → long `ScheduleWakeup`
   (capped so it never sleeps past `stop_at`); **do not exit** (continuous service).
 - **draining** — clock reached `stop_at` → no new dispatch; wait for active workers, bounded
@@ -88,7 +103,7 @@ For each known task issue (every `tasks[*].issue_number`):
   with exactly one `PLAN_FINDING_RECORDED` (carrying `source_issue`, `source_comment_id` = the gh
   comment node-id, `source_comment_ts` = the comment's `createdAt`, `source_uuid` = the inbox
   `uuid`). A fresh `MERGE_REQUEST` is **not** acked here — it is a *pending decision* acked only
-  by the merge gate (§6, `MERGE_GRANTED`/`MERGE_DENIED`), because the only legal source-tagged
+  by the merge gate (§5, `MERGE_GRANTED`/`MERGE_DENIED`), because the only legal source-tagged
   events for it are merge *outcomes*. `control_log.unacknowledged_uuids(fresh, emitted)` is used
   to **list the pending merge requests**, not as a must-be-empty gate. (Findings must fully ack;
   merge requests legitimately remain pending.)
@@ -112,39 +127,19 @@ For each known task issue (every `tasks[*].issue_number`):
   `depends_on_hypotheses`. Mark every task in the invalidated subgraph `TASK_STALE` and **halt
   its dispatch**. If a finding's blast radius can't be mapped confidently, **freeze broadly**.
 
-### 5. Dispatch (skip if draining)
-- Choose ready tasks: dependencies complete, not currently active, and revision-compatible
-  (`spawned_plan_revision` would be the current `plan_revision`). Honor `directions.md` priority.
-- Cap concurrency at the **frontier width** (a small bound, e.g. ≤5). For each chosen task:
-  - Ensure its GitHub task issue exists (`gh issue create`, label `loop:in-progress`).
-  - **Iteration index** `NNN` — a zero-padded 3-digit counter from `001`, monotonic across the
-    loop, **assigned once at `TASK_CREATED`** and reused on every re-dispatch. It is a **required
-    `TASK_CREATED` field**; `replay` stores `tasks[task_id].iteration`, so it is recovered from the
-    **control log**, never reconstructed from `docs/task-loop/logs/` (audit-only). It names the
-    worker's `NNN_<task>.md` record.
-  - **Attempt ownership** — mint a fresh `attempt_id` (uuid) for **this** dispatch. It is a
-    **required `TASK_DISPATCHED` field**; `replay` stores `tasks[task_id].current_attempt_id`
-    (latest dispatch wins) — the **durable single-flight token**. Each attempt writes only its own
-    **per-attempt remote branch** `<branch>-attempt-<attempt_id>`, so two attempts can never write
-    the same ref; a superseded worker can touch only its own dead branch.
-  - Emit `TASK_CREATED{task_id, plan_revision, issue_number, iteration}` (only the first time the
-    task enters the system) and `TASK_DISPATCHED{task_id, plan_revision, attempt_id}` (every
-    dispatch).
-  - Spawn **one** `cycle-worker` teammate (`agentType: cycle-worker`) with a prompt carrying
-    `task_id`, `issue=<n>`, `control_issue=<#>`, `spawned_plan_revision=<current>`, `iteration=NNN`,
-    `attempt_id`, the per-attempt branch `<branch>-attempt-<attempt_id>`, your
-    **`lead_worktree_root`** (`git rev-parse --show-toplevel`, for the worker's isolation
-    self-check), and — when re-dispatching a task that already has a GitHub-visible attempt —
-    `adopt_from_branch=`the latest pushed attempt branch (the new attempt branches *from* it;
-    Option-1: local-only pre-PR WIP is disposable). Record its id in `active_worker_ids`. The
-    teammate declares `isolation: worktree`, so the harness gives it its **own** worktree — never
-    ask it to create one; the worker self-checks isolation and aborts
-    (`WORKTREE_ISOLATION_FAILED`) if its toplevel equals `lead_worktree_root`.
-
-### 6. Merge (sole integrator, on a pending `MERGE_REQUEST`)
-A `MERGE_REQUEST` is pending (un-acked) from §3. This step is the **only** place it is acked,
-and a `MERGE_GRANTED`/`MERGE_DENIED` is emitted **only after the outcome is durable** — never a
-pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order:
+### 5. Merge first (sole integrator, on a pending `MERGE_REQUEST`)
+**Integrate completions before dispatching** so a merge that finishes a dependency unblocks its
+dependents **this same turn** (§6), never a turn later. A `MERGE_REQUEST` is pending (un-acked)
+from §3. This step is the **only** place it is acked, and a `MERGE_GRANTED`/`MERGE_DENIED` is
+emitted **only after the outcome is durable** — never a pre-merge "granted." Crash-safe via
+idempotent reconciliation.
+**Lease fence (required):** refresh + re-read the lease and re-confirm you still own it **at the
+start of this step and again immediately before `gh pr merge`** — `gh pr merge` is the most
+dangerous (irreversible) side effect and the turn-start lease alone is insufficient on a long turn.
+A second lead shares this orchestrator's GitHub identity, so the `mergedBy == self` reconcile path
+below **cannot** distinguish a valid prior owner from a stale owner who merged *after* losing the
+lease — therefore the only defense is **not merging once the lease is lost**. If you've lost it,
+abort the turn without merging or emitting. Act in this order:
 - **Reject stale attempts first:** if the `MERGE_REQUEST`'s `attempt_id` !=
   `tasks[task_id].current_attempt_id`, the worker was superseded by a later dispatch → emit
   `MERGE_DENIED` (stale attempt) and stop. A superseded attempt could only have written its own
@@ -167,7 +162,8 @@ pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order
 - Re-confirm the task is **revision-compatible** (`spawned_plan_revision == current_plan_revision`
   or explicitly `TASK_REVISION_COMPATIBLE`) and not `TASK_STALE`.
 - Confirm CI/review state and that the worker's Codex PR review had no blocking issues.
-- Merge bound to the validated head: `gh pr merge <N> --squash --delete-branch
+- **Re-read the lease one last time (final fence) — if you no longer own it, do NOT merge** — then
+  merge bound to the validated head: `gh pr merge <N> --squash --delete-branch
   --match-head-commit <pr_head_sha>`. If the head changed since validation, the guard fails →
   re-drain and re-validate (the worker will have minted a fresh attempt UUID).
 - Emit `MERGE_GRANTED{task_id, plan_revision, pr_head_sha, source_*}` — **exactly once** per
@@ -179,9 +175,103 @@ pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order
   recovery comments) and it is local, clean, and matches this task/attempt, remove it
   (`git worktree remove`); **never** remove a path equal to `lead_worktree_root`.
 
+### 6. Dispatch — proactive, seat-capped (skip if draining)
+**Lease fence first:** before this batch, **refresh + re-read the lease and re-confirm you still own
+it** — a merge-then-multi-dispatch turn can run long, and a mid-turn stale heartbeat could let the
+watchdog presume the lead dead and spawn a second one (the lease is a *soft* guard, §1/§"Emitting
+control events"). If you've lost it, **abort the turn without emitting**. The per-emit
+check-then-append seq guard still fences every individual `CONTROL_EVENT`; this fence keeps the
+heartbeat fresh across the long turn so the race stays vanishingly rare. Then recompute the frontier
+from the **post-merge** state and dispatch ready tasks into every **free worker seat**, up to the
+**5-seat cap**. **Proactive, not reluctant — but bounded:** do **not** hold a ready task back because
+other workers are still in flight (fill a free seat), and do **not** exceed 5 concurrent workers.
+When a §5 merge (or a freed seat) unblocks tasks, dispatch as many as fit the free seats now, this
+turn.
+The turn proceeds **select → dispatch**. The frontier **and the aging key are derived from the log**,
+so **no per-task side effect happens before selection** — only the ≤5 *selected* tasks touch GitHub,
+keeping the side-effect batch bounded even with hundreds of ready tasks (a 200-ready frontier still
+creates ≤5 issues this turn).
+
+- **Dispatchable** = dependencies complete (each dep's `MERGE_GRANTED` is in the log → status
+  `merged`), revision-compatible (`spawned_plan_revision` would be the current `plan_revision`), and
+  **either** status `ready` (never dispatched) **or** status `active` with **no live worker** for its
+  `current_attempt_id` (an orphaned/crashed attempt — re-dispatched as a *recovery*, branching from
+  `adopt_from_branch`; see *Recovery*). **Exclude** tasks with a **live** worker, `merged`, or
+  `stale`. (Status `active` alone is **not** "in flight" — on a cold resume `active_worker_ids` is
+  empty, so every un-merged dispatched task is a recovery candidate, never stranded.)
+- **Aging key (log-derived, zero side effect):** `ready_since(task)` = the seq of its **last
+  dependency's `MERGE_GRANTED`** (or `0` for a dependency-free root). It needs **no** per-task event
+  or issue, so an unselected task costs **nothing** on GitHub and the key is a pure function of the
+  replayed log — identical across resumes.
+- **Select** up to the number of free seats (deterministic, starvation-free): order by (1)
+  `directions.md` priority, then (2) **oldest** `ready_since`, then (3) the task/stage declaration
+  order in the **`docs/task-loop/proposal.md` Roadmap** (the task source §4 computes the frontier
+  from — *not* the per-task worker playbook `task-loop.md`) as the final tie-break. **Reserve ≥1 of
+  the 5 seats for the oldest dispatchable task** (a max-skip rule) so a stream of high-priority work
+  cannot starve it.
+- **Seat cap = 5** simultaneous `cycle-worker` teammates (one task each → at most 5 in flight **per
+  lead session**, **counting recovery re-dispatches**). A **documented, best-effort guideline in this prompt, not a
+  programmatically enforced limit** — a lead never *intentionally* runs more than 5. Tasks beyond the
+  cap are simply **not selected** this turn — they remain dispatchable (no issue, no event yet) and
+  win a seat as one frees (§7's bounded wake), never abandoned.
+  - **The cap is per-lead-session, not global.** Its one documented breach is a watchdog
+    **false-positive takeover** (a second lead spawns while the first's workers still live, see
+    *Recovery*): the new lead **cannot observe the old lead's teammates** (ephemeral, invisible across
+    sessions), so it may re-dispatch their `active` tasks and transiently run up to ~2× the cap until
+    the superseded attempts hit their merge-gate/lease fences and stop. That overshoot is
+    **correctness-safe** (durable `current_attempt_id` + per-attempt branches mean only one attempt
+    can ever merge) and **transient** — a bounded *cost* overrun, never a broken invariant. A true
+    global cap would need durable per-worker liveness heartbeats; that enforcement machinery is
+    deliberately **out of scope** (the cap is a guideline, not an invariant).
+  - **Takeover damping** (shrinks, does not eliminate, the overshoot): on the **first** turn after
+    taking over a stale lease, defer re-dispatch of `active`-status tasks by one bounded
+    recovery-probe interval before reclassifying them as orphaned — so a merely-stalled prior lead
+    does not instantly get its worker count doubled. Steady-state turns skip the delay.
+- **Dispatch each selected task** (≤5 — the only GitHub writes of this step):
+  - **Idempotent issue creation (crash-safe):** before `gh issue create`, search for an existing
+    issue carrying a `Task-Loop-Task: <task_id>` marker line and **reuse it** if found; otherwise
+    create one (label `loop:in-progress`) with that marker. This makes "create issue → emit
+    `TASK_CREATED`" recoverable: a crash *after* the issue exists but *before* the durable
+    `TASK_CREATED` is reconciled next turn by finding the marked issue and emitting `TASK_CREATED`
+    for it — **never a duplicate issue**.
+  - **Iteration index** `NNN` — a zero-padded 3-digit counter from `001`, monotonic across the loop,
+    **assigned once at `TASK_CREATED`** and reused on every re-dispatch (a **required `TASK_CREATED`
+    field**; `replay` stores `tasks[task_id].iteration`, recovered from the control log, never from
+    `docs/task-loop/logs/` (audit-only)). It names the worker's `NNN_<task>.md` record.
+  - Emit `TASK_CREATED{task_id, plan_revision, issue_number, iteration}` the **first time the task is
+    dispatched** (`replay` rejects a duplicate, enforcing once-only).
+  - **Attempt ownership:** mint a fresh `attempt_id` (uuid) and emit
+    `TASK_DISPATCHED{task_id, plan_revision, attempt_id}` (a **required field**; `replay` stores
+    `current_attempt_id`, latest wins — the **durable single-flight token**). Each attempt writes only
+    its own **per-attempt remote branch** `<branch>-attempt-<attempt_id>`, so two attempts can never
+    write the same ref; a superseded worker can touch only its own dead branch.
+  - Spawn **one** `cycle-worker` teammate (`agentType: cycle-worker`) with a prompt carrying
+    `task_id`, `issue=<n>`, `control_issue=<#>`, `spawned_plan_revision=<current>`, `iteration=NNN`,
+    `attempt_id`, the per-attempt branch `<branch>-attempt-<attempt_id>`, your **`lead_worktree_root`**
+    (`git rev-parse --show-toplevel`, for the worker's isolation self-check), and — when
+    re-dispatching a task that already has a GitHub-visible attempt — `adopt_from_branch=`the latest
+    pushed attempt branch (the new attempt branches *from* it; Option-1: local-only pre-PR WIP is
+    disposable). Record its id in `active_worker_ids`. The teammate declares `isolation: worktree`, so
+    the harness gives it its **own** worktree — never ask it to create one; the worker self-checks
+    isolation and aborts (`WORKTREE_ISOLATION_FAILED`) if its toplevel equals `lead_worktree_root`.
+
 ### 7. Wait / idle / exit
-- **Active workers exist** → `waiting`: rely on automatic idle notifications; set a long
-  `ScheduleWakeup` fallback. Drop `active_worker_ids` entries as workers report and are merged.
+Reached **only after §6 has filled every free seat it can** — never sleep with a free seat and ready
+work.
+- **Workers active, no capped backlog** → `waiting`: automatic teammate **idle notifications are the
+  primary wake** (a worker reporting done triggers §5→§6 the next turn); add only a **bounded
+  heartbeat-interval fallback** `ScheduleWakeup` **with jitter**. Do **not** poll aggressively —
+  active workers alone are not a reason to wake early.
+- **Ready tasks remain but all 5 seats are full** → `waiting` with a **shorter, still-floored +
+  jittered** fallback wake — a freeing seat also emits an idle notification, so this only backstops a
+  missed one; the next turn re-runs §5→§6 to fill the freed seat. **Never busy-loop:** the floor +
+  idle notifications bound the rate. Drop `active_worker_ids` entries as workers report and are merged.
+- **Deferred recovery candidates exist** (first turn after a stale-lease takeover — §6 takeover
+  damping is holding `active`-status tasks for one recovery-probe interval) → `waiting`: schedule the
+  **bounded recovery-probe wake (jittered)**; **do not `idle` or exit**. These are *not* "frontier
+  empty" — they are damped recovery work, and the very next turn (after the probe interval) §6
+  reclassifies and re-dispatches them. They also fail the pre-exit audit (below), so the loop cannot
+  declare quiescence while recovery is merely deferred.
 - **Frontier empty, none active, `stop_at` not reached** → `idle`: long `ScheduleWakeup` (capped
   to wake by `stop_at`); **do not exit**.
 - **draining** → dispatch nothing; wait for active workers until `drain_deadline_at`; past the
@@ -195,7 +285,10 @@ pre-merge "granted." Crash-safe via idempotent reconciliation; act in this order
 ### 8. Heartbeat
 Refresh the lease `heartbeat`/`expires_at` (and advisory `phase`/`stop_at`/schedule handles) by
 writing the **control-issue body header** (`gh issue edit`). This is the only durable write of the
-turn besides the appended `CONTROL_EVENT` comments — there is no local cache to persist.
+turn besides the appended `CONTROL_EVENT` comments — there is no local cache to persist. This
+end-of-turn refresh is **in addition to** the intra-turn lease re-reads §5/§6 perform before their
+side-effect groups; together they keep the heartbeat fresh across a long merge-then-multi-dispatch
+turn so a busy lead is never mistaken for a dead one.
 
 ## Emitting control events
 
@@ -232,10 +325,13 @@ checkpoint for an unknown/regressing issue, or a non-canonical timestamp.
 ## Pre-exit audit (recorded, real outputs)
 
 Before writing `phase: exiting`, prove with actual command output (`superpowers:verification-
-before-completion`): `ready == 0` (no dispatchable tasks), `active == 0`
-(`active_worker_ids` empty, no open `loop:in-progress` without a merged PR), `blocked ==
-acknowledged` (every blocked/stale task has a follow-up), `unmerged == 0` (no open PR awaiting a
-`MERGE_REQUEST`). Re-run it after the cooldown; only an all-clear second pass permits exit.
+before-completion`): `ready == 0` (no **dispatchable** tasks — counting any `active`-status task with
+no live worker, i.e. a **deferred recovery candidate**, as dispatchable), `active == 0`
+(`active_worker_ids` empty **and** no `active`-status task in the log awaiting (re-)dispatch, and no
+open `loop:in-progress` without a merged PR), `blocked == acknowledged` (every blocked/stale task has
+a follow-up), `unmerged == 0` (no open PR awaiting a `MERGE_REQUEST`). A damped/deferred recovery
+candidate therefore **fails** this audit — the loop cannot declare quiescence while recovery work is
+merely deferred. Re-run it after the cooldown; only an all-clear second pass permits exit.
 
 ## Recovery (cold resume)
 
@@ -248,7 +344,10 @@ relied upon. Because teammates die with the lead's session a crashed loop 1 *usu
 surviving workers — but a watchdog **false-positive** (lead alive, heartbeat merely stale) can spawn
 a second lead while a worker still lives, so safety must **not** depend on that: it comes from the
 durable `current_attempt_id` + **per-attempt branches** (below), with ephemerality only making the
-window rare. Respawn follows **one rule, the GitHub-visible-artifact line:**
+window rare. Orphaned tasks re-enter through §6's **Dispatchable** rule (status `active` with **no
+live worker** for `current_attempt_id`), so a crashed/resumed task is selected and re-dispatched by
+the same seat-capped frontier — never stranded, never a separate code path. Respawn follows **one
+rule, the GitHub-visible-artifact line:**
 
 - **No remote branch and no PR** for a dispatched task → any work was local-only pre-PR WIP, which
   is **disposable**: abandon it and **re-dispatch a fresh attempt** (new `attempt_id`) from clean


### PR DESCRIPTION
Fixes the orchestrator's reluctance to dispatch newly-unblocked tasks. It previously dispatched **before** merging and treated active workers as a reason to wait, so a task unblocked by a merge stalled a full turn (or longer).

**Changes**
- **Merge-first → proactive dispatch:** a merge unblocks its dependents the *same* turn; active workers never suppress dispatch.
- **Seat cap of 5** concurrent workers — proactive but bounded; a documented, **not-enforced**, best-effort per-lead-session guideline.
- **`select → dispatch`** with a **log-derived `ready_since`** aging key (only the ≤5 selected tasks touch GitHub), ordered priority → oldest `ready_since` → `proposal.md` Roadmap order, with a reserved seat to prevent starvation.
- Intra-turn **lease fences** around `gh pr merge` and the dispatch batch; **idempotent** `Task-Loop-Task`-marked issue creation.
- **Orphaned-active recovery** through the same frontier, with takeover damping, a §7 deferred-recovery wait state, and a pre-exit audit gate.

Pressure-tested with Codex over 6 rounds — conclusion at `docs/superpowers/specs/2026-06-13-task-loop-proactive-dispatch-conclusion.md`. `control_log.py` unchanged; 58 tests pass. Bumps task-loop to 0.8.0.