### PR TITLE
task-loop: two-loop fixed-interval control plane

### DIFF
--- a/docs/superpowers/plans/2026-06-14-task-loop-two-loop-control-plane.md
+++ b/docs/superpowers/plans/2026-06-14-task-loop-two-loop-control-plane.md
@@ -1,0 +1,249 @@
+# Two-Loop Control Plane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the `task-loop` orchestrator control plane from three jobs to two (a fixed-30-min-poll `/loop` orchestrator + a one-time stop early-wake), delete the watchdog, and add an artifact-aware recovery-disposition substep backed by one additive helper.
+
+**Architecture:** Prose change to `run-cycle` SKILL.md + orchestrator-loop.md (loop topology, fixed-poll wake, tri-state manual resume, recovery-disposition table, lease-header diagnostics, stop-time control), plus ONE additive pure helper in `control_log.py` (`latest_recovery_with_metadata`) with tests. No control-event schema change; the 58 existing tests stay green.
+
+**Tech Stack:** Python stdlib `unittest`; Markdown skill/reference prose.
+
+**Source of truth:** `docs/superpowers/specs/2026-06-14-task-loop-two-loop-control-plane-design.md` (Codex-converged) and `…-conclusion.md`.
+
+---
+
+### Task 1: Additive helper `latest_recovery_with_metadata`
+
+**Files:**
+- Modify: `task-loop/scripts/control_log.py` (add a function after `latest_recovery`, ends line 77)
+- Test: `task-loop/tests/test_control_log.py` (add to `class TestRecoveryComments`, ends line 411)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `task-loop/tests/test_control_log.py` inside `class TestRecoveryComments` (after line 411):
+
+```python
+    def test_latest_recovery_with_metadata_returns_canonical_created_at(self):
+        c1 = ("IC1", TS_EARLY,
+              control_log.format_recovery({"attempt_id": "A", "status": "in_progress"}))
+        c2 = ("IC2", TS_A,
+              control_log.format_recovery({"attempt_id": "A", "status": "pr_open"}))
+        meta = control_log.latest_recovery_with_metadata([c1, c2], "A")
+        self.assertEqual(meta["comment_id"], "IC2")
+        self.assertEqual(meta["created_at"], TS_A)
+        self.assertEqual(meta["recovery"]["status"], "pr_open")
+
+    def test_latest_recovery_with_metadata_ignores_other_attempts(self):
+        c1 = ("IC1", TS_EARLY,
+              control_log.format_recovery({"attempt_id": "A", "status": "pr_open"}))
+        c2 = ("IC2", TS_A,
+              control_log.format_recovery({"attempt_id": "B", "status": "merge_requested"}))
+        meta = control_log.latest_recovery_with_metadata([c1, c2], "A")
+        self.assertEqual(meta["comment_id"], "IC1")
+        self.assertEqual(meta["created_at"], TS_EARLY)
+        self.assertEqual(meta["recovery"]["status"], "pr_open")
+
+    def test_latest_recovery_with_metadata_none_when_absent(self):
+        c1 = ("IC1", TS_EARLY,
+              control_log.format_recovery({"attempt_id": "A", "status": "pr_open"}))
+        self.assertIsNone(control_log.latest_recovery_with_metadata([c1], "C"))
+
+    def test_latest_recovery_with_metadata_last_block_in_one_comment_wins(self):
+        # Two recovery blocks for attempt A in a single comment body: the LAST wins,
+        # carrying that comment's canonical created_at.
+        body = (control_log.format_recovery({"attempt_id": "A", "status": "in_progress"})
+                + "\n"
+                + control_log.format_recovery({"attempt_id": "A", "status": "merge_requesting"}))
+        meta = control_log.latest_recovery_with_metadata([("IC9", TS_B, body)], "A")
+        self.assertEqual(meta["comment_id"], "IC9")
+        self.assertEqual(meta["created_at"], TS_B)
+        self.assertEqual(meta["recovery"]["status"], "merge_requesting")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m unittest task-loop.tests.test_control_log -v 2>&1 | grep -i "metadata\|error\|fail" | head`
+(Run from repo root with `task-loop/__init__.py`/`tests/__init__.py` absent — the suite is discovered, so use the discover form below if the dotted path fails.)
+Run: `python3 -m unittest discover -s task-loop/tests -q`
+Expected: FAIL — `AttributeError: module 'control_log' has no attribute 'latest_recovery_with_metadata'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Insert into `task-loop/scripts/control_log.py` immediately after `latest_recovery` (after line 77, before `filter_new_inbox`):
+
+```python
+def latest_recovery_with_metadata(comments: list, attempt_id):
+    """Like `latest_recovery`, but return the GitHub-canonical metadata of the
+    winning comment, or None.
+
+    Returns `{"comment_id": id, "created_at": created_at, "recovery": rec}` for the
+    most recent recovery record tagged with `attempt_id` (LAST match wins, mirroring
+    `latest_recovery`), carrying the comment's canonical `created_at` so the
+    orchestrator's recovery-disposition "hold if recent" gate keys off durable GitHub
+    time, NOT the worker-authored JSON `ts` (skew/spoof-prone) or session memory."""
+    found = None
+    for (cid, created_at, body) in comments:
+        for rec in parse_recovery(body):
+            if rec.get("attempt_id") == attempt_id:
+                found = {"comment_id": cid, "created_at": created_at, "recovery": rec}
+    return found
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m unittest discover -s task-loop/tests -q`
+Expected: `OK` (62 tests: 58 existing + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add task-loop/scripts/control_log.py task-loop/tests/test_control_log.py
+git commit -m "task-loop: add latest_recovery_with_metadata helper for canonical-time recovery hold gate"
+```
+
+---
+
+### Task 2: orchestrator-loop.md — topology, wake, lease, recovery dispositions
+
+**Files:**
+- Modify: `task-loop/skills/run-cycle/references/orchestrator-loop.md`
+
+Each step is one anchored edit. Use the spec §3–§9 as the wording source.
+
+- [ ] **Step 1: Replace the fast-state header JSON** (current block lines 29–38).
+
+New header block:
+
+```json
+{
+  "lease": {"owner": "<id>", "expires_at": "<utc ~2x poll>"},
+  "last_turn_started_at": "<utc>",
+  "last_turn_completed_at": "<utc>",
+  "next_wakeup_at": "<utc>",
+  "phase": "dispatching|waiting|idle|draining|exiting_pending|exiting",
+  "stop_at": "<utc>",
+  "drain_deadline_at": null,
+  "stop_schedule_id": null
+}
+```
+
+Update the surrounding prose (lines 24–48) to: drop `watchdog_schedule_id` and the single `heartbeat`; state the header is soft/advisory/last-writer-wins and **sole-written**; describe `last_turn_started_at`/`last_turn_completed_at`/`next_wakeup_at` as **diagnostics that make manual resume informed** (sleeping vs hung-mid-turn vs dead); `expires_at` is the single-coordinator TTL (~2× the 1800 s poll); `stop_schedule_id` is the handle the orchestrator uses to cancel/recreate Loop B; **no sibling job consumes any of it — a human/preflight does.**
+
+- [ ] **Step 2: Replace the "State machine" intro + phase list** (lines 50–76).
+
+Reframe to two loops + fixed poll: the orchestrator is a `/loop` session ending each turn with a **fixed `ScheduleWakeup(1800)`**; **Step 2 stop-check is the sole stop decision**; `phase: exiting` is a **hard terminal guard at turn top** (a stray/late wake reading a clean `exiting` re-audits and stops; only a changed state reverts). Replace the `waiting` bullet's "idle notifications are the primary wake + jittered fallback + shorter backlog wake" with: **every non-terminal phase schedules the same fixed 1800 s wake; idle notifications are no longer part of the wake model.** Keep `dispatching`/`idle`/`draining`/`exiting_pending`/`exiting` meanings; `idle` now also uses the fixed wake.
+
+- [ ] **Step 3: Update §1 Lease & rebuild** (lines 80–88) to add tri-state resume.
+
+After the existing write-then-re-read fence prose, add: on resume/stale-lease, classify the prior lead from the advisory diagnostics — **`likely_alive`** (`next_wakeup_at` AND `expires_at` both future) → **default refuse takeover, allow explicit human force**; **`likely_dead`** (`now ≫ next_wakeup_at`, or `expires_at` well past) → acquire the lease but **observe/reconcile first** (do not eagerly mint attempts). The header is soft, so diagnostics are advisory inputs, never proof; human force is always available. Replace `heartbeat`-refresh references with `expires_at`/`next_wakeup_at`.
+
+- [ ] **Step 4: Rewrite the Control-plane note** — find the paragraph describing loops 1/2/3 (the watchdog/`heartbeat`/`watchdog_schedule_id` prose around lines 43–47) and replace with: **Loop A** (this `/loop` orchestrator, fixed 1800 s wake) + **Loop B** (one-time stop early-wake at `stop_at`; fires into Loop A's session, sets nothing — the woken turn's Step 2 decides; carries a `stop_at`/generation payload as stale-trigger defense; recreated by the orchestrator on an active `stop_at` change). No watchdog.
+
+- [ ] **Step 5: Add the recovery-disposition substep to §6 Dispatch** (insert before the "Dispatchable" bullet, line 195).
+
+Add a **Recovery disposition (before classifying `active`-with-no-live-worker as dispatchable)** block with the exact table from spec §5:
+- open PR / `merge_requesting` → reconcile (merge or deny); spawn no worker.
+- branch, no PR → **hold if recent**; after one poll or human force → mint a NEW attempt with `adopt_from_branch`.
+- recovery comments only → liveness hint; hold if recent; else mint fresh from `master`.
+- nothing (no branch/PR/recent recovery) → mint fresh immediately.
+- Invariant: never reuse `attempt_id` or write an existing attempt branch; `adopt_from_branch` only reads.
+- **Recent gate (pure function of canonical time):** `hold_until = latest_recovery_comment_created_at + 1800 + skew_grace` via `control_log.latest_recovery_with_metadata(comments, current_attempt_id)["created_at"]`; reject worker JSON `ts` and session memory.
+
+- [ ] **Step 6: Delete takeover damping** (lines 226–229, the "Takeover damping" bullet) and any "deferred recovery candidate" wake. Replace its role with a one-line pointer to the Step-5 disposition substep ("artifact-aware recovery replaces the old watchdog-era takeover damping").
+
+- [ ] **Step 7: Rewrite §7 Wait / idle / exit** (lines 258–283) to the fixed poll.
+
+Collapse to: any non-terminal state → **`ScheduleWakeup(1800)`** (one cadence). Remove the idle-notification-primary bullet, the jittered/backlog-shorter bullet, and the deferred-recovery-probe bullet. Keep `draining` (until `drain_deadline_at` → `orphaned_acknowledged`), `exiting_pending` (audit + cooldown), `exiting` (stop rescheduling). Add: **`phase: exiting` is a hard terminal guard** — a stray wake re-audits and stops; on exit the loop stops rescheduling.
+
+- [ ] **Step 8: Update the Recovery (cold resume) section** (lines 336–367) so it names manual `/run-cycle` resume as the death/hang recovery path, points orphaned re-entry at the Step-5 disposition table, and references `latest_recovery_with_metadata` for the recent-gate; keep the per-attempt-branch / `adopt_from_branch` semantics.
+
+- [ ] **Step 9: Add a Stop-time control note** (near §2/§7 or the Control-plane note): **active** stop update (re-invoke `/run-cycle`: runs as orchestrator, updates `stop_at`, cancels+recreates Loop B via `stop_schedule_id`, runs Step 2 — only ~0-latency path for shortening, sole-writer-clean) vs **passive** raw header edit (eventual, ≤ one poll; recreated on next wake; discouraged).
+
+- [ ] **Step 10: Grep for leftovers and commit.**
+
+```bash
+grep -n "watchdog\|heartbeat\|idle notification\|jitter\|Tier-0\|Tier-1\|takeover damping" task-loop/skills/run-cycle/references/orchestrator-loop.md
+```
+Expected: only intentional mentions (e.g. a historical note). Fix any stragglers, then:
+```bash
+git add task-loop/skills/run-cycle/references/orchestrator-loop.md
+git commit -m "task-loop: orchestrator-loop two-loop fixed-poll model + artifact-aware recovery"
+```
+
+---
+
+### Task 3: SKILL.md — control plane, setup, turn §7, invariants
+
+**Files:**
+- Modify: `task-loop/skills/run-cycle/SKILL.md`
+
+- [ ] **Step 1: Rewrite the "Control plane" section** (lines 43–78) from "one live loop + two guard jobs" to **"one live fixed-interval loop + one stop early-wake."** Describe Loop A (fixed 1800 s poll, monitor→merge→dispatch over the full re-derived frontier, self-bounds via Step 2, `phase: exiting` hard terminal guard) and Loop B (one-time stop early-wake at `stop_at`; the woken turn's Step 2 decides; recreated on active `stop_at` change). Delete the watchdog tiers and the `heartbeat`/`watchdog_schedule_id` prose. State death/intra-turn-hang recovery = **manual `/run-cycle` resume** (rebuilds 100% from GitHub); fixed poll structurally prevents inter-turn under-dispatch only.
+
+- [ ] **Step 2: Update Setup** (lines 80–115): drop step 5 (create watchdog); keep the stop job (now "create Loop B — the stop early-wake," recording `stop_schedule_id`). In the header description, drop `watchdog_schedule_id`; keep `stop_at`, `lease`, `stop_schedule_id`, and the diagnostics. Step 7's self-bound prose stays (fixed wake capped to `stop_at`).
+
+- [ ] **Step 3: Rewrite the high-level turn §7** (lines 158–163): not-draining → fixed 30-min wake; drained → exit; `phase: exiting` hard terminal guard. Remove "Teammate idle notifications are the primary wake" and the jittered/backlog/deferred-recovery language.
+
+- [ ] **Step 4: Update Hard invariants** (lines 166–184): keep "Sole integrator," "Single writer," "Merge gates," "Proactive, seat-capped dispatch." Reword "Continuous service" to the fixed-poll model (no idle-notification wake; a scheduled stop early-wake; manual resume on death/hang). Remove watchdog references.
+
+- [ ] **Step 5: Grep + commit.**
+
+```bash
+grep -n "watchdog\|heartbeat\|guard job\|idle notification\|Tier-0\|Tier-1\|three cooperating" task-loop/skills/run-cycle/SKILL.md
+```
+Fix stragglers, then:
+```bash
+git add task-loop/skills/run-cycle/SKILL.md
+git commit -m "task-loop: run-cycle SKILL two-loop control plane + fixed-poll turn"
+```
+
+---
+
+### Task 4: Design-spec §12 + version bump
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md` (control-plane / watchdog section)
+- Modify: `task-loop/.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Update the older design spec's control-plane prose.**
+
+```bash
+grep -n "watchdog\|three\b\|Loop 3\|heartbeat\|external watchdog" docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md | head
+```
+At the relevant section (§12 and the §1 "/loop self-paced" line ~30), add a short forward-pointer note: the control plane is superseded by the two-loop fixed-poll model in `2026-06-14-task-loop-two-loop-control-plane-design.md` (watchdog removed; manual resume only). Do not rewrite the whole spec — a dated note + pointer is enough.
+
+- [ ] **Step 2: Bump the plugin version.**
+
+In `task-loop/.claude-plugin/plugin.json`, change `"version": "0.8.1"` → `"version": "0.9.0"`.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md task-loop/.claude-plugin/plugin.json
+git commit -m "task-loop: note two-loop supersession in design spec; bump to 0.9.0"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full suite.**
+
+Run: `python3 -m unittest discover -s task-loop/tests -q`
+Expected: `OK` (62 tests).
+
+- [ ] **Step 2: Validate plugin.json.**
+
+Run: `python3 -c "import json;json.load(open('task-loop/.claude-plugin/plugin.json'))" && echo VALID`
+Expected: `VALID`.
+
+- [ ] **Step 3: Final leftover sweep across the skill.**
+
+Run: `grep -rn "watchdog\|Tier-0\|Tier-1\|watchdog_schedule_id" task-loop/skills/ ; echo done`
+Expected: no unintended hits (only deliberate historical references, if any).
+
+- [ ] **Step 4: Confirm no schema/protocol drift.**
+
+Run: `git diff --stat c2fe9a0 -- task-loop/scripts/control_log.py`
+Expected: only the additive `latest_recovery_with_metadata` (no edits to `replay`, `_STATUS_BY_TYPE`, `_REQUIRED_FIELDS`).

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -192,6 +192,13 @@ resumable state; `step-workflow` numbered file naming.
 
 ## 7. `run-cycle` skill + orchestrator (step c)
 
+> **Superseded (control-plane topology), 2026-06-14:** the three-job model below (self-paced loop +
+> watchdog + stop) is replaced by the **two-loop fixed-poll** model in
+> `2026-06-14-task-loop-two-loop-control-plane-design.md` — a fixed 30-min poll orchestrator (Loop A)
+> + a one-time stop early-wake (Loop B), **no watchdog**, death/intra-turn-hang recovery by **manual
+> `/run-cycle` resume**. The text below is retained for history; the run-cycle skill + `references/`
+> are the live source.
+
 Human entry point. Starts the orchestrator under **built-in `/loop` self-paced** (per the
 loop-mechanism conclusion — **not** ralph, **not** a blocking Stop hook), creates the
 Agent Team, and runs the state machine. It runs as **a live `/loop` lead plus two scheduler guard

--- a/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md
@@ -6,6 +6,14 @@
 - `2026-06-13-cycle-loop-mechanism-conclusion.md` (loop driver + termination)
 - `2026-06-13-living-proposal-ownership-conclusion.md` (proposal ownership + split-brain)
 
+> **Control-plane topology superseded (2026-06-14).** Every mention below of a **self-paced `/loop`**,
+> a **`heartbeat`**, a **`watchdog`**, or `watchdog_schedule_id` reflects the original *three-job*
+> control plane. That topology is replaced by the **two-loop fixed-poll** model in
+> `2026-06-14-task-loop-two-loop-control-plane-design.md` (Loop A = `/loop` on a fixed 30-min poll;
+> Loop B = a one-time stop early-wake; **no watchdog**; death/intra-turn-hang recovery by **manual
+> `/run-cycle` resume**). The run-cycle skill + its `references/` are the live source; the prose here
+> is retained for history.
+
 ## 1. Overview
 
 `task-loop` generalizes the METBG "study loop" — a proven autonomous, resumable

--- a/docs/superpowers/specs/2026-06-14-task-loop-two-loop-control-plane-conclusion.md
+++ b/docs/superpowers/specs/2026-06-14-task-loop-two-loop-control-plane-conclusion.md
@@ -1,0 +1,112 @@
+# task-loop two-loop control plane — Codex deliberation conclusion
+
+**Date:** 2026-06-14 · **Method:** `dev-skills:discuss-with-codex` (adversarial), 6 rounds (round cap).
+**Outcome:** **Substantively converged.** Every objection was conceded and folded into the design; no
+standoff remained at the cap. An always-adversarial critic kept surfacing narrower refinements of one
+corner (stop-time control), but the core topology was stable from round 2.
+
+## Problem
+
+`run-cycle` ran as **three jobs**: a self-paced `/loop` orchestrator (Loop 1), a one-time stop (Loop
+2), and a recurring 30-min watchdog (Loop 3). The watchdog conflated two failure modes, and as an
+in-session `CronCreate` job it could not survive the very session-death it nominally watched. The
+self-paced wake model (idle-notification-primary + jittered fallbacks + backlog + recovery-probe
+wakes) was complex and unpredictable. Goal: collapse to **two loops + a pure fixed 30-min poll**.
+
+## Settled position
+
+**Topology — two loops.**
+- **Loop A** = the `/loop` orchestrator; every turn ends with a **fixed `ScheduleWakeup(1800)`**.
+  Per-turn steps 1–5 unchanged (lease & rebuild; **Step 2 stop-check is the sole stop decision**;
+  ingest worker events = "monitor team status"; replan; **merge first**). Step 6 (dispatch) gains a
+  **recovery-disposition substep** (below). Step 7 simplifies to: not-draining → fixed 30-min wake;
+  drained → exit. `phase: exiting` is a **hard terminal guard** at turn top; on exit, stop rescheduling.
+- **Loop B** = a one-time scheduled **early-wake** at `stop_at`. It does **not** force `phase: exiting`;
+  it triggers a normal turn whose Step-2 check (against the **current** header `stop_at`) decides. A
+  stale early fire is therefore harmless (turn continues). Loop B carries a `stop_at`/generation payload
+  as stale-trigger defense.
+
+**Wake claim — narrowed (R1).** The fixed poll eliminates **inter-turn under-dispatch only** (stale
+carried frontier + missed idle notifications — the "reluctance" class). It does **not** eliminate an
+**intra-turn hang** (a long/blocking `gh`/CI/spawn call that never reaches Step 7). Mitigation:
+**best-effort per-command deadlines** on the orchestrator's own calls with **reconcile-on-timeout**
+(re-inspect ambiguous side effects, e.g. did `gh pr merge` land, before rescheduling). An intra-turn
+hang is **not fully eliminable** and is a **documented capability reduction** vs the old watchdog,
+handled by **manual `/run-cycle` resume**. (User decision: manual resume only.)
+
+**Lease header — diagnostics, soft/advisory, sole-written.**
+`{owner, expires_at (~2× poll), last_turn_started_at, last_turn_completed_at, next_wakeup_at, stop_at,
+stop_schedule_id, drain_deadline_at}`. **Dropped:** `watchdog_schedule_id` and the single `heartbeat`
+field. `stop_schedule_id` is **kept** (R5) so the orchestrator can cancel/recreate Loop B.
+
+**Manual resume — tri-state, artifact-aware (R2/R3), on advisory diagnostics, human force always available.**
+- `likely_alive` (`next_wakeup_at` **and** `expires_at` both future) → **default refuse**, allow
+  explicit human force-takeover (the header is soft, never an absolute proof).
+- `likely_dead` (`now ≫ next_wakeup_at`, or `expires_at` well past) → acquire lease, **observe/reconcile
+  first**.
+- **Recovery-disposition substep** gating "active with no live worker → dispatchable":
+  - open PR / `merge_requesting` → **reconcile** (merge or deny); spawn **no** worker.
+  - branch, no PR → **hold if recent**; after one poll or human force → mint a **new** attempt with
+    `adopt_from_branch`.
+  - recovery comments only → liveness hint; hold if recent; else mint **fresh from `master`**.
+  - nothing (no branch/PR/recent recovery) → mint **fresh** immediately.
+  - **Invariant (unchanged):** never reuse `attempt_id` or write an existing attempt branch;
+    `adopt_from_branch` only **reads** the old branch.
+- **The "recent" gate is a pure function of canonical GitHub time (R4):**
+  `hold_until = latest_recovery_comment_created_at + 1800 + skew_grace`. This requires a new **additive**
+  helper `control_log.latest_recovery_with_metadata(comments, attempt_id) → {comment_id, created_at,
+  recovery}` (the existing `latest_recovery` discards `created_at`). Worker-authored JSON `ts` and
+  session memory are both rejected as the gate source.
+
+**Stop-time control — passive vs active (R6).**
+- **Active stop update** (re-invoke `/run-cycle` to resume / stop-now / new `stop_at`): runs **as the
+  orchestrator**, acquires the lease, updates `stop_at`, **cancels+recreates Loop B immediately**, runs
+  Step 2. The **only** path that honestly claims ~0 latency for **shortening**.
+- **Passive raw header edit** while Loop A sleeps: allowed but only **eventually observed** (≤ one poll,
+  ~30 min); reconciled (Loop B recreated) on next wake. Discouraged vs the active path because it also
+  races the sole-writer model.
+- ~0 stop latency holds at the **original** `stop_at` (unedited) via Loop B.
+
+**Kept unchanged (orthogonal correctness machinery):** intra-turn lease fences (R2 — they guard a
+manual double-start's same-identity irreversible merge, not the watchdog), attempt-fencing + per-attempt
+branches, all merge gates, the check-then-append seq guard, and the `control_log.py` **event schema**
+(no new event types; `replay`/dedupe/checkpoints + the 58 existing tests untouched).
+
+**Deleted:** the watchdog job, `watchdog_schedule_id`, takeover damping (replaced by artifact-aware
+recovery), and the Tier-0/Tier-1 alert/auto-relaunch machinery.
+
+## Strongest objections & how each resolved
+
+1. **(R1) "Stuck impossible" overclaimed.** A fixed poll self-corrects only **between** turns; an
+   intra-turn hang never reschedules. Conceded: narrowed the claim to inter-turn under-dispatch; added
+   best-effort deadlines + reconcile-on-timeout; documented the intra-turn-hang reduction → manual resume.
+2. **(R2) Binary resume over-trusts a soft header.** Write-then-die = false "alive"; alive-but-late =
+   false "dead". Conceded: tri-state + artifact-aware damping; richer advisory diagnostics; human force
+   always available. Kept intra-turn lease fences (they are not watchdog leftovers).
+3. **(R3) Artifact-aware prose collides with attempt-fencing** (`adopt_from_branch` *is* a fresh
+   attempt). Conceded: exact disposition table; "steps 1–6 unchanged" retracted — Step 6/recovery gains
+   a disposition substep (prose), schema still untouched.
+4. **(R4) The hold gate needs canonical time, not worker `ts` or session memory.** Conceded: additive
+   helper `latest_recovery_with_metadata` + tests; hold rule as a pure function of GitHub `created_at`.
+   "No code change" retracted; "no schema change / existing tests green" stands.
+5. **(R5) Stale stop-trigger under mutable `stop_at`.** Conceded: keep `stop_schedule_id`; Loop B
+   demoted to an early-wake (turn decides via Step 2), never force-exit; `phase: exiting` reachable only
+   via the legitimate drain path.
+6. **(R6) "Recreate Loop B on any edit" assumes the orchestrator is awake.** Conceded: split passive
+   (eventual, ≤ one poll) from active (`/run-cycle` resume, ~0 latency) stop updates; Loop B generation
+   payload is stale-trigger defense, not edit detection.
+
+## Unresolved tensions
+
+None as a standoff. Two **accepted residuals**, both consequences of locked user decisions, documented
+honestly rather than hidden:
+- **Intra-turn hang has no in-protocol detection** (manual resume only) — a real reduction vs the
+  watchdog, mitigated but not eliminated by best-effort deadlines.
+- **Passive `stop_at` edits incur up to one-poll latency** and race the sole-writer model; the active
+  `/run-cycle` path is the ~0-latency, sole-writer-clean alternative.
+
+## How it ended
+
+Six rounds (round cap). Substantively converged: the core two-loop + fixed-poll + manual-resume design
+was stable from round 2; rounds 3–6 hardened recovery dispositions, the canonical-time hold gate, and
+stop-time control. Every objection was conceded and integrated; no live disagreement remained.

--- a/docs/superpowers/specs/2026-06-14-task-loop-two-loop-control-plane-design.md
+++ b/docs/superpowers/specs/2026-06-14-task-loop-two-loop-control-plane-design.md
@@ -1,0 +1,180 @@
+# Design — `task-loop` two-loop control plane (fixed-interval poll)
+
+**Status:** design (brainstorming output, pre-Codex)
+**Branch:** `feat-two-loop-control-plane`
+**Supersedes (control-plane topology only):** the "three jobs" model in
+`2026-06-13-task-loop-control-plane-conclusion.md`. All other conclusions
+(seq guard, attempt-fencing, recovery semantics, merge gates) are unchanged.
+
+## 1. Problem
+
+`run-cycle` today runs as **three cooperating jobs**:
+
+1. **Loop 1** — a live `/loop` Agent-Teams lead session (the orchestrator). It **self-paces**:
+   teammate idle-notifications are the "primary wake," with jittered `ScheduleWakeup` fallbacks and
+   a separate shorter wake when a capped backlog waits on a freeing seat.
+2. **Loop 2** — a one-time scheduled *stop* at `stop_at`.
+3. **Loop 3** — a recurring 30-min *watchdog* that reads the lease heartbeat and, if stale, alerts
+   ("orchestrator down, resume needed") or (Tier-1, optional) relaunches.
+
+Two problems motivate the change:
+
+- **The watchdog conflates two different failure modes.** Its real day-to-day value was catching an
+  orchestrator that is **alive but stuck** — not dispatching newly-unblocked work (the same
+  "reluctance" PR #122 addressed). Genuine **session death** it cannot reliably catch anyway: a
+  watchdog created by the orchestrator runs *in the orchestrator's own session* (`CronCreate` fires
+  into the current idle REPL and dies when that session exits), so it cannot survive the death it was
+  built to detect. The only true cross-session resurrector was always Tier-1 — an *external* OS
+  supervisor, i.e. infrastructure, never one of the loops.
+- **The self-paced wake model is complex and unpredictable.** "Idle-notification primary + jittered
+  fallback + backlog-shorter + deferred-recovery probe" is a lot of machinery, and its trigger timing
+  is hard to reason about ("does not specify when it triggers").
+
+## 2. Decision
+
+**Collapse to two loops and a fixed-interval poll.**
+
+- **"Alive but stuck"** is resolved *structurally* by a **fixed 30-min poll that re-derives the
+  complete task frontier from GitHub every tick.** There is no carried-over "what to do next" state
+  that can wedge; a tick that under-dispatches is fully corrected by the next tick's fresh
+  full-frontier re-evaluation, seat-capped at 5.
+- **"Session truly dead"** is resolved by **manual `/run-cycle` resume**, which rebuilds 100% from
+  GitHub (the no-local-files payoff). This is an explicit, accepted tradeoff: no in-protocol liveness
+  watch. (Decided 2026-06-14.)
+
+**Locked constraints (user decisions):**
+- **Pure fixed 30-min poll** — *not* a hybrid with idle-notification early-wake. Predictability over
+  latency.
+- **Manual resume only** for session death — no mandatory external supervisor, no in-protocol alert.
+
+**Accepted tradeoff:** a worker that finishes at minute 1 waits up to ~30 min for the next tick to
+merge its PR, delaying its dependents. Bought in exchange for a dead-simple, predictable,
+self-correcting control plane.
+
+## 3. Architecture — two loops
+
+```
+                          stop_at
+   Loop A (orchestrator, /loop)        Loop B (stop event)
+   ┌───────────────────────────┐       ┌──────────────────┐
+   │ every 30 min, one turn:    │       │ one-time @ stop_at │
+   │  1 lease & rebuild (replay)│       │  confirm drained   │
+   │  2 stop-check (→ draining)  │      │  end the run       │
+   │  3 ingest worker events ────┼──◄── "monitor team status"
+   │  4 replan barrier          │       └──────────────────┘
+   │  5 MERGE first (integrator)│
+   │  6 DISPATCH full frontier, │   ← re-derived from GitHub every tick;
+   │    seat-capped at 5        │     this is what makes "stuck" impossible
+   │  7 ScheduleWakeup(1800) ───┼─┐   (fixed 30-min; or exit if drained)
+   │  8 heartbeat (refresh lease)│ │
+   └───────────────────────────┘ │
+              ▲                    │
+              └────── 30 min ──────┘
+```
+
+- **Loop A — the orchestrator.** Driven by built-in `/loop`. Each turn ends with a **fixed
+  `ScheduleWakeup(1800)`** (30 min). It still **self-bounds**: a turn that finds the clock at/after
+  `stop_at` enters `draining`, and on drain-complete it stops rescheduling (the run ends from inside
+  Loop A as the primary stop path).
+- **Loop B — the stop event.** A one-time scheduled job at `stop_at`. With no watchdog to cancel, its
+  job shrinks to: confirm Loop A has drained and the run has ended — a **decoupled "time's up"
+  teardown** that does not depend on Loop A self-bounding correctly on every tick.
+
+### Substrate: `/loop` + fixed `ScheduleWakeup`, not `CronCreate`
+
+Loop A stays a live `/loop` session that schedules its own next wake at a fixed 1800 s, rather than
+becoming a recurring `CronCreate` job. Reasons:
+
+- `/loop` is the existing driver — this is a surgical change to the *cadence*, not the substrate.
+- The orchestrator must hold a live local session to spawn Agent-Teams teammates regardless;
+  `CronCreate` firing into that same session adds a second mechanism for no gain.
+- `CronCreate` carries a silent **7-day auto-expiry** that would kill a long run, and only fires
+  "while the REPL is idle" — coupling we don't want on the primary loop.
+
+`ScheduleWakeup` with a fixed delay *is* the fixed interval.
+
+## 4. The per-turn algorithm (what changes)
+
+Steps 1–6 are **unchanged** from the current `orchestrator-loop.md` (lease & rebuild; stop check;
+event-drain & ingest; replan barrier; **merge first**; proactive seat-capped dispatch over the
+full re-derived frontier). The "monitor team status" the user described **is** step 3 (ingest worker
+events: progress, PR opened, merge requested) feeding steps 5–6.
+
+**Step 7 (Wait / idle / exit) is simplified** to a pure fixed poll:
+
+- Not draining (workers active, capped backlog, *or* empty frontier) → **`ScheduleWakeup(1800)`**.
+  One cadence for every non-terminal state. **Removed:** "idle notifications are the primary wake,"
+  jittered fallbacks, the shorter backlog wake, and the deferred-recovery-probe wake.
+- `draining` → dispatch nothing; wait for active workers until `drain_deadline_at`; past it, mark
+  overdue workers `orphaned_acknowledged` (unchanged).
+- Drain complete → `exiting_pending` (record pre-exit audit, short cooldown wake) → re-audit clean →
+  `exiting` (stop rescheduling). Unchanged except it no longer competes with idle-notification wakes.
+
+Idle notifications are **no longer part of the wake model.** They may still arrive, but the loop does
+not depend on them; every turn is idempotent and re-derives state from GitHub, so whatever a turn
+finds, it handles.
+
+## 5. Cascading simplifications (in scope)
+
+1. **Delete the watchdog (Loop 3) entirely** — the recurring job, the `watchdog_schedule_id` header
+   field, and the Tier-0 detect+alert / Tier-1 auto-relaunch machinery. The SKILL "Control plane"
+   section becomes *one live fixed-interval loop + one stop job*. Death recovery is documented
+   honestly as manual `/run-cycle` resume.
+2. **Drop takeover damping** (orchestrator-loop §6). It existed specifically to shrink the
+   **watchdog false-positive** two-lead window (a second lead spawned while the first's workers still
+   lived). With no watchdog, that spawn source is gone.
+3. **Simplify Setup** — drop the "create watchdog" step; keep "create stop." The body runtime header
+   loses `watchdog_schedule_id`.
+4. **`Continuous service` / wake invariants** updated to the fixed-poll model.
+
+## 6. Deliberately kept (orthogonal correctness machinery)
+
+These are **not** touched — they are hard-won and independent of loop topology:
+
+- **The lease** as the single-coordinator guard. Its remaining job is narrower: catch a **manual
+  double-start** (a human running `/run-cycle` twice). A second start reads the lease; if
+  `expires_at` is in the future it exits. Refreshed each tick (step 8).
+- **Attempt-fencing** (`current_attempt_id` + per-attempt branches) — the durable single-flight
+  correctness backstop for *any* two-lead window, including a forced manual double-start.
+- **The check-then-append seq guard** and **all merge gates** (pre-merge drain barrier, head-SHA
+  binding, `mergedBy` provenance halt).
+
+## 7. Open questions to pressure-test with Codex
+
+1. **Lease `heartbeat` field.** Its only consumer was the watchdog. With manual-resume-only, is
+   `expires_at` (refreshed each tick) sufficient for the single-coordinator guard, letting us drop the
+   separate `heartbeat` field — or does removing it lose something?
+2. **Intra-turn lease fences (PR #122).** The re-read-before-merge, final-fence-before-`gh pr merge`,
+   and re-read-before-dispatch fences were added partly because the watchdog could spawn a second lead
+   *mid-run*. With that source gone (only manual double-start remains, caught at startup), can these
+   relax to a single per-turn lease check — or are they cheap insurance worth keeping for
+   defense-in-depth (and any future re-introduction of auto-relaunch)? **Default: keep them** unless
+   Codex shows they're pure dead weight.
+3. **Is dropping takeover damping safe** on a *manual* stale-lease takeover? The human resumes only
+   when they believe the prior session is dead, so its teammates are gone — but is there a residual
+   "stalled-but-alive prior lead" risk a human could trip?
+4. **Loop B necessity.** Given Loop A self-bounds every tick, is the separate stop event a meaningful
+   backstop or pure ceremony? (User asked for it explicitly; the question is whether to frame it as a
+   guarantee or note it as redundant-but-cheap.)
+
+## 8. Files affected
+
+- `task-loop/skills/run-cycle/SKILL.md` — Control plane section (3 jobs → 2), Setup (drop watchdog),
+  high-level turn §7, Hard invariants.
+- `task-loop/skills/run-cycle/references/orchestrator-loop.md` — Fast-state header JSON (drop
+  `watchdog_schedule_id`, maybe `heartbeat`), State machine (drop watchdog, fixed-poll wake), §1 lease,
+  §7 wait/idle/exit (fixed poll), §6 (drop takeover damping), Recovery (manual resume = death path),
+  Control plane subsection.
+- `docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md` — §12 watchdog / control-plane prose.
+- `task-loop/.claude-plugin/plugin.json` — version bump 0.8.1 → 0.9.0 (notable control-plane change).
+- New: `docs/superpowers/specs/2026-06-14-task-loop-two-loop-control-plane-conclusion.md` (Codex
+  deliberation outcome).
+- `task-loop/scripts/control_log.py` — **no change expected** (loop topology is prose; the protocol
+  is untouched). 58 tests must stay green.
+
+## 9. Out of scope
+
+- Re-introducing any external supervisor or unattended auto-relaunch (explicitly deferred — manual
+  resume only).
+- Changing the control protocol, attempt-fencing, recovery semantics, or merge gates.
+- Re-introducing idle-notification reactivity (rejected in favor of the pure fixed poll).

--- a/docs/superpowers/specs/2026-06-14-task-loop-two-loop-control-plane-design.md
+++ b/docs/superpowers/specs/2026-06-14-task-loop-two-loop-control-plane-design.md
@@ -1,180 +1,192 @@
 # Design — `task-loop` two-loop control plane (fixed-interval poll)
 
-**Status:** design (brainstorming output, pre-Codex)
+**Status:** design — **Codex-converged** (see `2026-06-14-task-loop-two-loop-control-plane-conclusion.md`,
+6 rounds).
 **Branch:** `feat-two-loop-control-plane`
 **Supersedes (control-plane topology only):** the "three jobs" model in
 `2026-06-13-task-loop-control-plane-conclusion.md`. All other conclusions
-(seq guard, attempt-fencing, recovery semantics, merge gates) are unchanged.
+(seq guard, attempt-fencing, recovery artifact-semantics, merge gates) are unchanged.
 
 ## 1. Problem
 
 `run-cycle` today runs as **three cooperating jobs**:
 
-1. **Loop 1** — a live `/loop` Agent-Teams lead session (the orchestrator). It **self-paces**:
-   teammate idle-notifications are the "primary wake," with jittered `ScheduleWakeup` fallbacks and
-   a separate shorter wake when a capped backlog waits on a freeing seat.
+1. **Loop 1** — a live `/loop` Agent-Teams lead session (the orchestrator), **self-paced**:
+   idle-notifications "primary," jittered `ScheduleWakeup` fallbacks, a shorter backlog wake, and a
+   recovery-probe wake.
 2. **Loop 2** — a one-time scheduled *stop* at `stop_at`.
-3. **Loop 3** — a recurring 30-min *watchdog* that reads the lease heartbeat and, if stale, alerts
-   ("orchestrator down, resume needed") or (Tier-1, optional) relaunches.
+3. **Loop 3** — a recurring 30-min *watchdog* that reads the lease heartbeat and, if stale, alerts or
+   (Tier-1) relaunches.
 
-Two problems motivate the change:
+Two problems:
 
-- **The watchdog conflates two different failure modes.** Its real day-to-day value was catching an
-  orchestrator that is **alive but stuck** — not dispatching newly-unblocked work (the same
-  "reluctance" PR #122 addressed). Genuine **session death** it cannot reliably catch anyway: a
-  watchdog created by the orchestrator runs *in the orchestrator's own session* (`CronCreate` fires
-  into the current idle REPL and dies when that session exits), so it cannot survive the death it was
-  built to detect. The only true cross-session resurrector was always Tier-1 — an *external* OS
-  supervisor, i.e. infrastructure, never one of the loops.
-- **The self-paced wake model is complex and unpredictable.** "Idle-notification primary + jittered
-  fallback + backlog-shorter + deferred-recovery probe" is a lot of machinery, and its trigger timing
-  is hard to reason about ("does not specify when it triggers").
+- **The watchdog conflates two failure modes.** Its real day-to-day value was catching an orchestrator
+  that is **alive but stuck** — not dispatching newly-unblocked work (the "reluctance" PR #122
+  addressed). True **session death** it cannot reliably catch: a watchdog created by the orchestrator
+  runs *in the orchestrator's own session* (`CronCreate` fires into the current idle REPL and dies when
+  that session exits), so it cannot survive the death it was built to detect. The only true
+  cross-session resurrector was always Tier-1 — an *external* OS supervisor (infrastructure, never a loop).
+- **The self-paced wake model is complex and unpredictable** ("does not specify when it triggers").
 
 ## 2. Decision
 
-**Collapse to two loops and a fixed-interval poll.**
+**Collapse to two loops and a pure fixed 30-min poll.**
 
-- **"Alive but stuck"** is resolved *structurally* by a **fixed 30-min poll that re-derives the
-  complete task frontier from GitHub every tick.** There is no carried-over "what to do next" state
-  that can wedge; a tick that under-dispatches is fully corrected by the next tick's fresh
-  full-frontier re-evaluation, seat-capped at 5.
-- **"Session truly dead"** is resolved by **manual `/run-cycle` resume**, which rebuilds 100% from
-  GitHub (the no-local-files payoff). This is an explicit, accepted tradeoff: no in-protocol liveness
-  watch. (Decided 2026-06-14.)
+- **"Alive but stuck" between turns** is resolved *structurally* by a fixed 30-min poll that
+  **re-derives the complete task frontier from GitHub every tick** — no carried-over "what next" state
+  can wedge; a tick that under-dispatches is corrected by the next, seat-capped at 5.
+- **"Session truly dead" or hung inside a turn** → **manual `/run-cycle` resume**, which rebuilds 100%
+  from GitHub. No in-protocol liveness watch.
 
-**Locked constraints (user decisions):**
-- **Pure fixed 30-min poll** — *not* a hybrid with idle-notification early-wake. Predictability over
-  latency.
-- **Manual resume only** for session death — no mandatory external supervisor, no in-protocol alert.
+**Narrowed claim (Codex R1):** the fixed poll eliminates **inter-turn under-dispatch only**. An
+**intra-turn hang** (a `gh`/CI/spawn call that never returns before the turn reschedules) is **not**
+structurally eliminated — it has **no in-protocol detection** now, a real reduction vs the watchdog,
+accepted under "manual resume only." Mitigation: **best-effort per-command deadlines** on the
+orchestrator's own calls, with **reconcile-on-timeout** (re-inspect ambiguous side effects before
+rescheduling) — reduces, does not eliminate.
 
-**Accepted tradeoff:** a worker that finishes at minute 1 waits up to ~30 min for the next tick to
-merge its PR, delaying its dependents. Bought in exchange for a dead-simple, predictable,
-self-correcting control plane.
+**Locked user decisions:** pure fixed 30-min poll (no idle early-wake); manual resume only.
+**Accepted tradeoff:** a worker finishing at minute 1 waits up to ~30 min for the next tick to merge,
+delaying dependents — bought for a dead-simple, predictable, self-correcting control plane.
 
 ## 3. Architecture — two loops
 
 ```
-                          stop_at
-   Loop A (orchestrator, /loop)        Loop B (stop event)
-   ┌───────────────────────────┐       ┌──────────────────┐
-   │ every 30 min, one turn:    │       │ one-time @ stop_at │
-   │  1 lease & rebuild (replay)│       │  confirm drained   │
-   │  2 stop-check (→ draining)  │      │  end the run       │
-   │  3 ingest worker events ────┼──◄── "monitor team status"
-   │  4 replan barrier          │       └──────────────────┘
-   │  5 MERGE first (integrator)│
-   │  6 DISPATCH full frontier, │   ← re-derived from GitHub every tick;
-   │    seat-capped at 5        │     this is what makes "stuck" impossible
-   │  7 ScheduleWakeup(1800) ───┼─┐   (fixed 30-min; or exit if drained)
-   │  8 heartbeat (refresh lease)│ │
-   └───────────────────────────┘ │
+   Loop A (orchestrator, /loop)         Loop B (stop early-wake)
+   ┌───────────────────────────┐        ┌───────────────────────────┐
+   │ every 30 min, one turn:    │       │ one-time @ stop_at:         │
+   │  1 lease & rebuild (replay)│       │  wake Loop A (in-session);  │
+   │  2 STOP-CHECK (sole stop   │◄──────│  the turn's Step 2 decides  │
+   │    decision; → draining)   │       │  against CURRENT stop_at.   │
+   │  3 ingest worker events ───┼─ "monitor team status"             │
+   │  4 replan barrier          │       │  recreated by Loop A on an  │
+   │  5 MERGE first (integrator)│       │  ACTIVE stop_at change.     │
+   │  6 DISPATCH full frontier, │       └───────────────────────────┘
+   │    seat-capped, + recovery │
+   │    disposition substep     │   ← frontier re-derived from GitHub every tick
+   │  7 ScheduleWakeup(1800) ───┼─┐   (fixed; or exit if drained)
+   │  8 heartbeat (lease + diag)│ │
+   └───────────────────────────┘ │   phase:exiting = HARD terminal guard at turn top
               ▲                    │
               └────── 30 min ──────┘
 ```
 
-- **Loop A — the orchestrator.** Driven by built-in `/loop`. Each turn ends with a **fixed
-  `ScheduleWakeup(1800)`** (30 min). It still **self-bounds**: a turn that finds the clock at/after
-  `stop_at` enters `draining`, and on drain-complete it stops rescheduling (the run ends from inside
-  Loop A as the primary stop path).
-- **Loop B — the stop event.** A one-time scheduled job at `stop_at`. With no watchdog to cancel, its
-  job shrinks to: confirm Loop A has drained and the run has ended — a **decoupled "time's up"
-  teardown** that does not depend on Loop A self-bounding correctly on every tick.
+- **Loop A — the orchestrator.** `/loop`-driven; each turn ends with a **fixed `ScheduleWakeup(1800)`**.
+  **Step 2 stop-check is the sole stop decision** (against the current header `stop_at`). On
+  drain-complete it stops rescheduling. `phase: exiting` is a **hard terminal guard** at turn top: a
+  stray/late wake reading a clean `exiting` re-audits and stops without dispatching; only a changed
+  state reverts to dispatching/waiting.
+- **Loop B — the stop early-wake.** A one-time scheduled job at `stop_at` that **wakes Loop A**
+  (fires into its session while idle); it does **not** force `phase: exiting` — the woken turn's Step 2
+  decides. A stale early fire is harmless (turn continues). Loop B carries a `stop_at`/generation
+  payload as stale-trigger defense. Value: bounds stop latency to ~0 at the original `stop_at`.
 
-### Substrate: `/loop` + fixed `ScheduleWakeup`, not `CronCreate`
+### Substrate: `/loop` + fixed `ScheduleWakeup`, not `CronCreate` for Loop A
 
-Loop A stays a live `/loop` session that schedules its own next wake at a fixed 1800 s, rather than
-becoming a recurring `CronCreate` job. Reasons:
-
-- `/loop` is the existing driver — this is a surgical change to the *cadence*, not the substrate.
-- The orchestrator must hold a live local session to spawn Agent-Teams teammates regardless;
-  `CronCreate` firing into that same session adds a second mechanism for no gain.
-- `CronCreate` carries a silent **7-day auto-expiry** that would kill a long run, and only fires
-  "while the REPL is idle" — coupling we don't want on the primary loop.
-
-`ScheduleWakeup` with a fixed delay *is* the fixed interval.
+Loop A stays a live `/loop` session scheduling its own fixed 1800 s wake. Reasons: `/loop` is the
+existing driver (surgical change); the orchestrator must hold a live session to spawn teammates anyway;
+`CronCreate` carries a silent **7-day auto-expiry** and only fires "while the REPL is idle" — coupling
+we don't want on the primary loop. (Loop B *is* a one-time scheduled job, fine for a single fire.)
 
 ## 4. The per-turn algorithm (what changes)
 
-Steps 1–6 are **unchanged** from the current `orchestrator-loop.md` (lease & rebuild; stop check;
-event-drain & ingest; replan barrier; **merge first**; proactive seat-capped dispatch over the
-full re-derived frontier). The "monitor team status" the user described **is** step 3 (ingest worker
-events: progress, PR opened, merge requested) feeding steps 5–6.
+- **Steps 1–5 unchanged** (lease & rebuild; stop-check; ingest worker events = "monitor team status";
+  replan; **merge first**).
+- **Step 6 (dispatch) gains a recovery-disposition substep** (§5).
+- **Step 7 simplified** to a pure fixed poll: any non-terminal state → **`ScheduleWakeup(1800)`**.
+  **Removed:** "idle notifications primary," jittered fallbacks, the shorter backlog wake, the
+  deferred-recovery-probe wake. `draining`/`exiting_pending`/`exiting` unchanged except they no longer
+  compete with idle-notification wakes. Idle notifications are **no longer part of the wake model**.
+- **Step 8 (heartbeat)** writes the richer lease diagnostics (§6).
 
-**Step 7 (Wait / idle / exit) is simplified** to a pure fixed poll:
+## 5. Recovery disposition substep (Codex R2/R3/R4)
 
-- Not draining (workers active, capped backlog, *or* empty frontier) → **`ScheduleWakeup(1800)`**.
-  One cadence for every non-terminal state. **Removed:** "idle notifications are the primary wake,"
-  jittered fallbacks, the shorter backlog wake, and the deferred-recovery-probe wake.
-- `draining` → dispatch nothing; wait for active workers until `drain_deadline_at`; past it, mark
-  overdue workers `orphaned_acknowledged` (unchanged).
-- Drain complete → `exiting_pending` (record pre-exit audit, short cooldown wake) → re-audit clean →
-  `exiting` (stop rescheduling). Unchanged except it no longer competes with idle-notification wakes.
+Manual resume is **tri-state on advisory diagnostics, human force always available**:
+`likely_alive` (`next_wakeup_at` & `expires_at` both future) → **default refuse**, allow human force;
+`likely_dead` (`now ≫ next_wakeup_at` or `expires_at` well past) → acquire lease, **observe/reconcile
+first**.
 
-Idle notifications are **no longer part of the wake model.** They may still arrive, but the loop does
-not depend on them; every turn is idempotent and re-derives state from GitHub, so whatever a turn
-finds, it handles.
+Before classifying an `active`-with-no-live-worker task as dispatchable, apply the **exact disposition
+table**:
 
-## 5. Cascading simplifications (in scope)
+| Current-attempt artifact | Disposition |
+|---|---|
+| open PR / `merge_requesting` | **reconcile** (merge or deny); spawn no worker |
+| branch, no PR | **hold if recent**; after one poll or human force → mint **new** attempt `adopt_from_branch` |
+| recovery comments only | liveness hint; hold if recent; else mint **fresh from `master`** |
+| nothing (no branch/PR/recent recovery) | mint **fresh** immediately |
 
-1. **Delete the watchdog (Loop 3) entirely** — the recurring job, the `watchdog_schedule_id` header
-   field, and the Tier-0 detect+alert / Tier-1 auto-relaunch machinery. The SKILL "Control plane"
-   section becomes *one live fixed-interval loop + one stop job*. Death recovery is documented
-   honestly as manual `/run-cycle` resume.
-2. **Drop takeover damping** (orchestrator-loop §6). It existed specifically to shrink the
-   **watchdog false-positive** two-lead window (a second lead spawned while the first's workers still
-   lived). With no watchdog, that spawn source is gone.
-3. **Simplify Setup** — drop the "create watchdog" step; keep "create stop." The body runtime header
-   loses `watchdog_schedule_id`.
-4. **`Continuous service` / wake invariants** updated to the fixed-poll model.
+**Invariant (unchanged):** never reuse `attempt_id` or write an existing attempt branch;
+`adopt_from_branch` only **reads** the old branch.
 
-## 6. Deliberately kept (orthogonal correctness machinery)
+The **"recent" gate is a pure function of canonical GitHub time:**
+`hold_until = latest_recovery_comment_created_at + 1800 + skew_grace`. Worker-authored JSON `ts` and
+session memory are both rejected. This requires an **additive** helper
+`control_log.latest_recovery_with_metadata(comments, attempt_id) → {comment_id, created_at, recovery}`
+(the existing `latest_recovery` discards `created_at`), plus unit tests. **No new event types; schema,
+`replay`, dedupe, checkpoints, and the 58 existing tests unchanged.**
 
-These are **not** touched — they are hard-won and independent of loop topology:
+This **replaces takeover damping** (which existed only for the now-deleted watchdog false-positive).
 
-- **The lease** as the single-coordinator guard. Its remaining job is narrower: catch a **manual
-  double-start** (a human running `/run-cycle` twice). A second start reads the lease; if
-  `expires_at` is in the future it exits. Refreshed each tick (step 8).
-- **Attempt-fencing** (`current_attempt_id` + per-attempt branches) — the durable single-flight
-  correctness backstop for *any* two-lead window, including a forced manual double-start.
-- **The check-then-append seq guard** and **all merge gates** (pre-merge drain barrier, head-SHA
-  binding, `mergedBy` provenance halt).
+## 6. Lease header (Codex R2/R4/R5)
 
-## 7. Open questions to pressure-test with Codex
+```json
+{
+  "owner": "<id>", "expires_at": "<utc ~2x poll>",
+  "last_turn_started_at": "<utc>", "last_turn_completed_at": "<utc>", "next_wakeup_at": "<utc>",
+  "phase": "dispatching|waiting|idle|draining|exiting_pending|exiting",
+  "stop_at": "<utc>", "drain_deadline_at": null, "stop_schedule_id": null
+}
+```
 
-1. **Lease `heartbeat` field.** Its only consumer was the watchdog. With manual-resume-only, is
-   `expires_at` (refreshed each tick) sufficient for the single-coordinator guard, letting us drop the
-   separate `heartbeat` field — or does removing it lose something?
-2. **Intra-turn lease fences (PR #122).** The re-read-before-merge, final-fence-before-`gh pr merge`,
-   and re-read-before-dispatch fences were added partly because the watchdog could spawn a second lead
-   *mid-run*. With that source gone (only manual double-start remains, caught at startup), can these
-   relax to a single per-turn lease check — or are they cheap insurance worth keeping for
-   defense-in-depth (and any future re-introduction of auto-relaunch)? **Default: keep them** unless
-   Codex shows they're pure dead weight.
-3. **Is dropping takeover damping safe** on a *manual* stale-lease takeover? The human resumes only
-   when they believe the prior session is dead, so its teammates are gone — but is there a residual
-   "stalled-but-alive prior lead" risk a human could trip?
-4. **Loop B necessity.** Given Loop A self-bounds every tick, is the separate stop event a meaningful
-   backstop or pure ceremony? (User asked for it explicitly; the question is whether to frame it as a
-   guarantee or note it as redundant-but-cheap.)
+Soft/advisory/last-writer-wins, **sole-written** by the orchestrator. **Dropped:** `watchdog_schedule_id`
+and the single `heartbeat` field. **Kept:** `stop_schedule_id` (so the orchestrator can cancel/recreate
+Loop B). The diagnostics make manual resume **informed** (sleeping vs hung-mid-turn vs dead) instead of
+guessing from one TTL; no watchdog consumes them — a human/preflight does.
 
-## 8. Files affected
+## 7. Stop-time control (Codex R6)
 
-- `task-loop/skills/run-cycle/SKILL.md` — Control plane section (3 jobs → 2), Setup (drop watchdog),
-  high-level turn §7, Hard invariants.
-- `task-loop/skills/run-cycle/references/orchestrator-loop.md` — Fast-state header JSON (drop
-  `watchdog_schedule_id`, maybe `heartbeat`), State machine (drop watchdog, fixed-poll wake), §1 lease,
-  §7 wait/idle/exit (fixed poll), §6 (drop takeover damping), Recovery (manual resume = death path),
-  Control plane subsection.
+- **Active stop update** — re-invoke `/run-cycle` (resume / stop-now / new `stop_at`): runs **as the
+  orchestrator**, acquires the lease, updates `stop_at`, **cancels+recreates Loop B immediately**, runs
+  Step 2. The only ~0-latency path for **shortening**, and sole-writer-clean.
+- **Passive raw header edit** while Loop A sleeps: allowed but **eventually observed** (≤ one poll,
+  ~30 min); Loop B recreated on next wake. Discouraged (races sole-writer) vs the active path.
+- ~0 stop latency holds at the **original** `stop_at` via Loop B.
+
+## 8. Cascading simplifications (in scope)
+
+1. **Delete the watchdog (Loop 3)** — job, `watchdog_schedule_id`, Tier-0/Tier-1 alert/relaunch
+   machinery. SKILL "Control plane" → *one live fixed-interval loop + one stop early-wake*. Death/hang
+   recovery documented honestly as manual `/run-cycle` resume.
+2. **Replace takeover damping** with the artifact-aware recovery disposition substep (§5).
+3. **Simplify Setup** — drop "create watchdog"; keep "create stop." Header loses `watchdog_schedule_id`.
+4. **Simplify Step 7 wake** and the `Continuous service`/wake invariants to the fixed-poll model.
+
+## 9. Deliberately kept (orthogonal correctness machinery)
+
+Untouched — hard-won and independent of loop topology: **intra-turn lease fences** (they guard a manual
+double-start's same-identity irreversible merge, *not* the watchdog), **attempt-fencing** +
+per-attempt branches, the **check-then-append seq guard**, all **merge gates**, and the
+`control_log.py` **event schema** + its 58 tests.
+
+## 10. Files affected
+
+- `task-loop/skills/run-cycle/SKILL.md` — Control plane (3 jobs → 2), Setup (drop watchdog; keep stop),
+  high-level turn §7, Hard invariants, stop-time control note.
+- `task-loop/skills/run-cycle/references/orchestrator-loop.md` — header JSON (drop `watchdog_schedule_id`
+  + `heartbeat`, add diagnostics, keep `stop_schedule_id`), State machine (drop watchdog, fixed-poll
+  wake, `phase: exiting` hard terminal guard), §1 lease + tri-state resume, §6 recovery-disposition
+  substep + table, §7 fixed-poll wait/idle/exit, Recovery (manual resume = death/hang path; disposition
+  table), Control plane subsection, Loop B early-wake + stop-time control.
+- `task-loop/scripts/control_log.py` — **additive** `latest_recovery_with_metadata` helper (no schema
+  change).
+- `task-loop/tests/` — new tests for `latest_recovery_with_metadata`; **58 existing stay green**.
 - `docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md` — §12 watchdog / control-plane prose.
-- `task-loop/.claude-plugin/plugin.json` — version bump 0.8.1 → 0.9.0 (notable control-plane change).
-- New: `docs/superpowers/specs/2026-06-14-task-loop-two-loop-control-plane-conclusion.md` (Codex
-  deliberation outcome).
-- `task-loop/scripts/control_log.py` — **no change expected** (loop topology is prose; the protocol
-  is untouched). 58 tests must stay green.
+- `task-loop/.claude-plugin/plugin.json` — version 0.8.1 → 0.9.0 (notable control-plane change).
+- New conclusion: `2026-06-14-task-loop-two-loop-control-plane-conclusion.md` (already written).
 
-## 9. Out of scope
+## 11. Out of scope
 
-- Re-introducing any external supervisor or unattended auto-relaunch (explicitly deferred — manual
-  resume only).
-- Changing the control protocol, attempt-fencing, recovery semantics, or merge gates.
-- Re-introducing idle-notification reactivity (rejected in favor of the pure fixed poll).
+- Any external supervisor / unattended auto-relaunch (manual resume only).
+- Changing the control-event schema, attempt-fencing, recovery artifact-semantics, or merge gates.
+- Re-introducing idle-notification reactivity (rejected for the pure fixed poll).

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.8.1"
+  "version": "0.9.0"
 }

--- a/task-loop/scripts/control_log.py
+++ b/task-loop/scripts/control_log.py
@@ -77,6 +77,23 @@ def latest_recovery(comments: list, attempt_id):
     return found
 
 
+def latest_recovery_with_metadata(comments: list, attempt_id):
+    """Like `latest_recovery`, but return the GitHub-canonical metadata of the
+    winning comment, or None.
+
+    Returns `{"comment_id": id, "created_at": created_at, "recovery": rec}` for the
+    most recent recovery record tagged with `attempt_id` (LAST match wins, mirroring
+    `latest_recovery`), carrying the comment's canonical `created_at` so the
+    orchestrator's recovery-disposition "hold if recent" gate keys off durable GitHub
+    time, NOT the worker-authored JSON `ts` (skew/spoof-prone) or session memory."""
+    found = None
+    for (cid, created_at, body) in comments:
+        for rec in parse_recovery(body):
+            if rec.get("attempt_id") == attempt_id:
+                found = {"comment_id": cid, "created_at": created_at, "recovery": rec}
+    return found
+
+
 def filter_new_inbox(inbox_events: list, seen_uuids) -> list:
     """Return inbox events whose uuid has not been seen, in order, deduping
     repeats within the batch. `seen_uuids` is any container supporting `in`."""

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -84,8 +84,9 @@ crash/hang). Detect which **first**, and keep **all** state in GitHub — no loc
    4–5), rebuild from GitHub, and apply the tri-state takeover (`references/` §1). Otherwise it is a
    **fresh start**.
 2. **Lease:** read the header `lease`. If a **live** lease (`expires_at` in the future) is owned by a
-   different instance → **exit** (never two orchestrators) — unless this is an explicit human
-   force-takeover of a diagnosably-dead lead (tri-state resume, `references/` §1). Else claim it: write
+   different instance → **exit** (never two orchestrators) — unless an explicit human force-takeover is
+   in effect (the header is soft, so force is always available, including over a still-`likely_alive`
+   lead; tri-state resume, `references/` §1). Else claim it: write
    the header with your `lease` (`owner`, `expires_at = now + TTL`) and the turn diagnostics, then
    **re-read and confirm you still own it** before any side effect (the **write-then-re-read fence** —
    GitHub has no atomic CAS). This is the only single-coordinator guard — no local lock file.

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-cycle
-description: This skill should be used when the user asks to "run cycle", "run the task loop", "start the orchestrator", "start the task-loop run", "drive the autonomous loop", or to begin autonomous, orchestrated execution of a task-loop project. It runs the orchestrator under built-in /loop (self-paced): each turn it computes the dependency-ordered task frontier from a single GitHub control issue, spawns one cycle-worker teammate per ready task, validates and merges their PRs (sole integrator), and terminates by a scheduled drain-signal — not an iteration cap.
+description: This skill should be used when the user asks to "run cycle", "run the task loop", "start the orchestrator", "start the task-loop run", "drive the autonomous loop", or to begin autonomous, orchestrated execution of a task-loop project. It runs the orchestrator under built-in /loop on a fixed 30-min poll: each turn it computes the dependency-ordered task frontier from a single GitHub control issue, spawns one cycle-worker teammate per ready task, validates and merges their PRs (sole integrator), and terminates by a scheduled drain-signal — not an iteration cap.
 version: 0.1.0
 ---
 
@@ -10,7 +10,7 @@ version: 0.1.0
 
 Third and final step of the task-loop workflow (`specify-aims` → `create-cycle` →
 **`run-cycle`**). It is the **orchestrator**: the main agent, driven by built-in **`/loop`
-(self-paced)**, that plans and dispatches work and is the **sole integrator** (the only agent
+on a fixed 30-min poll**, that plans and dispatches work and is the **sole integrator** (the only agent
 that merges). It does **not** run any task's cycle itself — `cycle-worker` teammates do that,
 one per task.
 
@@ -40,79 +40,70 @@ Before starting, verify and stop with guidance if any fails:
   provenance and **halts** if it ever finds a task-loop PR merged by someone else, rather than
   laundering it as authorized — but settings should prevent that case.)
 
-## Control plane — one live loop + two guard jobs (no local files)
+## Control plane — one live fixed-interval loop + one stop early-wake (no local files)
 
-`run-cycle` runs as **three cooperating jobs** — a running loop cannot reliably police its own
-death, so two sibling guard jobs bound and watch it. **No local files**: all coordination state
-lives in GitHub (the single control issue); schedule handles live in the scheduler itself,
-recorded in the control-issue body.
+`run-cycle` runs as **two cooperating jobs**. **No local files**: all coordination state lives in
+GitHub (the single control issue); the one schedule handle lives in the scheduler itself, recorded in
+the control-issue body.
 
-1. **Running loop (loop 1)** — a **live `/loop` Agent-Teams lead session** (the orchestrator),
-   **not** a scheduler job. Each turn it **heartbeats its lease into the control-issue body**,
-   replays the control-issue comment log to rebuild fast state, plans → dispatches → merges, and
-   **self-bounds on `stop_at`**. Teammate idle notifications are a **within-session latency
-   optimization, not part of correctness** — correctness rests entirely on GitHub replay +
-   idempotent respawn (see `references/`).
-2. **Watchdog (loop 3)** — a **recurring scheduler job every 30 min**. It reads the control-issue
-   body; if loop 1's `heartbeat` is stale **and `now < stop_at`**, loop 1 is presumed dead:
-   - **Tier 0 (always — the guaranteed floor): detect + alert.** Post a **plain non-control
-     comment** (no `task-loop-event` fence — invisible to the sequencer) plus a push notification
-     "orchestrator down, resume needed." Recovery is then a clean **manual `/run-cycle`** (it
-     rebuilds 100% from GitHub — that is the payoff of no-local-files).
-   - **Tier 1 (only if a tested local supervisor is configured): unattended auto-relaunch.** A
-     dead `/loop` session cannot relaunch itself and a cloud routine cannot spawn local Agent-Teams
-     teammates, so true auto-resurrection needs a **named local supervisor** (OS launchd/cron, or
-     a verified locally-running job) with a tested launch template (repo cwd, `CLAUDE_CODE_
-     EXPERIMENTAL_AGENT_TEAMS=1`, plugin loaded, `gh` authed, `/run-cycle` under `/loop`, log
-     capture). That is **setup/config, not runtime state**, but it is a real precondition — the
-     Phase-0 spike must validate it before any unattended-resurrection claim. Absent it, the
-     watchdog stays at Tier 0.
-   The `now < stop_at` guard ensures neither tier resurrects the run after an intentional stop.
-3. **Stop (loop 2)** — a **one-time scheduler job at `stop_at`**. It reads the control-issue body
-   for `watchdog_schedule_id`, **cancels the watchdog (loop 3) first** (so it can't resurrect the
-   run), then confirms loop 1 has drained. The clean teardown of loops 1 **and** 3.
+1. **Loop A — the orchestrator** — a **live `/loop` Agent-Teams lead session**, **not** a scheduler
+   job. Each turn it refreshes its lease in the control-issue body, replays the control-issue comment
+   log to rebuild fast state, **monitors team status → merges → dispatches over the full re-derived
+   frontier (seat-capped at 5)**, and ends with a **fixed `ScheduleWakeup(1800)`** (30 min). It
+   **self-bounds on `stop_at`** (the Step-2 stop-check is the sole stop decision) and treats
+   `phase: exiting` as a **hard terminal guard**. A fixed poll that re-derives the whole frontier each
+   tick makes an *alive-but-stuck* orchestrator structurally impossible *between* turns — which is what
+   the old watchdog really guarded against. There is **no watchdog**.
+2. **Loop B — the stop early-wake** — a **one-time scheduler job at `stop_at`** that fires into Loop
+   A's own session and **wakes it early** so the woken turn's Step-2 stop-check drains promptly (bounds
+   stop latency to ~0). It does **not** write the header or force exit itself. Its handle
+   (`stop_schedule_id`) lives in the control-issue body so the orchestrator can cancel/recreate it when
+   `stop_at` changes (see `references/` → *Stop-time control*).
 
-The two guard jobs (2 & 3) and any Tier-1 relaunch must run in the **same local environment**
-where Agent Teams is enabled. Their handles (`watchdog_schedule_id`, `stop_schedule_id`) live in
-the **control-issue body runtime header** (orchestrator is its sole writer) so loop 2 can cancel
-loop 3 — **no `orchestrator-state.json`, no flag file, nothing on local disk.**
+**Death / intra-turn-hang recovery is manual `/run-cycle` resume** — it rebuilds 100% from GitHub (the
+payoff of no-local-files), so there is **no in-protocol liveness watch**. This is an accepted reduction
+vs the old watchdog: a fixed poll prevents *inter-turn* under-dispatch, but an *intra-turn* hang
+(mitigated by best-effort command deadlines, not eliminated) or a dead session is recovered by a human
+re-running `/run-cycle`. Loop B runs in the **same local environment** where Agent Teams is enabled.
+**No `orchestrator-state.json`, no flag file, nothing on local disk.**
 
 ## Setup
 
-`run-cycle` is invoked two ways — a **fresh start** (you) or a **resubmit** (loop 3, after a
-crash). Detect which **first**, and keep **all** state in GitHub — no local files:
+`run-cycle` is invoked two ways — a **fresh start** or a **resume** (a human re-running it after a
+crash/hang). Detect which **first**, and keep **all** state in GitHub — no local files:
 
 0. **Control issue:** find the project's single pinned control issue (labelled
    `task-loop:control`), or create it if absent (`gh issue create`, then pin + label). Its
    **comments** are the append-only, sequenced `CONTROL_EVENT` log; its **body** is the mutable
-   **runtime header** — a fenced ` ```task-loop-runtime ` JSON block holding `lease`, `stop_at`,
-   `watchdog_schedule_id`, `stop_schedule_id`, and an advisory `phase`. The orchestrator (loop 1)
-   is the header's **sole writer**; loops 2 & 3 only read it.
-1. **Fresh vs resubmit:** read the body header. If it already holds a valid `stop_at` **and** both
-   schedule handles, this is a **resubmit/resume** — **skip the duration prompt and schedule
-   creation** (steps 4–6); the loops already exist. Otherwise it is a **fresh start**.
-2. **Lease:** read the header `lease`. If a **live** lease (`expires_at` in the future) is owned by
-   a different instance → **exit** (never two orchestrators). Else claim it: write the header with
-   your `lease` (`owner`, `expires_at = now + TTL`, `heartbeat = now`), then **re-read and confirm
-   you still own it** before any side effect (the **write-then-re-read fence** — GitHub has no
-   atomic CAS). This is the only single-coordinator guard — no local lock file.
-3. **Team:** create the agent team you spawn `cycle-worker` teammates into (recreated on a
-   resubmit, since teammates are ephemeral).
+   **runtime header** — a fenced ` ```task-loop-runtime ` JSON block holding `lease`, the turn
+   diagnostics (`last_turn_started_at`/`last_turn_completed_at`/`next_wakeup_at`), `stop_at`,
+   `stop_schedule_id`, and an advisory `phase`. The orchestrator (Loop A) is the header's **sole
+   writer**.
+1. **Fresh vs resume:** read the body header. If it already holds a valid `stop_at` **and**
+   `stop_schedule_id`, this is a **resume** — **skip the duration prompt and Loop B creation** (steps
+   4–5), rebuild from GitHub, and apply the tri-state takeover (`references/` §1). Otherwise it is a
+   **fresh start**.
+2. **Lease:** read the header `lease`. If a **live** lease (`expires_at` in the future) is owned by a
+   different instance → **exit** (never two orchestrators) — unless this is an explicit human
+   force-takeover of a diagnosably-dead lead (tri-state resume, `references/` §1). Else claim it: write
+   the header with your `lease` (`owner`, `expires_at = now + TTL`) and the turn diagnostics, then
+   **re-read and confirm you still own it** before any side effect (the **write-then-re-read fence** —
+   GitHub has no atomic CAS). This is the only single-coordinator guard — no local lock file.
+3. **Team:** create the agent team you spawn `cycle-worker` teammates into (recreated on a resume,
+   since teammates are ephemeral).
 4. *(fresh only)* **Run duration (prompt for it).** **Ask the user** *"How long should the loop run
    before a graceful stop? (default: 24 hours)"* — accept a duration or an absolute time, **default
    24 hours**. An **interactive prompt, not a command-line argument**. Write the absolute `stop_at`
    (UTC) into the body header.
-5. *(fresh only)* **Create the watchdog (loop 3)** with the built-in scheduler: a recurring job
-   **every 30 min** that, when the header `heartbeat` is stale and `now < stop_at`, **detects +
-   alerts** (Tier 0: a plain non-control comment + push notification) and — only if a tested local
-   supervisor is configured — auto-relaunches `run-cycle` (Tier 1). Write its handle into the header
-   as `watchdog_schedule_id`. (See *Control plane* for the Tier-0/Tier-1 launcher contract.)
-6. *(fresh only)* **Create the stop (loop 2)** with the built-in scheduler: a one-time job at
-   `stop_at` that reads `watchdog_schedule_id` from the header, **cancels it**, then confirms loop 1
-   has drained. Write its handle into the header as `stop_schedule_id`.
-7. **Run the orchestrator turn (loop 1)** (below / `references/`). It self-bounds: each turn it
-   compares the clock to `stop_at` and caps its next wake so it wakes by `stop_at` to drain — so the
-   run stops even if loop 2 fails. (To run longer or stop sooner, edit `stop_at` in the header.)
+5. *(fresh only)* **Create Loop B — the stop early-wake** with the built-in scheduler: a one-time job
+   at `stop_at` that fires into this session and wakes the orchestrator so its Step-2 stop-check drains
+   promptly. Write its handle into the header as `stop_schedule_id`. (It does **not** force exit — the
+   woken turn decides; see *Stop-time control*.)
+6. **Run the orchestrator turn (Loop A)** (below / `references/`). It self-bounds: each turn it
+   compares the clock to `stop_at`, caps its next wake so it wakes by `stop_at` to drain — so the run
+   stops even if Loop B never fires — and ends with the fixed 30-min `ScheduleWakeup`. To run longer or
+   stop sooner, **re-invoke `/run-cycle`** (active stop update: updates `stop_at` and recreates Loop B,
+   ~0 latency), or edit `stop_at` in the header (passive: observed within one poll).
 
 ## The orchestrator turn (high level)
 
@@ -147,7 +138,7 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
    up to **5 concurrent `cycle-worker` teammates** (documented guideline, not enforced) by
    `directions.md` priority, then oldest `ready_since`, then `proposal.md` Roadmap order, reserving ≥1
    seat for the oldest (starvation-free). **Active workers never suppress dispatch, but a lead never
-   *intentionally* exceeds 5 in flight** (best-effort per-session cap; a watchdog false-positive
+   *intentionally* exceeds 5 in flight** (best-effort per-session cap; a manual double-start
    takeover may transiently exceed it, correctness-safe via attempt fencing). **Dispatch** each
    selected task: idempotently create/reuse its `Task-Loop-Task:
    <task_id>`-marked issue, emit `TASK_CREATED{…, iteration}` (first dispatch) + `TASK_DISPATCHED{…,
@@ -155,12 +146,12 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
    the task issue number, `control_issue`, `spawned_plan_revision` (= current), `iteration`, a fresh
    `attempt_id`, the per-attempt branch `<branch>-attempt-<attempt_id>`, `lead_worktree_root`, and
    the scope.
-7. **Wait / idle / exit:** reached only after §6 has filled every free seat it can. Teammate **idle
-   notifications are the primary wake**; add a **bounded, jittered** fallback `ScheduleWakeup`
-   (shorter when a capped backlog waits on a freeing seat, never a busy-loop); **idle** (long
-   `ScheduleWakeup`, do **not** exit) only when the frontier is empty with no stop signal; when
+7. **Wait / idle / exit:** reached only after §6 has filled every free seat it can. Any non-terminal
+   state schedules the **same fixed `ScheduleWakeup(1800)`** (idle notifications are no longer part of
+   the wake model); **idle** (do **not** exit) when the frontier is empty with no stop signal; when
    draining completes, run the recorded **pre-exit audit** and a **two-phase quiescence exit**
-   (cooldown + re-audit) before stopping.
+   (cooldown + re-audit) before stopping. `phase: exiting` is a **hard terminal guard** — a stray/late
+   wake re-audits and stops without dispatching.
 
 ## Hard invariants
 
@@ -174,12 +165,13 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
 - **Proactive, seat-capped dispatch:** each turn merges completions **first**, then dispatches ready
   tasks into free seats **up to 5 concurrent workers** (documented guideline, not enforced). Active
   workers never suppress dispatch — a task unblocked by a merge is submitted the **same turn** if a
-  seat is free — but a lead never *intentionally* runs >5 (best-effort per-session cap; a watchdog
-  false-positive may transiently exceed it, bounded by attempt fencing); selection is
+  seat is free — but a lead never *intentionally* runs >5 (best-effort per-session cap; a manual
+  double-start may transiently exceed it, bounded by attempt fencing); selection is
   priority-then-oldest-ready (starvation-free).
-- **Continuous service:** "no ready work" is `idle`, never exit. Termination is a scheduled
-  **drain-signal**, with a bounded, non-destructive drain (overdue workers →
-  `orphaned_acknowledged`).
+- **Continuous service:** "no ready work" is `idle` (a fixed 30-min wake), never exit. Termination is a
+  scheduled **drain-signal** (the Loop B early-wake + the Step-2 self-bound), with a bounded,
+  non-destructive drain (overdue workers → `orphaned_acknowledged`). Death or an intra-turn hang is
+  recovered by **manual `/run-cycle` resume** — there is no watchdog.
 - **Labels are a human index only;** the GitHub append-only control-event log is authoritative;
   the Agent-Teams mailbox is notification-only.
 

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -95,7 +95,9 @@ stray/late wake reading a clean `exiting` re-audits and stops without dispatchin
 
 ### 1. Lease & rebuild
 - Read the **control-issue body header**. If a **live** lease (`expires_at` in the future) is owned
-  by a different instance → exit (never two orchestrators). Else acquire/refresh the lease by writing
+  by a different instance → exit (never two orchestrators) — **unless an explicit human
+  force-takeover is in effect** (the header is soft, so force is always available, including over a
+  still-`likely_alive` lease; see the tri-state below). Else acquire/refresh the lease by writing
   the header (`owner`, `expires_at = now + TTL`, and the turn diagnostics `last_turn_started_at = now`
   and the `next_wakeup_at` you intend to schedule), then **re-read the header and confirm you still own
   it** before any side effect (the **write-then-re-read fence**; GitHub gives no atomic CAS, so this is
@@ -233,10 +235,12 @@ creates ≤5 issues this turn).
     re-dispatch mints a fresh `attempt_id` + its own branch, and `adopt_from_branch` only **reads** the
     old branch.
   - **"Recent" is a pure function of canonical GitHub time** (not the worker-authored JSON `ts`, not
-    session memory): `hold_until = created_at + 1800 + skew_grace`, where `created_at =
-    control_log.latest_recovery_with_metadata(comments, current_attempt_id)["created_at"]`. If
-    `now < hold_until` → **hold** the task one poll (a merely-late live worker can finish or
-    self-report) and re-evaluate next tick; human force overrides the hold.
+    session memory). Let `m = control_log.latest_recovery_with_metadata(comments, current_attempt_id)`.
+    **If `m is None`** (no recovery comment for `current_attempt_id` — e.g. a branch-but-no-PR attempt
+    that pushed before ever reporting) → treat as **not recent** → mint per the table immediately, **no
+    hold**. Otherwise `hold_until = m["created_at"] + 1800 + skew_grace`: if `now < hold_until` →
+    **hold** the task one poll (a merely-late live worker can finish or self-report) and re-evaluate
+    next tick; else mint per the table. Human force overrides any hold.
 - **Dispatchable** = dependencies complete (each dep's `MERGE_GRANTED` is in the log → status
   `merged`), revision-compatible (`spawned_plan_revision` would be the current `plan_revision`), and
   **either** status `ready` (never dispatched) **or** status `active` with **no live worker** for its

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -22,52 +22,68 @@ state = control_log.replay(events)
 ```
 
 **No local files.** The only mutable runtime cell is the **control-issue body runtime header** — a
-fenced ` ```task-loop-runtime ` JSON block the orchestrator (loop 1) is the **sole writer** of.
+fenced ` ```task-loop-runtime ` JSON block the orchestrator (Loop A) is the **sole writer** of.
 Everything else is the append-only comment log (replayed above) or live session memory; nothing is
 written to local disk. Header shape:
 
 ```json
 {
-  "lease": {"owner": "<id>", "expires_at": "<utc>", "heartbeat": "<utc>"},
+  "lease": {"owner": "<id>", "expires_at": "<utc ~2x poll>"},
+  "last_turn_started_at": "<utc>",
+  "last_turn_completed_at": "<utc>",
+  "next_wakeup_at": "<utc>",
   "phase": "dispatching|waiting|idle|draining|exiting_pending|exiting",
   "stop_at": "<utc>",
   "drain_deadline_at": null,
-  "watchdog_schedule_id": null,
   "stop_schedule_id": null
 }
 ```
 
 `phase`/`current_plan_revision`/`active_worker_ids` are **derived** (rebuilt by `replay` + session
-memory) — the header only persists what a *sibling job* must read: the `lease` heartbeat, `stop_at`,
-and the two schedule handles. The lease `heartbeat` is refreshed every turn (a `gh issue edit` of
-the body); the **watchdog** (loop 3) reads the header and treats a stale `heartbeat`/`expires_at` as
-"the running loop died" and resubmits it. `stop_at` is the self-bound graceful-stop time;
-`watchdog_schedule_id`/`stop_schedule_id` are the built-in scheduler handles for loops 3 and 2 (so
-loop 2 can cancel loop 3). See *Control plane*. Body writes are last-writer-wins, which is safe
-because the lease loser exits — but two near-simultaneous writers are possible, so the lease is a
-**soft** single-coordinator guard, not an atomic CAS.
+memory). The header is **soft, advisory, last-writer-wins**, and the orchestrator is its **sole
+writer** — it persists only the lease plus diagnostics a *human or the resume preflight* reads; **no
+sibling job consumes it** (there is no watchdog). `expires_at` (~2× the 1800 s poll) is the
+single-coordinator TTL: a manual second `/run-cycle` start that finds it in the future exits.
+`last_turn_started_at`/`last_turn_completed_at`/`next_wakeup_at` are **diagnostics** that make a manual
+resume *informed* (sleeping vs hung-mid-turn vs dead) instead of guessing from one TTL — advisory
+inputs, never proof. `stop_at` is the self-bound graceful-stop time; `stop_schedule_id` is the
+scheduler handle the orchestrator uses to cancel/recreate **Loop B** (the stop early-wake) when
+`stop_at` changes. See *Stop-time control*. Because writes are last-writer-wins and GitHub gives no
+atomic CAS, the lease is a **soft** single-coordinator guard (the loser exits on the write-then-re-read
+fence), not an atomic lock.
 
 ## State machine
+
+**Two loops.** **Loop A** is this `/loop` orchestrator; every turn ends with a **fixed
+`ScheduleWakeup(1800)`** (30 min). **Loop B** is a one-time stop early-wake at `stop_at` (see
+*Stop-time control*). There is **no watchdog** — a fixed poll that re-derives the whole frontier each
+tick makes an *alive-but-stuck* orchestrator structurally impossible *between* turns. It does **not**
+cover an *intra-turn hang* (a `gh`/CI/spawn call that never returns before the turn reschedules): wrap
+the orchestrator's own long calls in **best-effort command deadlines** and **reconcile any ambiguous
+side effect on timeout** (re-inspect PR state before rescheduling) so a turn almost always returns to
+schedule its next poll; a genuine hang or a dead session is then handled by **manual `/run-cycle`
+resume** (a documented reduction vs the old watchdog).
 
 **Dispatch is a seat-capped action, not a phase.** Every turn — *after* merging completions (§5) —
 the orchestrator fills every **free worker seat** with a ready task, up to a **fixed cap of 5**
 concurrent `cycle-worker` teammates (5 tasks in flight), **whether or not other workers are still
 active**. It is **proactive** (a task unblocked this turn is dispatched this turn) but **bounded**
-(never more than 5 *intentionally* per lead session — see §6 for the watchdog-false-positive caveat)
-— active workers never suppress dispatch of newly-ready work *as long as a seat is free*. `waiting` is what the orchestrator does *after* it has filled every seat it
-can, not an alternative to dispatching. Re-entering a turn always re-runs merge→dispatch first.
-The 5-seat cap is a **documented guideline in this prompt, not a programmatically enforced limit**.
-The phases:
+(never more than 5 *intentionally* per lead session — see §6 for the manual-double-start caveat) —
+active workers never suppress dispatch of newly-ready work *as long as a seat is free*. `waiting` is
+what the orchestrator does *after* it has filled every seat it can, not an alternative to dispatching.
+Re-entering a turn always re-runs merge→dispatch first. The 5-seat cap is a **documented guideline in
+this prompt, not a programmatically enforced limit**. **`phase: exiting` is a hard terminal guard** (a
+stray/late wake reading a clean `exiting` re-audits and stops without dispatching — §7). The phases:
 
 - **dispatching** — creating tasks + spawning workers for ready tasks this turn. Entered whenever
   any ready task exists and `stop_at` is not reached — **including while other workers are active**
   (a §5 merge or a freed concurrency slot just unblocked it).
-- **waiting** — after filling every free seat, work is in flight. Teammate idle notifications are
-  the **primary** wake; add a **bounded, jittered** fallback `ScheduleWakeup` — shorter only when a
-  capped backlog waits on a freeing seat, never aggressive polling, never a busy-loop (see §7).
-  `waiting` never means "stop dispatching" — the next turn re-runs §5→§6 first.
-- **idle** — no ready work, no active workers, `stop_at` not reached → long `ScheduleWakeup`
-  (capped so it never sleeps past `stop_at`); **do not exit** (continuous service).
+- **waiting** — after filling every free seat, work is in flight → the **fixed `ScheduleWakeup(1800)`**.
+  Idle notifications are **no longer part of the wake model**; every non-terminal phase uses the one
+  fixed cadence. `waiting` never means "stop dispatching" — the next turn re-runs §5→§6 first.
+- **idle** — no ready work, no active workers, `stop_at` not reached → the same **fixed
+  `ScheduleWakeup(1800)`** (capped so it never sleeps past `stop_at`); **do not exit** (continuous
+  service).
 - **draining** — clock reached `stop_at` → no new dispatch; wait for active workers, bounded
   by `drain_deadline_at`.
 - **exiting_pending** — drain complete → record the pre-exit audit, `ScheduleWakeup` a 60–120 s
@@ -79,12 +95,21 @@ The phases:
 
 ### 1. Lease & rebuild
 - Read the **control-issue body header**. If a **live** lease (`expires_at` in the future) is owned
-  by a different instance → exit (never two orchestrators). Else acquire/refresh the lease by
-  writing the header (`owner`, `expires_at = now + TTL`, `heartbeat = now`), then **re-read the
-  header and confirm you still own it** before any side effect (the **write-then-re-read fence**;
-  GitHub gives no atomic CAS, so this is how a lease loser detects it lost and exits).
-- On resume / stale lease (`expires_at` past, or `phase: exiting` without a clean prior audit):
-  take over, then **rebuild fast state from the control issue** (replay the comment log, above).
+  by a different instance → exit (never two orchestrators). Else acquire/refresh the lease by writing
+  the header (`owner`, `expires_at = now + TTL`, and the turn diagnostics `last_turn_started_at = now`
+  and the `next_wakeup_at` you intend to schedule), then **re-read the header and confirm you still own
+  it** before any side effect (the **write-then-re-read fence**; GitHub gives no atomic CAS, so this is
+  how a lease loser detects it lost and exits).
+- **On resume / stale lease, classify the prior lead from the advisory diagnostics (tri-state):**
+  - **`likely_alive`** — `next_wakeup_at` **and** `expires_at` both in the future → the prior lead is
+    sleeping normally → **default refuse** the takeover, but allow an **explicit human force-takeover**
+    (the header is soft, so this is never an absolute block).
+  - **`likely_dead`** — `now ≫ next_wakeup_at` (the lead missed its wake → hung or dead) or
+    `expires_at` well past → acquire the lease but enter **observe/reconcile first** (do **not** eagerly
+    mint attempts — §6's recovery-disposition substep gates re-dispatch).
+  - The diagnostics are **advisory inputs, never proof** (the header is last-writer-wins and can be
+    stale either way); human force is always available.
+- After takeover, **rebuild fast state from the control issue** (replay the comment log, above).
   There is no local cache to distrust — fast state is always reconstructed from GitHub.
 
 ### 2. Stop check
@@ -177,11 +202,12 @@ abort the turn without merging or emitting. Act in this order:
 
 ### 6. Dispatch — proactive, seat-capped (skip if draining)
 **Lease fence first:** before this batch, **refresh + re-read the lease and re-confirm you still own
-it** — a merge-then-multi-dispatch turn can run long, and a mid-turn stale heartbeat could let the
-watchdog presume the lead dead and spawn a second one (the lease is a *soft* guard, §1/§"Emitting
-control events"). If you've lost it, **abort the turn without emitting**. The per-emit
-check-then-append seq guard still fences every individual `CONTROL_EVENT`; this fence keeps the
-heartbeat fresh across the long turn so the race stays vanishingly rare. Then recompute the frontier
+it** — a merge-then-multi-dispatch turn can run long, and a **manual double-start** (a human
+force-resuming during that long turn) could put a second lead on the same GitHub identity (the lease is
+a *soft* guard, §1/§"Emitting control events"). If you've lost it, **abort the turn without emitting**.
+The per-emit check-then-append seq guard still fences every individual `CONTROL_EVENT`; this fence
+keeps `expires_at` fresh across the long turn so the race stays vanishingly rare. Then recompute the
+frontier
 from the **post-merge** state and dispatch ready tasks into every **free worker seat**, up to the
 **5-seat cap**. **Proactive, not reluctant — but bounded:** do **not** hold a ready task back because
 other workers are still in flight (fill a free seat), and do **not** exceed 5 concurrent workers.
@@ -192,13 +218,32 @@ so **no per-task side effect happens before selection** — only the ≤5 *selec
 keeping the side-effect batch bounded even with hundreds of ready tasks (a 200-ready frontier still
 creates ≤5 issues this turn).
 
+- **Recovery disposition (apply before classifying an `active`-with-no-live-worker task as
+  dispatchable).** Such a task is **not** unconditionally re-dispatched — first inspect its
+  GitHub-visible artifacts for `current_attempt_id` and pick the exact disposition (this **replaces**
+  the old watchdog-era *takeover damping*):
+  - **open PR / `merge_requesting`** (latest recovery for `current_attempt_id`) → **reconcile**: drive
+    it through the §5 merge gate (merge or deny). **Spawn no worker.**
+  - **a per-attempt branch but no PR** → **hold if recent** (gate below); else mint a **new** attempt
+    with `adopt_from_branch` = that branch.
+  - **recovery comments only** (no branch, no PR) → a liveness hint only; **hold if recent**; else mint
+    a **fresh** attempt from clean `master`.
+  - **nothing** (no branch, no PR, no recent recovery) → mint a **fresh** attempt immediately.
+  - **Invariant (unchanged):** never reuse an `attempt_id` or write an existing attempt branch; every
+    re-dispatch mints a fresh `attempt_id` + its own branch, and `adopt_from_branch` only **reads** the
+    old branch.
+  - **"Recent" is a pure function of canonical GitHub time** (not the worker-authored JSON `ts`, not
+    session memory): `hold_until = created_at + 1800 + skew_grace`, where `created_at =
+    control_log.latest_recovery_with_metadata(comments, current_attempt_id)["created_at"]`. If
+    `now < hold_until` → **hold** the task one poll (a merely-late live worker can finish or
+    self-report) and re-evaluate next tick; human force overrides the hold.
 - **Dispatchable** = dependencies complete (each dep's `MERGE_GRANTED` is in the log → status
   `merged`), revision-compatible (`spawned_plan_revision` would be the current `plan_revision`), and
   **either** status `ready` (never dispatched) **or** status `active` with **no live worker** for its
-  `current_attempt_id` (an orphaned/crashed attempt — re-dispatched as a *recovery*, branching from
-  `adopt_from_branch`; see *Recovery*). **Exclude** tasks with a **live** worker, `merged`, or
-  `stale`. (Status `active` alone is **not** "in flight" — on a cold resume `active_worker_ids` is
-  empty, so every un-merged dispatched task is a recovery candidate, never stranded.)
+  `current_attempt_id` (an orphaned/crashed attempt — subject to the **recovery disposition** above).
+  **Exclude** tasks with a **live** worker, `merged`, or `stale`. (Status `active` alone is **not** "in
+  flight" — on a cold resume `active_worker_ids` is empty, so every un-merged dispatched task is a
+  recovery candidate, never stranded.)
 - **Aging key (log-derived, zero side effect):** `ready_since(task)` = the seq of its **last
   dependency's `MERGE_GRANTED`** (or `0` for a dependency-free root). It needs **no** per-task event
   or issue, so an unselected task costs **nothing** on GitHub and the key is a pure function of the
@@ -214,19 +259,19 @@ creates ≤5 issues this turn).
   programmatically enforced limit** — a lead never *intentionally* runs more than 5. Tasks beyond the
   cap are simply **not selected** this turn — they remain dispatchable (no issue, no event yet) and
   win a seat as one frees (§7's bounded wake), never abandoned.
-  - **The cap is per-lead-session, not global.** Its one documented breach is a watchdog
-    **false-positive takeover** (a second lead spawns while the first's workers still live, see
-    *Recovery*): the new lead **cannot observe the old lead's teammates** (ephemeral, invisible across
-    sessions), so it may re-dispatch their `active` tasks and transiently run up to ~2× the cap until
-    the superseded attempts hit their merge-gate/lease fences and stop. That overshoot is
-    **correctness-safe** (durable `current_attempt_id` + per-attempt branches mean only one attempt
-    can ever merge) and **transient** — a bounded *cost* overrun, never a broken invariant. A true
-    global cap would need durable per-worker liveness heartbeats; that enforcement machinery is
-    deliberately **out of scope** (the cap is a guideline, not an invariant).
-  - **Takeover damping** (shrinks, does not eliminate, the overshoot): on the **first** turn after
-    taking over a stale lease, defer re-dispatch of `active`-status tasks by one bounded
-    recovery-probe interval before reclassifying them as orphaned — so a merely-stalled prior lead
-    does not instantly get its worker count doubled. Steady-state turns skip the delay.
+  - **The cap is per-lead-session, not global.** Its one documented breach is a **manual double-start
+    takeover** (a human runs `/run-cycle` a second time and force-takes a lease the first lead still
+    holds — the startup lease check normally prevents this): the new lead **cannot observe the old
+    lead's teammates** (ephemeral, invisible across sessions), so it may re-dispatch their `active`
+    tasks and transiently run up to ~2× the cap until the superseded attempts hit their
+    merge-gate/lease fences and stop. That overshoot is **correctness-safe** (durable
+    `current_attempt_id` + per-attempt branches mean only one attempt can ever merge) and **transient**
+    — a bounded *cost* overrun, never a broken invariant. A true global cap would need durable
+    per-worker liveness heartbeats; that enforcement machinery is deliberately **out of scope** (the cap
+    is a guideline, not an invariant).
+  - The **recovery-disposition substep** (reconcile/adopt artifacts, hold-if-recent before minting) is
+    what now caps that cost; it **replaces** the old watchdog-era *takeover damping*. The tri-state
+    resume (§1) further refuses a takeover when the prior lead is diagnosably alive.
 - **Dispatch each selected task** (≤5 — the only GitHub writes of this step):
   - **Idempotent issue creation (crash-safe):** before `gh issue create`, search for an existing
     issue carrying a `Task-Loop-Task: <task_id>` marker line and **reuse it** if found; otherwise
@@ -257,38 +302,56 @@ creates ≤5 issues this turn).
 
 ### 7. Wait / idle / exit
 Reached **only after §6 has filled every free seat it can** — never sleep with a free seat and ready
-work.
-- **Workers active, no capped backlog** → `waiting`: automatic teammate **idle notifications are the
-  primary wake** (a worker reporting done triggers §5→§6 the next turn); add only a **bounded
-  heartbeat-interval fallback** `ScheduleWakeup` **with jitter**. Do **not** poll aggressively —
-  active workers alone are not a reason to wake early.
-- **Ready tasks remain but all 5 seats are full** → `waiting` with a **shorter, still-floored +
-  jittered** fallback wake — a freeing seat also emits an idle notification, so this only backstops a
-  missed one; the next turn re-runs §5→§6 to fill the freed seat. **Never busy-loop:** the floor +
-  idle notifications bound the rate. Drop `active_worker_ids` entries as workers report and are merged.
-- **Deferred recovery candidates exist** (first turn after a stale-lease takeover — §6 takeover
-  damping is holding `active`-status tasks for one recovery-probe interval) → `waiting`: schedule the
-  **bounded recovery-probe wake (jittered)**; **do not `idle` or exit**. These are *not* "frontier
-  empty" — they are damped recovery work, and the very next turn (after the probe interval) §6
-  reclassifies and re-dispatches them. They also fail the pre-exit audit (below), so the loop cannot
-  declare quiescence while recovery is merely deferred.
-- **Frontier empty, none active, `stop_at` not reached** → `idle`: long `ScheduleWakeup` (capped
-  to wake by `stop_at`); **do not exit**.
+work. The wake model is a **pure fixed poll**: every non-terminal state schedules the **same fixed
+`ScheduleWakeup(1800)`** (30 min). Idle notifications are **not** relied upon; whatever a turn finds it
+re-derives from GitHub and handles.
+- **Workers active, a capped backlog, or the frontier empty** (`stop_at` not reached) →
+  `waiting`/`idle`: schedule the **fixed `ScheduleWakeup(1800)`**, capped so it never sleeps past
+  `stop_at`; **do not exit** (continuous service). One cadence for all of these — no jittered fallback,
+  no shorter backlog wake, no recovery-probe wake. A held recovery candidate (§6 "hold if recent") is
+  simply re-evaluated on the next fixed tick. Drop `active_worker_ids` entries as workers report and are
+  merged.
 - **draining** → dispatch nothing; wait for active workers until `drain_deadline_at`; past the
   deadline, mark overdue workers `orphaned_acknowledged` (record worktree/issue/PR pointers — no
   abrupt kill) and proceed.
 - **Drain complete** → `exiting_pending`: run the **pre-exit audit** (below), record real command
   outputs into a decision record, `ScheduleWakeup` a 60–120 s cooldown.
-- **Cooldown wake** → re-run the audit from scratch. Still clean → `exiting`: stop rescheduling.
-  Anything changed → revert to `dispatching`/`waiting`.
+- **Cooldown wake** → re-run the audit from scratch. Still clean → `exiting`: **stop rescheduling**
+  (no further `ScheduleWakeup`). Anything changed → revert to `dispatching`/`waiting`.
+- **Hard terminal guard.** Because the stop early-wake (Loop B) or a stray/late `ScheduleWakeup` can
+  fire after exit, a turn that reads a clean `phase: exiting` at the top **re-audits and stops without
+  dispatching** — a late wake can never re-enter the run; only a changed state reverts to
+  `dispatching`/`waiting`.
 
 ### 8. Heartbeat
-Refresh the lease `heartbeat`/`expires_at` (and advisory `phase`/`stop_at`/schedule handles) by
-writing the **control-issue body header** (`gh issue edit`). This is the only durable write of the
-turn besides the appended `CONTROL_EVENT` comments — there is no local cache to persist. This
-end-of-turn refresh is **in addition to** the intra-turn lease re-reads §5/§6 perform before their
-side-effect groups; together they keep the heartbeat fresh across a long merge-then-multi-dispatch
-turn so a busy lead is never mistaken for a dead one.
+Refresh the lease `expires_at` and the diagnostics (`last_turn_completed_at = now`, and the
+`next_wakeup_at` you are about to schedule) — plus advisory `phase`/`stop_at`/`stop_schedule_id` — by
+writing the **control-issue body header** (`gh issue edit`). This is the only durable write of the turn
+besides the appended `CONTROL_EVENT` comments — there is no local cache to persist. This end-of-turn
+refresh is **in addition to** the intra-turn lease re-reads §5/§6 perform before their side-effect
+groups; together they keep `expires_at` fresh across a long merge-then-multi-dispatch turn so a busy
+lead is never mistaken for a stale one by a *manual* resume (the only remaining second-lead source —
+there is no watchdog).
+
+## Stop-time control (Loop B)
+
+**Loop B** is a one-time scheduled job at `stop_at` that fires **into Loop A's own session** (the
+built-in scheduler enqueues a prompt that runs while the REPL is idle, i.e. between polls). It does
+**not** write the header or force `phase: exiting` itself — it simply **wakes Loop A early**, and that
+turn's **Step 2 stop-check (against the *current* header `stop_at`)** is the sole stop decision. A
+stale early fire is therefore harmless: the woken turn sees `now < stop_at` and continues. Loop B
+carries the `stop_at` (a `stop_generation`) it was created for as **stale-trigger defense**, but Step
+2's check is the real gate. Its value: it **bounds stop latency to ~0** at the scheduled `stop_at`,
+versus the up-to-one-poll lag Loop A's own Step-2 check would otherwise incur.
+
+Changing `stop_at` (run longer / stop sooner) splits into two paths:
+- **Active stop update** — re-invoke `/run-cycle` (resume / stop-now / new `stop_at`): it runs **as the
+  orchestrator**, acquires the lease, updates `stop_at`, **cancels the old Loop B via `stop_schedule_id`
+  and creates a new one** for the new time, then runs Step 2. This is the **only** ~0-latency path for
+  **shortening**, and it is sole-writer-clean.
+- **Passive raw header edit** while Loop A sleeps — allowed but only **eventually observed** (≤ one
+  poll, ~30 min): Loop A recreates Loop B and acts on the new `stop_at` on its next wake. Discouraged
+  (it races the sole-writer model) in favor of the active path.
 
 ## Emitting control events
 
@@ -309,8 +372,9 @@ confirm its true max `seq` is still `state["last_seq"]`** — only then `assign_
 higher `seq` has appeared, a competing sequencer exists: re-ingest, recompute, retry; if it
 persists you have lost the lease → **exit**. Together with the write-then-re-read lease fence (§1),
 this is the single-sequencer guarantee under GitHub's non-CAS body writes — a vanishingly-small
-TOCTOU window between the re-read and the append remains and is accepted (the watchdog only acts on
-an already-stale heartbeat, so two live orchestrators are rare by construction). If `replay` ever
+TOCTOU window between the re-read and the append remains and is accepted (the only second-lead source
+is a *manual* double-start, which the startup lease check normally prevents, so two live orchestrators
+are rare by construction). If `replay` ever
 raises on a seq gap/dup or duplicate `source_uuid`, that is **detectable corruption → halt and
 escalate to a human**, never continue.
 
@@ -326,28 +390,31 @@ checkpoint for an unknown/regressing issue, or a non-canonical timestamp.
 
 Before writing `phase: exiting`, prove with actual command output (`superpowers:verification-
 before-completion`): `ready == 0` (no **dispatchable** tasks — counting any `active`-status task with
-no live worker, i.e. a **deferred recovery candidate**, as dispatchable), `active == 0`
-(`active_worker_ids` empty **and** no `active`-status task in the log awaiting (re-)dispatch, and no
-open `loop:in-progress` without a merged PR), `blocked == acknowledged` (every blocked/stale task has
-a follow-up), `unmerged == 0` (no open PR awaiting a `MERGE_REQUEST`). A damped/deferred recovery
-candidate therefore **fails** this audit — the loop cannot declare quiescence while recovery work is
-merely deferred. Re-run it after the cooldown; only an all-clear second pass permits exit.
+no live worker, i.e. a **recovery candidate** (§6 disposition, including one still inside a
+hold-if-recent window), as dispatchable), `active == 0` (`active_worker_ids` empty **and** no
+`active`-status task in the log awaiting (re-)dispatch, and no open `loop:in-progress` without a merged
+PR), `blocked == acknowledged` (every blocked/stale task has a follow-up), `unmerged == 0` (no open PR
+awaiting a `MERGE_REQUEST`). A held or unreconciled recovery candidate therefore **fails** this audit —
+the loop cannot declare quiescence while recovery work is still pending. Re-run it after the cooldown;
+only an all-clear second pass permits exit.
 
-## Recovery (cold resume)
+## Recovery (cold resume / manual resume)
 
-A fresh orchestrator on clean `master` rebuilds entirely from GitHub: the control issue (replay →
-revision, dedupe set, scan floors, task statuses, **`iteration`**, **`current_attempt_id`**), the
-per-task **append-only recovery comments** (read via `control_log.latest_recovery(comments,
-current_attempt_id)`), open
-PRs, and `docs/task-loop/logs/` (audit only). Ephemeral teammates and `~/.claude/tasks/` are **not**
-relied upon. Because teammates die with the lead's session a crashed loop 1 *usually* leaves no
-surviving workers — but a watchdog **false-positive** (lead alive, heartbeat merely stale) can spawn
-a second lead while a worker still lives, so safety must **not** depend on that: it comes from the
-durable `current_attempt_id` + **per-attempt branches** (below), with ephemerality only making the
-window rare. Orphaned tasks re-enter through §6's **Dispatchable** rule (status `active` with **no
-live worker** for `current_attempt_id`), so a crashed/resumed task is selected and re-dispatched by
-the same seat-capped frontier — never stranded, never a separate code path. Respawn follows **one
-rule, the GitHub-visible-artifact line:**
+Manual `/run-cycle` resume is the **death/hang recovery path** (there is no watchdog). A fresh
+orchestrator on clean `master` rebuilds entirely from GitHub: the control issue (replay → revision,
+dedupe set, scan floors, task statuses, **`iteration`**, **`current_attempt_id`**), the per-task
+**append-only recovery comments** (read via `control_log.latest_recovery(comments,
+current_attempt_id)`, with `control_log.latest_recovery_with_metadata` supplying the canonical
+`created_at` for §6's hold-if-recent gate), open PRs, and `docs/task-loop/logs/` (audit only).
+Ephemeral teammates and `~/.claude/tasks/` are **not** relied upon. Because teammates die with the
+lead's session, a dead session *usually* leaves no surviving workers — but a **manual double-start**
+(a human force-resumes a lead that is actually alive) can spawn a second lead while a worker still
+lives, so safety must **not** depend on that: it comes from the durable `current_attempt_id` +
+**per-attempt branches** (below), with ephemerality only making the window rare; the tri-state resume
+(§1) and the recovery-disposition substep (§6) cap the *cost*. Orphaned tasks re-enter through §6's
+**recovery disposition** (status `active` with **no live worker** for `current_attempt_id`), so a
+crashed/resumed task is selected and re-dispatched by the same seat-capped frontier — never stranded,
+never a separate code path. Respawn follows **one rule, the GitHub-visible-artifact line:**
 
 - **No remote branch and no PR** for a dispatched task → any work was local-only pre-PR WIP, which
   is **disposable**: abandon it and **re-dispatch a fresh attempt** (new `attempt_id`) from clean

--- a/task-loop/tests/test_control_log.py
+++ b/task-loop/tests/test_control_log.py
@@ -410,6 +410,42 @@ class TestRecoveryComments(unittest.TestCase):
         self.assertEqual(control_log.latest_recovery([c1, c2], "A")["status"], "pr_open")
         self.assertIsNone(control_log.latest_recovery([c1, c2], "C"))
 
+    def test_latest_recovery_with_metadata_returns_canonical_created_at(self):
+        c1 = ("IC1", TS_EARLY,
+              control_log.format_recovery({"attempt_id": "A", "status": "in_progress"}))
+        c2 = ("IC2", TS_A,
+              control_log.format_recovery({"attempt_id": "A", "status": "pr_open"}))
+        meta = control_log.latest_recovery_with_metadata([c1, c2], "A")
+        self.assertEqual(meta["comment_id"], "IC2")
+        self.assertEqual(meta["created_at"], TS_A)
+        self.assertEqual(meta["recovery"]["status"], "pr_open")
+
+    def test_latest_recovery_with_metadata_ignores_other_attempts(self):
+        c1 = ("IC1", TS_EARLY,
+              control_log.format_recovery({"attempt_id": "A", "status": "pr_open"}))
+        c2 = ("IC2", TS_A,
+              control_log.format_recovery({"attempt_id": "B", "status": "merge_requested"}))
+        meta = control_log.latest_recovery_with_metadata([c1, c2], "A")
+        self.assertEqual(meta["comment_id"], "IC1")
+        self.assertEqual(meta["created_at"], TS_EARLY)
+        self.assertEqual(meta["recovery"]["status"], "pr_open")
+
+    def test_latest_recovery_with_metadata_none_when_absent(self):
+        c1 = ("IC1", TS_EARLY,
+              control_log.format_recovery({"attempt_id": "A", "status": "pr_open"}))
+        self.assertIsNone(control_log.latest_recovery_with_metadata([c1], "C"))
+
+    def test_latest_recovery_with_metadata_last_block_in_one_comment_wins(self):
+        # Two recovery blocks for attempt A in a single comment body: the LAST wins,
+        # carrying that comment's canonical created_at.
+        body = (control_log.format_recovery({"attempt_id": "A", "status": "in_progress"})
+                + "\n"
+                + control_log.format_recovery({"attempt_id": "A", "status": "merge_requesting"}))
+        meta = control_log.latest_recovery_with_metadata([("IC9", TS_B, body)], "A")
+        self.assertEqual(meta["comment_id"], "IC9")
+        self.assertEqual(meta["created_at"], TS_B)
+        self.assertEqual(meta["recovery"]["status"], "merge_requesting")
+
 
 class TestEndToEnd(unittest.TestCase):
     def test_ingest_emit_replay_and_cold_resume_dedupe(self):


### PR DESCRIPTION
Collapse the `run-cycle` orchestrator control plane from **three jobs to two**, replacing the self-paced wake model with a **pure fixed 30-min poll**.

- **Loop A** — the `/loop` orchestrator, ending each turn with a fixed `ScheduleWakeup(1800)`. A fixed poll that re-derives the whole frontier every tick makes an *alive-but-stuck* orchestrator structurally impossible between turns — which is what the old watchdog really guarded against.
- **Loop B** — a one-time stop early-wake at `stop_at` (the woken turn's Step-2 check decides; bounds stop latency to ~0).
- **Watchdog deleted.** Death / intra-turn-hang recovery is **manual `/run-cycle` resume** (rebuilds 100% from GitHub). No in-protocol liveness watch.

Manual resume is now **tri-state + artifact-aware** (refuse-if-diagnosably-alive; reconcile/adopt a current attempt's PR/branch before minting a fresh one), with a hold-if-recent gate keyed off canonical GitHub comment time via a new additive helper `latest_recovery_with_metadata`.

Design Codex-pressure-tested over 6 rounds (spec + conclusion under `docs/superpowers/specs/2026-06-14-*`). No control-event schema change; 58 existing protocol tests stay green (62 total). Version 0.8.1 → 0.9.0.