### PR TITLE
task-loop: cycle-worker rule for long-running jobs

### DIFF
--- a/docs/superpowers/specs/2026-06-13-cycle-worker-longjob-conclusion.md
+++ b/docs/superpowers/specs/2026-06-13-cycle-worker-longjob-conclusion.md
@@ -1,0 +1,62 @@
+# cycle-worker long-running-job rule — Codex deliberation conclusion
+
+**Date:** 2026-06-13 · **Method:** `dev-skills:discuss-with-codex` (adversarial), 5 rounds.
+**Outcome:** Converged — Codex replied **NO FURTHER OBJECTIONS**. Scoped to
+`task-loop/agents/cycle-worker.md` only; no protocol/`control_log.py` change.
+
+## Problem
+
+Cycle-workers could get stuck foreground-blocking on long-running jobs (test suites, builds, etc.).
+A foreground `Bash` call is hard-capped at 10 minutes, so a long job is *killed*, and a synchronous
+block stalls the worker's turn. The user asked to add a rule to the worker agent config: jobs
+estimated > ~5 min should be backgrounded and watched.
+
+## Settled rule (as added to `cycle-worker.md`)
+
+For a **shell command** estimated to approach the 10-min foreground cap or with unbounded variance
+(> ~5 min):
+
+```bash
+J=job-<label>-<attempt_id>-r<N>     # one RUN-unique stem the worker picks; bump <N> per rerun
+rm -f "$J.status"                   # clear before launch
+( cmd > "$J.log" 2>&1; rc=$?; printf '%s\n' "$rc" > "$J.status"; exit "$rc" )
+```
+- Run the command **itself** with `Bash run_in_background`; the background completion is the single
+  terminal signal.
+- **Verify BOTH, in order:** (a) `<J>.status` **exists** and equals `0` (authoritative exit code,
+  written by the wrapper not the job's stdout — unspoofable, and a *missing* status = failure); and
+  (b) `Read <J>.log` and scan for failure evidence, **inspecting each match in context** (a `0` exit
+  can hide a swallowed child failure; `failed=0` / `0 errors` / test *names* are benign). Proceed only
+  if status is `0` **and** every match is benign. Never infer success from silence.
+- **Streamed progress** (CI steps, epochs) → `Monitor`, filter covering success **and** failure.
+- **Completion signaled outside the launched process** (detached server, remote CI) → and only then →
+  a `run_in_background` `until`-loop. Never use `until grep` for an ordinary command (fires early on
+  an incidental `Error`, or hangs if the marker never prints).
+- **Non-shell long calls** (a `Workflow` run, `discuss-with-codex`) are **not** shell jobs — rely on
+  the tool's own bounded/background completion; if unbounded with no such mechanism, break it into
+  smaller bounded calls or escalate to the orchestrator.
+
+## Objections raised and how each resolved
+
+1. **(R1) Don't weaken "verify terminal state" to "the process exited"** — a wrapper can exit `0`
+   while the log says FAILED/OOM. Applied: normalized exit status + a *mandatory* log read & failure
+   scan. Also: lead with plain `run_in_background` (not the `until`-loop), demote the `until`-loop to
+   externally-signaled completion, keep ~5 min ("approach the cap / unbounded variance").
+2. **(R2) Substrate overclaim** — the trigger listed `Workflow`/Codex but the mechanism was a Bash
+   wrapper. Applied: scoped the wrapper to shell jobs; added a dedicated non-shell bullet.
+3. **(R2) In-log `__CYCLE_EXIT` marker is spoofable/stale** — logs are untrusted output. Applied:
+   separate status file.
+4. **(R2) "No failure signatures" too absolute** (`failed=0`, `0 errors`, test names match).
+   Applied: context-aware inspection of each match, not a blind regex gate.
+5. **(R3) The snippet hid filenames + used two different UUIDs** (unpairable; worker can't `Read`
+   them). Applied: one worker-chosen job stem with derived `.log`/`.status`.
+6. **(R3) Over-asserted the `Workflow` background contract.** Applied: lead with "use the tool's own
+   bounded/background completion," Workflow/codex as parenthetical in-harness examples.
+7. **(R4) Stem was attempt-unique but not run-unique** — a rerun of the same label in one attempt
+   could read a prior run's stale `0` (esp. if killed before writing). Applied: **run-unique** stem
+   (`-r<N>`) + **clear status before launch**; a missing status is treated as failure.
+
+## How it ended
+
+Converged after 5 rounds — Codex's objections narrowed from substance (verify-vs-exited) to a final
+stale-reuse edge case, then `NO FURTHER OBJECTIONS`. No unresolved tensions.

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.8.0"
+  "version": "0.8.1"
 }

--- a/task-loop/agents/cycle-worker.md
+++ b/task-loop/agents/cycle-worker.md
@@ -97,6 +97,44 @@ description of the task. If any is missing, ask the orchestrator (the team lead)
   Stage files by explicit path; commit with clean, attribution-free text via `git commit -F`.
 - **No nested teams.** For intra-task parallelism use `Workflow` or inline subagents, never a
   sub-team.
+- **Never foreground-block a long shell job — background it and verify its terminal state.** If a
+  **shell command** may plausibly **approach the 10-minute foreground cap or has unbounded variance**
+  (full test suites, builds, installs, large downloads/datasets, training scripts — anything
+  estimated **>~5 min**), do **not** run it as a blocking foreground call: it would be **killed at the
+  10-min cap**, and a synchronous block stalls your turn. Run the command **itself** with **`Bash`
+  `run_in_background`**, writing its output and exit status to two files derived from **one job stem
+  you choose** — name it after the job, your `attempt_id`, **and a per-run counter** so the two files
+  are pairable, their paths are ones you **know** (to `Read` later), and each run is **unique even
+  across reruns of the same job in one attempt** (no stale reuse). **Clear the status file before
+  launch**, so a run killed before the wrapper writes leaves *no* status rather than a stale `0`:
+  ```bash
+  J=job-<label>-<attempt_id>-r<N>     # ONE run-unique stem you pick; bump <N> on every rerun
+  rm -f "$J.status"
+  ( cmd > "$J.log" 2>&1; rc=$?; printf '%s\n' "$rc" > "$J.status"; exit "$rc" )
+  ```
+  The background completion is your single terminal signal. **Then verify BOTH, in order:**
+  (a) `<J>.status` **exists** and contains exactly `0` — that is the authoritative exit code, written
+  by the wrapper, **not** by the job's own stdout; a run-unique stem plus the pre-launch clear mean it
+  cannot be spoofed by a log line or reused stale, and a **missing** status (e.g. the run was killed
+  before it wrote) is a **failure**, never success;
+  and (b) **`Read` `<J>.log` and scan for failure evidence** (`FAILED`, `Error`, `Traceback`,
+  `Killed`, `OOM`, skipped setup, partial output) — **inspect each match in context**, since a `0`
+  exit can still hide a swallowed child failure while `failed=0` / `0 errors` / a test *name* are
+  benign. Proceed only if the status is `0` **and** every match is genuinely benign. **Never infer
+  success from silence.**
+  - **Streamed progress** (CI steps, training epochs — you want checkpoints, not just the end) → use
+    **`Monitor`** on a command that emits one line per event and exits at a terminal state, the
+    filter covering success **and** failure signatures.
+  - **Completion signaled OUTSIDE the launched process** (a detached server becoming ready, a remote
+    CI/job) — and only then → a `run_in_background` `until`-loop polling that external marker. Do
+    **not** use an `until grep`-loop for an ordinary command: it can fire early on an incidental
+    `Error` string, or hang forever if the tool exits without your marker.
+  - **Non-shell long calls are NOT shell jobs** — never force them into the wrapper above; rely on
+    the tool's **own** bounded/background completion. (In this harness a `Workflow` run returns
+    immediately and notifies on completion, and `discuss-with-codex` bounds each Codex call itself.)
+    If some other tool could run unbounded with no such background/monitorable completion, **break it
+    into smaller bounded calls** or tell the orchestrator the task needs orchestration support —
+    don't block on it.
 
 **Handoff (the end of your cycle):**
 When the rubric is green, the PR is open, and Codex review has no blocking issues, post a


### PR DESCRIPTION
Adds a hard rule to the `cycle-worker` agent so workers don't get stuck foreground-blocking on long jobs (a foreground `Bash` is killed at the 10-min cap, and a synchronous block stalls the worker's turn).

**Rule** — for a shell command estimated > ~5 min:
- Run it via `Bash run_in_background` with a **run-unique** one-stem log + status (`job-<label>-<attempt_id>-r<N>`), status cleared before launch.
- Verify **both**: the separate `<J>.status` file **exists** and equals `0` (authoritative, unspoofable; missing = failure) **and** a context-aware scan of `<J>.log` for failure evidence. Never infer success from silence.
- Reserve the `until`-loop for completion signaled **outside** the launched process; use `Monitor` for streamed progress; leave non-shell long calls (`Workflow`/Codex) to their own bounded/background completion.

Pressure-tested with Codex over 5 rounds (converged) — conclusion at `docs/superpowers/specs/2026-06-13-cycle-worker-longjob-conclusion.md`. Agent-config only; no protocol/`control_log.py` change. Bumps task-loop to 0.8.1.