### PR TITLE
task-loop: cycle-worker self-provisions its own git worktree (fix Teams isolation)

### DIFF
--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -44,8 +44,9 @@ c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-si
 `task-loop` invokes skills from two **required** plugins — install them first:
 
 - **`superpowers`** — `brainstorming`, `writing-plans`, `test-driven-development`,
-  `verification-before-completion`, `finishing-a-development-branch`. (Worker worktree isolation is
-  automatic via the `cycle-worker` agent's `isolation: worktree` declaration.)
+  `verification-before-completion`, `finishing-a-development-branch`. (Each `cycle-worker` creates its
+  own git worktree at invocation — in-process Teams do not honor an `isolation: worktree` declaration,
+  so the worker self-provisions one keyed on its `attempt_id`.)
 - **`dev-skills`** — `discuss-with-codex`, `goal-rubric`, `doc-update`, `step-workflow`.
 
 **Run the `preflight` skill** to check two scopes: that these skills are loadable in your

--- a/task-loop/agents/cycle-worker.md
+++ b/task-loop/agents/cycle-worker.md
@@ -13,12 +13,10 @@ assistant: "I'll spawn a teammate using the cycle-worker agent type, passing tas
 Context: A previous worker's PR was merged, unblocking a dependent task in the shared task list.
 user: "(orchestrator) Task T9 is now unblocked; assign it."
 assistant: "I'll spawn a cycle-worker teammate for T9, passing its task_id, issue number, control_issue, current spawned_plan_revision, iteration index, a fresh attempt_id, its per-attempt branch, and lead_worktree_root."
-<commentary>Each unblocked task gets its own fresh cycle-worker; the worker runs in its own auto-provided git worktree (isolation: worktree), pushes only its per-attempt branch, and posts a MERGE_REQUEST inbox event (carrying attempt_id) when done.</commentary>
+<commentary>Each unblocked task gets its own fresh cycle-worker; the worker self-provisions its own git worktree at invocation (keyed on attempt_id), pushes only its per-attempt branch, and posts a MERGE_REQUEST inbox event (carrying attempt_id) when done.</commentary>
 </example>
 
 model: inherit
-color: green
-isolation: worktree
 tools: ["Bash", "Read", "Edit", "Write", "Glob", "Grep", "Skill", "Workflow", "TodoWrite", "Monitor", "ScheduleWakeup", "WebFetch", "WebSearch"]
 ---
 
@@ -30,13 +28,12 @@ and is the only agent that integrates work.
 **Your inputs (from the spawn prompt):** `task_id`, the task's GitHub `issue` number, the
 `control_issue` number, `spawned_plan_revision`, `iteration` (your record index), `attempt_id`
 (your durable ownership token), your per-attempt branch `<branch>-attempt-<attempt_id>`,
-`lead_worktree_root` (for the isolation self-check), optionally `adopt_from_branch`, and a short
+`lead_worktree_root` (the base for your worktree self-setup), optionally `adopt_from_branch`, and a short
 description of the task. If any is missing, ask the orchestrator (the team lead) before starting.
 
 **Your core responsibilities:**
 1. Read `docs/task-loop/task-loop.md` and follow its cycle **step by step** for your one
-   task: recover/anchor → confirm scope → create your task branch (in the worktree you already
-   run in) → binary rubric →
+   task: recover/anchor → confirm scope → set up your own worktree + attempt branch → binary rubric →
    spec/plan → TDD implementation → verify rubric with real output → reconcile → doc-update →
    open PR + adversarial Codex review → request merge → finalize the decision record.
 2. **Deliberate, don't ask the user.** Use the `discuss-with-codex` skill at the rubric, at
@@ -82,18 +79,41 @@ description of the task. If any is missing, ask the orchestrator (the team lead)
   the attempt: return to `pr_open`, push the fix (new head), and mint a **new** UUID. On resume
   from `merge_requesting`, repost the *same* UUID only if the current head still equals
   `merge_request_head_sha`.
-- **You already run in your own isolated git worktree** — your agent declares `isolation: worktree`,
-  so the harness gives every worker a separate worktree (branched from fresh `master`)
-  automatically. **Verify it FIRST:** run `git rev-parse --show-toplevel`; if it equals
-  `lead_worktree_root`, isolation was **not** honored — **stop immediately, post
-  `WORKTREE_ISOLATION_FAILED` to the orchestrator, and do nothing else** (no checkout, no edits) so
-  you can never race the lead's tree. **Do not create another worktree** (no `using-git-worktrees`,
-  no `git worktree add`). Then work on an **attempt-scoped local branch** and push only to your
-  **per-attempt remote branch**: `git fetch origin`; if `adopt_from_branch` was given
-  `git checkout -B <local> origin/<adopt_from_branch>`, else `git checkout -B <local> origin/master`
-  (the fresh base); push with `git push origin HEAD:<branch>-attempt-<attempt_id>` and open the PR
-  with an **explicit head** (`gh pr create --head <branch>-attempt-<attempt_id> --base master ...`),
-  never letting `gh` infer it. You write **only your own** per-attempt branch — never a shared one.
+- **Set up your OWN git worktree before any edit — always, as your first action.** This agent does
+  **not** rely on harness worktree isolation: in-process Claude Code Teams do **not** honor an
+  `isolation: worktree` declaration, so as a teammate you start in the **lead's shared tree**. Create
+  and enter your own worktree, keyed on your `attempt_id` so concurrent workers never collide and a
+  same-attempt re-entry reuses (never duplicates) it. The snippet sets `base` to
+  `origin/<adopt_from_branch>` if `adopt_from_branch` was given, else `origin/master` (the fresh base);
+  `<local>` is an **attempt-scoped local branch** (unique per `attempt_id`, so it is never "already
+  checked out" in a sibling worker's tree). Because up to 5 workers set up against the **same** shared
+  repo, the loops **retry transient git locks** (a `*.lock` from another git process) — a lock is
+  **never** fatal:
+  ```bash
+  base="origin/master"; [ -n "<adopt_from_branch>" ] && base="origin/<adopt_from_branch>"
+  WT_PARENT="$(dirname "$lead_worktree_root")/.task-loop-worktrees"; mkdir -p "$WT_PARENT"
+  WT="$WT_PARENT/<task_id>-attempt-<attempt_id>"
+  n=0; until git -C "$lead_worktree_root" fetch origin || [ $n -ge 5 ]; do n=$((n+1)); sleep 2; done
+  if git -C "$lead_worktree_root" worktree list --porcelain | grep -qxF "worktree $WT"; then
+    cd "$WT"                                                # re-entry: reuse this attempt's worktree
+  else
+    n=0; until git -C "$lead_worktree_root" worktree add -B <local> "$WT" "$base" || [ $n -ge 5 ]; do
+      n=$((n+1)); sleep 2; done
+    cd "$WT"
+  fi
+  ```
+  Then **verify isolation took**: `git rev-parse --show-toplevel` must equal
+  `$WT` and **not** `lead_worktree_root` (on re-entry also confirm `git -C "$WT" symbolic-ref --short
+  HEAD` is `<local>`). **Only if you genuinely cannot create or enter a worktree** — post
+  `WORKTREE_ISOLATION_FAILED` to the orchestrator and do nothing else (no checkout, no edits). **`$WT`
+  is your working root for the entire cycle:** cwd may not persist across separate tool calls, so begin
+  each repo-touching shell sequence with `cd "$WT"` (or `git -C "$WT" …`) and use absolute paths under
+  `$WT` for file edits. **Record `$WT` in your first recovery comment** so the orchestrator can
+  `git worktree remove` it (after merge, or when reclaiming a dead attempt) and a cold resume can find
+  it. Then push **only** to your **per-attempt remote branch**:
+  `git push origin HEAD:<branch>-attempt-<attempt_id>`, and open the PR with an **explicit head**
+  (`gh pr create --head <branch>-attempt-<attempt_id> --base master ...`), never letting `gh` infer it.
+  You write **only your own** per-attempt branch and worktree — never a shared one.
   Stage files by explicit path; commit with clean, attribution-free text via `git commit -F`.
 - **No nested teams.** For intra-task parallelism use `Workflow` or inline subagents, never a
   sub-team.
@@ -149,8 +169,8 @@ orchestrator validates and merges only if your `attempt_id` is still current; it
 - *Superseded by a later dispatch* (`attempt_id` != `current_attempt_id`): stop at the next fenced
   boundary, record `superseded_attempt`, push nothing further, shut down — the current attempt owns
   the task.
-- *Worktree isolation not honored* (`--show-toplevel` == `lead_worktree_root`): post
-  `WORKTREE_ISOLATION_FAILED` and stop before any edit.
+- *Cannot create a worktree* (the `git worktree add` self-setup fails, or `--show-toplevel` still
+  equals `lead_worktree_root` afterward): post `WORKTREE_ISOLATION_FAILED` and stop before any edit.
 - *Rubric cannot go green:* fix, or descope honestly — file the descoped items as follow-up
   issues (never silently omit), record why, and reflect the reduced scope in the PR.
 - *Genuine human-only blocker* (compute/budget beyond this environment, missing licensed

--- a/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
+++ b/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
@@ -67,22 +67,41 @@ Validate the scope against the issue; confirm `spawned_plan_revision` matches th
 `master` **and** that `attempt_id == current_attempt_id` for your task (replay the `control_issue`).
 If your attempt was superseded, stop now (`superseded_attempt`).
 
-### 3. Verify isolation, then create your attempt branch
-You run in your **own** isolated worktree (your agent declares `isolation: worktree`). **Verify it
-first:** `git rev-parse --show-toplevel`; if it equals `lead_worktree_root`, isolation was **not**
-honored — **stop and post `WORKTREE_ISOLATION_FAILED`**, do nothing else (no checkout, no edits).
-**Do not create another worktree** (no `using-git-worktrees`, no `git worktree add`). Then check out
-an **attempt-scoped local branch** and bind it to your **per-attempt remote branch**
-`<branch>-attempt-<attempt_id>` (so two attempts never write the same ref): `git fetch origin`; if
-`adopt_from_branch` was given, `git checkout -B <local> origin/<adopt_from_branch>`, else
-`git checkout -B <local> origin/master` (the fresh base; prefix from {{BRANCH_PREFIXES}}). Open the per-cycle
-record `docs/task-loop/logs/<NNN>_<task>.md` (`<NNN>` = the iteration index from your spawn prompt,
-zero-padded from `001`; see operating principle 8) with frontmatter `status: in_progress`,
-`iteration`, `task`, `issue`, `branch`, `attempt_id`, `spawned_plan_revision` and empty **Rubric** +
-**Decision log** sections, and post your first **`task-loop-recovery` comment** (append-only,
-`attempt_id`-tagged): `status=in_progress`, `resume_from=<step>`, `branch`,
-`worktree=<show-toplevel>`, `attempt_id`, `spawned_plan_revision`. Local pre-PR WIP is **disposable**
-(not recoverable off-machine) — durability begins at the first push (step 9).
+### 3. Set up your own worktree, then create your attempt branch
+This agent does **not** rely on harness worktree isolation — in-process Teams do **not** honor an
+`isolation: worktree` declaration, so you start in the lead's **shared** tree. **Your first action** is
+to create and enter your **own** worktree, keyed on your `attempt_id` (so concurrent workers never
+collide and a same-attempt re-entry reuses, never duplicates, it). The snippet sets `base` to
+`origin/<adopt_from_branch>` if `adopt_from_branch` was given, else `origin/master` (the fresh base);
+`<local>` is an attempt-scoped local branch (unique per `attempt_id`, so it is never "already checked
+out" elsewhere; prefix from {{BRANCH_PREFIXES}}). 5 workers share one repo, so the loops **retry
+transient git locks** (a `*.lock` from another git process) — a lock is **never** fatal:
+```bash
+base="origin/master"; [ -n "<adopt_from_branch>" ] && base="origin/<adopt_from_branch>"
+WT_PARENT="$(dirname "$lead_worktree_root")/.task-loop-worktrees"; mkdir -p "$WT_PARENT"
+WT="$WT_PARENT/<task_id>-attempt-<attempt_id>"
+n=0; until git -C "$lead_worktree_root" fetch origin || [ $n -ge 5 ]; do n=$((n+1)); sleep 2; done
+if git -C "$lead_worktree_root" worktree list --porcelain | grep -qxF "worktree $WT"; then
+  cd "$WT"                                                # re-entry: reuse this attempt's worktree
+else
+  n=0; until git -C "$lead_worktree_root" worktree add -B <local> "$WT" "$base" || [ $n -ge 5 ]; do
+    n=$((n+1)); sleep 2; done
+  cd "$WT"
+fi
+```
+If you still cannot create/enter a worktree after the retries, post `WORKTREE_ISOLATION_FAILED` and do
+nothing else. **Verify:**
+`git rev-parse --show-toplevel` == `$WT` (≠ `lead_worktree_root`); on re-entry also `git -C "$WT"
+symbolic-ref --short HEAD` == `<local>`. **`$WT` is your working root for the whole cycle** — cwd may not
+persist across separate tool calls, so prefix repo-touching shell with `cd "$WT"` (or `git -C "$WT" …`)
+and use absolute paths under `$WT` for file edits. Open the per-cycle record
+`docs/task-loop/logs/<NNN>_<task>.md` (`<NNN>` = the iteration index from your spawn prompt, zero-padded
+from `001`; see operating principle 8) with frontmatter `status: in_progress`, `iteration`, `task`,
+`issue`, `branch`, `attempt_id`, `spawned_plan_revision` and empty **Rubric** + **Decision log**
+sections, and post your first **`task-loop-recovery` comment** (append-only, `attempt_id`-tagged):
+`status=in_progress`, `resume_from=<step>`, `branch`, `worktree=$WT`, `attempt_id`,
+`spawned_plan_revision`. Local pre-PR WIP is **disposable** (not recoverable off-machine) — durability
+begins at the first push (step 9).
 
 ### 4. Define the rubric (binary)
 Use `dev-skills:goal-rubric` to draft a binary pass/fail rubric (each item a test name, a

--- a/task-loop/skills/preflight/SKILL.md
+++ b/task-loop/skills/preflight/SKILL.md
@@ -35,8 +35,9 @@ a skill to test it** — invoking `brainstorming` / `discuss-with-codex` (etc.) 
 Required (9 skills across 2 plugins):
 
 - **`superpowers`** — `brainstorming`, `writing-plans`, `test-driven-development`,
-  `verification-before-completion`, `finishing-a-development-branch`. (Worker isolation is handled
-  by the `cycle-worker` agent's `isolation: worktree` declaration, **not** `using-git-worktrees`.)
+  `verification-before-completion`, `finishing-a-development-branch`. (Each `cycle-worker`
+  self-provisions its own git worktree at invocation — in-process Teams do not honor an
+  `isolation: worktree` declaration, and it does **not** use `using-git-worktrees`.)
 - **`dev-skills`** — `discuss-with-codex`, `goal-rubric`, `doc-update`, `step-workflow`.
 
 **Matching (owner-verified preferred):** the task-loop depends on these *specific plugins'*

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -198,9 +198,16 @@ abort the turn without merging or emitting. Act in this order:
   request's `source_uuid`, which `replay` rejects). If invalid, emit `MERGE_DENIED{... source_*}` +
   `TASK_STALE`, and message the worker to stop/rescope.
 - After that emit, remove the worker from `active_worker_ids` (the worker's `NNN_<task>.md` record
-  is already on `master`). **Worktree cleanup:** if the worker recorded its worktree path (in its
-  recovery comments) and it is local, clean, and matches this task/attempt, remove it
-  (`git worktree remove`); **never** remove a path equal to `lead_worktree_root`.
+  is already on `master`). **Worktree cleanup:** the attempt's worktree path is **deterministic**
+  (`$(dirname "$lead_worktree_root")/.task-loop-worktrees/<task_id>-attempt-<attempt_id>`), so derive
+  it even when no recovery comment recorded it. Remove it **only** when the path sits under that
+  `.task-loop-worktrees/` prefix, matches this task/attempt, and is **not** `lead_worktree_root`. On a
+  **merged** attempt the tree is clean → `git worktree remove`. Apply the **same cleanup to any attempt
+  that reaches a terminal non-merged disposition** (superseded, stale, denied, or orphaned past the
+  drain deadline): that attempt is abandoned and its tree may be **dirty**, so force it
+  (`git worktree remove --force`) — its only durable surface was its own per-attempt remote branch, so
+  discarding the local tree loses nothing. The harness no longer auto-cleans worker worktrees, so
+  without this dead attempts would leak them. After removal, `git worktree prune`.
 
 ### 6. Dispatch — proactive, seat-capped (skip if draining)
 **Lease fence first:** before this batch, **refresh + re-read the lease and re-confirm you still own
@@ -297,12 +304,14 @@ creates ≤5 issues this turn).
   - Spawn **one** `cycle-worker` teammate (`agentType: cycle-worker`) with a prompt carrying
     `task_id`, `issue=<n>`, `control_issue=<#>`, `spawned_plan_revision=<current>`, `iteration=NNN`,
     `attempt_id`, the per-attempt branch `<branch>-attempt-<attempt_id>`, your **`lead_worktree_root`**
-    (`git rev-parse --show-toplevel`, for the worker's isolation self-check), and — when
+    (`git rev-parse --show-toplevel`, the base for the worker's worktree self-setup + isolation verify),
+    and — when
     re-dispatching a task that already has a GitHub-visible attempt — `adopt_from_branch=`the latest
     pushed attempt branch (the new attempt branches *from* it; Option-1: local-only pre-PR WIP is
-    disposable). Record its id in `active_worker_ids`. The teammate declares `isolation: worktree`, so
-    the harness gives it its **own** worktree — never ask it to create one; the worker self-checks
-    isolation and aborts (`WORKTREE_ISOLATION_FAILED`) if its toplevel equals `lead_worktree_root`.
+    disposable). Record its id in `active_worker_ids`. The worker **creates its own git worktree** at
+    invocation (in-process Teams do **not** honor an `isolation: worktree` declaration) — keyed on its
+    `attempt_id`, as a sibling of `lead_worktree_root` — and records that path in a recovery comment for
+    your §5 cleanup; it aborts (`WORKTREE_ISOLATION_FAILED`) only if it cannot create one.
 
 ### 7. Wait / idle / exit
 Reached **only after §6 has filled every free seat it can** — never sleep with a free seat and ready


### PR DESCRIPTION
Fixes the worktree-isolation bug for in-process Teams.

`isolation: worktree` is not honored for Teams teammates, so every `cycle-worker` started in the lead's shared tree and aborted with `WORKTREE_ISOLATION_FAILED` — no worker could run.

- Remove `isolation` (and unused `color`) from the `cycle-worker` frontmatter.
- The worker now always self-provisions its own attempt-keyed worktree at invocation: idempotent re-entry, transient-git-lock retry, cwd-anchored, with `WORKTREE_ISOLATION_FAILED` kept only as the true-failure fallback.
- The orchestrator cleans the worker's deterministic worktree path, force-removing terminal non-merged (dirty) attempts so they don't leak.
- Sync the skeleton playbook, preflight/run-cycle prose, and README; bump to 0.9.1.

Reviewed adversarially with Codex (two rounds, all findings folded in); 62 tests pass.

Closes #125
