### PR TITLE
task-loop: parameterized compute-utilization policy + 15-min Loop A cadence

### DIFF
--- a/docs/superpowers/specs/2026-06-14-task-loop-general-rules-placement-conclusion.md
+++ b/docs/superpowers/specs/2026-06-14-task-loop-general-rules-placement-conclusion.md
@@ -1,0 +1,83 @@
+# Conclusion — Where do task-loop's general worker rules live?
+
+**Goal:** Should task-loop's general (project-agnostic) worker rules live ONLY in the
+`cycle-worker` agent system prompt, instead of being duplicated into the rendered
+`task-loop.md` playbook (the `create-cycle` skeleton)? Triggered by wanting to add a new
+general rule: "fully utilize available compute (cores/GPUs/SLURM), parallelize, never crawl
+single-threaded."
+
+**How it ended:** Converged after 3 rounds with Codex (adversarial critic).
+
+## Settled position
+
+**NO — do not move general rules into the system prompt only.** The committed, rendered
+`docs/task-loop/task-loop.md` must remain the **self-contained, auditable contract**: it
+explicitly declares itself "the instruction set a worker follows," and the system prompt
+already defers to it ("follow `task-loop.md` step by step"). Hollowing it out would gut
+auditability, manual recovery, and reproducibility, and would turn plugin-version bumps into
+**silent, undiffable behavior changes** in every already-scaffolded project — especially
+dangerous for compute policy (cost/quota/cluster-etiquette).
+
+### The new compute rule answers its own placement
+Its *safe* form is **project-parameterized**, so it physically cannot be a system-prompt-only
+rule. It belongs in the **rendered playbook** as an operating principle carrying a new
+`{{COMPUTE_POLICY}}` placeholder — exactly like `{{CONTRACTS}}` / `{{TEST_CONVENTIONS}}`, which
+already live playbook-only and are **not** duplicated in `cycle-worker.md`. Two reasons it must
+be parameterized rather than a blanket "use everything":
+
+1. **Etiquette/quota:** cluster/SLURM submission needs an account/partition and has
+   shared-resource implications — it must be gated behind explicit project policy, never a
+   silent default.
+2. **Oversubscription (correctness):** the loop runs **up to 5 concurrent workers on one host**
+   (`skeleton:78`, `cycle-worker.md:89`). If each worker grabs all CPUs/GPUs they thrash. The
+   safe default is a **bounded per-worker share**, not "grab everything."
+
+The general *backgrounding* kernel ("never foreground-block / never let a long job block")
+already exists in BOTH files — unchanged. The compute principle is **additive** and references it.
+
+## Key decisions
+
+1. Reject "system-prompt-only." Playbook stays the authoritative, self-contained contract.
+2. Add the compute rule as a **parameterized playbook operating principle** (`{{COMPUTE_POLICY}}`),
+   NOT in the system prompt.
+3. **Ship the placeholder machinery with the rule** (Codex's rollout-gap catch): update
+   `create-cycle/SKILL.md` to discover/interview/render `{{COMPUTE_POLICY}}` so no generated
+   playbook is ever left with a raw placeholder or ad-hoc policy.
+4. **Concrete safe default** for `{{COMPUTE_POLICY}}`: parallelize aggressively but cap each
+   worker to a bounded share of the 5-seat loop (default `max(1, floor(nproc/5))`-style),
+   background long jobs, never single-thread a parallelizable task; **local CPU only** — no
+   GPU/SLURM/multi-node submission unless the policy explicitly names the account/partition/device.
+   (Future enhancement: orchestrator passes an explicit `worker_parallelism_budget` since it,
+   not the worker, knows live seat occupancy.)
+5. Optionally add a `directions-template.md` heading for temporary compute overrides (steering
+   file is highest priority).
+6. **Defer the drift fix** (the dual-source duplication of the *non-parameterized* worker
+   contract) to its own follow-up issue: a canonical `task-loop/shared/worker-guardrails.md`
+   asset, generated/synced into both surfaces, a unittest verifying both embedded blocks match
+   canonical, **plus a CI workflow that actually runs it** (without CI the test is advisory).
+   Kept separate because the largest shared chunk is the worktree block and a botched sync could
+   corrupt the live agent contract — coupling it to a behavior addition is risky.
+
+## Strongest objections Codex raised, and how each resolved
+
+- **"Always-loaded isn't enough — the playbook must be a complete contract."** Conceded;
+  drove the rejection of system-prompt-only.
+- **"Central updates = silent cross-project behavior change, dangerous for compute."** Conceded;
+  drove "behavior change must be a reviewable diff in the committed playbook" → parameterized
+  playbook placement.
+- **"Delimiter+unittest isn't drift-proof (no CI), byte-equality is two sinks + an alarm, and
+  the worktree guardrail is too big to slim."** Conceded all three; replaced my inconsistent
+  "slim + byte-equality" mechanism with Codex's canonical-asset design — and moved it to a
+  follow-up so this PR stays a clean behavior addition.
+- **"`{{COMPUTE_POLICY}}` rollout gap + bounded share needs a real allocator."** Accepted;
+  added decisions 3 and 4.
+
+## Unresolved tension (a genuine user decision)
+
+The user's stated intent ("use ALL GPUs and CPUs, go fast, don't waste") conflicts with the
+safe conservative default (bounded per-worker share to avoid 5-worker oversubscription). Chosen
+resolution: the **default** policy is conservative-safe, but `{{COMPUTE_POLICY}}` is
+**user-tunable per project**, and the `create-cycle` interview should surface this fork so the
+project owner picks aggressive-vs-bounded explicitly (knowing their host size, typical seat
+occupancy, and whether jobs are CPU- or GPU-bound). To be confirmed with the user before
+writing the default text.

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.9.1"
+  "version": "0.10.0"
 }

--- a/task-loop/skills/create-cycle/SKILL.md
+++ b/task-loop/skills/create-cycle/SKILL.md
@@ -56,6 +56,10 @@ Discover, without asking:
   plugin. These become the `{{BRANCH_PREFIXES}}` and inform the commit/PR steps.
 - Whether a **code skeleton exists** yet (package layout, build config) or the repo is
   docs-only (drives the `{{BOOTSTRAP_NOTE}}`).
+- The **compute environment** — whether an HPC scheduler (`sinfo`/`squeue`) or GPUs
+  (`nvidia-smi`) are present, and the local core count (`nproc`). This **informs** the default
+  `{{COMPUTE_POLICY}}` wording (it does **not** by itself authorize cluster submission — that
+  stays gated on a named account/partition, below).
 
 ### 3. Interview for the project specifics (finalize fuzzy ones with Codex)
 Ask the user only for what cannot be detected, one topic at a time, and pressure-test
@@ -68,12 +72,24 @@ ambiguous answers with `dev-skills:discuss-with-codex`:
   conservation checks, integration gates) → `{{TEST_CONVENTIONS}}`.
 - A **bootstrap note** if the repo has no code yet (what the earliest scaffolding tasks are)
   → `{{BOOTSTRAP_NOTE}}`.
+- The **compute policy** — how aggressively a worker should use this machine, and any account
+  /partition for cluster submission → `{{COMPUTE_POLICY}}`. **Never leave it raw or invent it
+  ad hoc.** Default (use unless the user states a constraint): *"Use all available **local**
+  compute — every CPU core and available GPU; parallelize independent work; never run a
+  parallelizable job single-threaded; background long jobs and verify their terminal state. Do
+  **not** submit to a cluster/SLURM scheduler unless this policy names an allowed account
+  /partition — then submit heavy jobs to compute nodes (`sbatch`/`srun`), never the shared login
+  node. Note: up to 5 cycle-workers may share this host, so this aggressive default can
+  oversubscribe; if you routinely run several workers at once, set a per-worker cap (e.g.
+  `cores ÷ workers`) here."* Only pressure-test with `discuss-with-codex` when the project has
+  shared-cluster quota/etiquette constraints (then name the account/partition and any per-worker
+  cap).
 - The **north star** phrasing → `{{NORTH_STAR}}` (from the Charter).
 
 ### 4. Render the playbook
 Copy `assets/task-loop-skeleton.md` to `docs/task-loop/task-loop.md` and replace **every**
-occurrence of each `{{PLACEHOLDER}}` (some appear twice — e.g. `{{CONTRACTS}}` and
-`{{TEST_CONVENTIONS}}` recur in the operating principles). For an absent fill — e.g. no
+occurrence of each `{{PLACEHOLDER}}` (some appear twice — e.g. `{{CONTRACTS}}`,
+`{{TEST_CONVENTIONS}}`, and `{{COMPUTE_POLICY}}` recur in the operating principles). For an absent fill — e.g. no
 bootstrap needed when a code skeleton already exists — write `n/a` or remove that bullet;
 never leave a raw `{{...}}`. Leave the generic cycle steps and operating principles intact —
 they are deliberately project-agnostic. Do **not** weaken the worker's control-protocol

--- a/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
+++ b/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
@@ -17,6 +17,7 @@ orchestrator (`run-cycle`) is the sole integrator and the sole editor of
 - **Steering file (read first):** `docs/task-loop/directions.md`
 - **Correctness contracts (not optional polish):** {{CONTRACTS}}
 - **What "tested" means here:** {{TEST_CONVENTIONS}}
+- **Compute policy (how fully to use this host):** {{COMPUTE_POLICY}}
 - **Branch prefixes:** {{BRANCH_PREFIXES}} (hyphen-joined; the repo hook may reject other forms)
 - **Bootstrap note:** {{BOOTSTRAP_NOTE}}
 
@@ -46,6 +47,13 @@ orchestrator (`run-cycle`) is the sole integrator and the sole editor of
    (and also **post the rubric to the issue** as the acceptance interface), keep appending the
    Decision log through the cycle, and **commit it with your implementation** — it is durable git
    state, part of your PR. Never skip the Rubric section.
+9. **Use the compute you have.** Get the task done fast — **never crawl single-threaded** when work
+   can be parallelized. At task start, **detect what's available** (`nproc` for CPU cores,
+   `nvidia-smi` for GPUs, and on an HPC login node `sinfo`/`squeue` for a scheduler), then apply the
+   **Compute policy** above — {{COMPUTE_POLICY}} — running independent sub-tasks concurrently
+   (multiprocessing, batch arrays, `Workflow`/inline-subagent fan-out — never a sub-team) and
+   backgrounding long jobs per principle 2 (then verify their terminal state). Don't waste capacity
+   and don't wait on avoidable single-threaded slowness.
 
 ## The cycle
 

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-cycle
-description: This skill should be used when the user asks to "run cycle", "run the task loop", "start the orchestrator", "start the task-loop run", "drive the autonomous loop", or to begin autonomous, orchestrated execution of a task-loop project. It runs the orchestrator under built-in /loop on a fixed 30-min poll: each turn it computes the dependency-ordered task frontier from a single GitHub control issue, spawns one cycle-worker teammate per ready task, validates and merges their PRs (sole integrator), and terminates by a scheduled drain-signal — not an iteration cap.
+description: This skill should be used when the user asks to "run cycle", "run the task loop", "start the orchestrator", "start the task-loop run", "drive the autonomous loop", or to begin autonomous, orchestrated execution of a task-loop project. It runs the orchestrator under built-in /loop on a fixed 15-min poll: each turn it computes the dependency-ordered task frontier from a single GitHub control issue, spawns one cycle-worker teammate per ready task, validates and merges their PRs (sole integrator), and terminates by a scheduled drain-signal — not an iteration cap.
 version: 0.1.0
 ---
 
@@ -10,7 +10,7 @@ version: 0.1.0
 
 Third and final step of the task-loop workflow (`specify-aims` → `create-cycle` →
 **`run-cycle`**). It is the **orchestrator**: the main agent, driven by built-in **`/loop`
-on a fixed 30-min poll**, that plans and dispatches work and is the **sole integrator** (the only agent
+on a fixed 15-min poll**, that plans and dispatches work and is the **sole integrator** (the only agent
 that merges). It does **not** run any task's cycle itself — `cycle-worker` teammates do that,
 one per task.
 
@@ -49,7 +49,7 @@ the control-issue body.
 1. **Loop A — the orchestrator** — a **live `/loop` Agent-Teams lead session**, **not** a scheduler
    job. Each turn it refreshes its lease in the control-issue body, replays the control-issue comment
    log to rebuild fast state, **monitors team status → merges → dispatches over the full re-derived
-   frontier (seat-capped at 5)**, and ends with a **fixed `ScheduleWakeup(1800)`** (30 min). It
+   frontier (seat-capped at 5)**, and ends with a **fixed `ScheduleWakeup(900)`** (15 min). It
    **self-bounds on `stop_at`** (the Step-2 stop-check is the sole stop decision) and treats
    `phase: exiting` as a **hard terminal guard**. A fixed poll that re-derives the whole frontier each
    tick makes an *alive-but-stuck* orchestrator structurally impossible *between* turns — which is what
@@ -102,7 +102,7 @@ crash/hang). Detect which **first**, and keep **all** state in GitHub — no loc
    woken turn decides; see *Stop-time control*.)
 6. **Run the orchestrator turn (Loop A)** (below / `references/`). It self-bounds: each turn it
    compares the clock to `stop_at`, caps its next wake so it wakes by `stop_at` to drain — so the run
-   stops even if Loop B never fires — and ends with the fixed 30-min `ScheduleWakeup`. To run longer or
+   stops even if Loop B never fires — and ends with the fixed 15-min `ScheduleWakeup`. To run longer or
    stop sooner, **re-invoke `/run-cycle`** (active stop update: updates `stop_at` and recreates Loop B,
    ~0 latency), or edit `stop_at` in the header (passive: observed within one poll).
 
@@ -148,7 +148,7 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
    `attempt_id`, the per-attempt branch `<branch>-attempt-<attempt_id>`, `lead_worktree_root`, and
    the scope.
 7. **Wait / idle / exit:** reached only after §6 has filled every free seat it can. Any non-terminal
-   state schedules the **same fixed `ScheduleWakeup(1800)`** (idle notifications are no longer part of
+   state schedules the **same fixed `ScheduleWakeup(900)`** (idle notifications are no longer part of
    the wake model); **idle** (do **not** exit) when the frontier is empty with no stop signal; when
    draining completes, run the recorded **pre-exit audit** and a **two-phase quiescence exit**
    (cooldown + re-audit) before stopping. `phase: exiting` is a **hard terminal guard** — a stray/late
@@ -169,7 +169,7 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
   seat is free — but a lead never *intentionally* runs >5 (best-effort per-session cap; a manual
   double-start may transiently exceed it, bounded by attempt fencing); selection is
   priority-then-oldest-ready (starvation-free).
-- **Continuous service:** "no ready work" is `idle` (a fixed 30-min wake), never exit. Termination is a
+- **Continuous service:** "no ready work" is `idle` (a fixed 15-min wake), never exit. Termination is a
   scheduled **drain-signal** (the Loop B early-wake + the Step-2 self-bound), with a bounded,
   non-destructive drain (overdue workers → `orphaned_acknowledged`). Death or an intra-turn hang is
   recovered by **manual `/run-cycle` resume** — there is no watchdog.

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -42,7 +42,7 @@ written to local disk. Header shape:
 `phase`/`current_plan_revision`/`active_worker_ids` are **derived** (rebuilt by `replay` + session
 memory). The header is **soft, advisory, last-writer-wins**, and the orchestrator is its **sole
 writer** — it persists only the lease plus diagnostics a *human or the resume preflight* reads; **no
-sibling job consumes it** (there is no watchdog). `expires_at` (~2× the 1800 s poll) is the
+sibling job consumes it** (there is no watchdog). `expires_at` (~2× the 900 s poll) is the
 single-coordinator TTL: a manual second `/run-cycle` start that finds it in the future exits.
 `last_turn_started_at`/`last_turn_completed_at`/`next_wakeup_at` are **diagnostics** that make a manual
 resume *informed* (sleeping vs hung-mid-turn vs dead) instead of guessing from one TTL — advisory
@@ -55,7 +55,7 @@ fence), not an atomic lock.
 ## State machine
 
 **Two loops.** **Loop A** is this `/loop` orchestrator; every turn ends with a **fixed
-`ScheduleWakeup(1800)`** (30 min). **Loop B** is a one-time stop early-wake at `stop_at` (see
+`ScheduleWakeup(900)`** (15 min). **Loop B** is a one-time stop early-wake at `stop_at` (see
 *Stop-time control*). There is **no watchdog** — a fixed poll that re-derives the whole frontier each
 tick makes an *alive-but-stuck* orchestrator structurally impossible *between* turns. It does **not**
 cover an *intra-turn hang* (a `gh`/CI/spawn call that never returns before the turn reschedules): wrap
@@ -78,11 +78,11 @@ stray/late wake reading a clean `exiting` re-audits and stops without dispatchin
 - **dispatching** — creating tasks + spawning workers for ready tasks this turn. Entered whenever
   any ready task exists and `stop_at` is not reached — **including while other workers are active**
   (a §5 merge or a freed concurrency slot just unblocked it).
-- **waiting** — after filling every free seat, work is in flight → the **fixed `ScheduleWakeup(1800)`**.
+- **waiting** — after filling every free seat, work is in flight → the **fixed `ScheduleWakeup(900)`**.
   Idle notifications are **no longer part of the wake model**; every non-terminal phase uses the one
   fixed cadence. `waiting` never means "stop dispatching" — the next turn re-runs §5→§6 first.
 - **idle** — no ready work, no active workers, `stop_at` not reached → the same **fixed
-  `ScheduleWakeup(1800)`** (capped so it never sleeps past `stop_at`); **do not exit** (continuous
+  `ScheduleWakeup(900)`** (capped so it never sleeps past `stop_at`); **do not exit** (continuous
   service).
 - **draining** — clock reached `stop_at` → no new dispatch; wait for active workers, bounded
   by `drain_deadline_at`.
@@ -245,7 +245,7 @@ creates ≤5 issues this turn).
     session memory). Let `m = control_log.latest_recovery_with_metadata(comments, current_attempt_id)`.
     **If `m is None`** (no recovery comment for `current_attempt_id` — e.g. a branch-but-no-PR attempt
     that pushed before ever reporting) → treat as **not recent** → mint per the table immediately, **no
-    hold**. Otherwise `hold_until = m["created_at"] + 1800 + skew_grace`: if `now < hold_until` →
+    hold**. Otherwise `hold_until = m["created_at"] + 900 + skew_grace`: if `now < hold_until` →
     **hold** the task one poll (a merely-late live worker can finish or self-report) and re-evaluate
     next tick; else mint per the table. Human force overrides any hold.
 - **Dispatchable** = dependencies complete (each dep's `MERGE_GRANTED` is in the log → status
@@ -316,10 +316,10 @@ creates ≤5 issues this turn).
 ### 7. Wait / idle / exit
 Reached **only after §6 has filled every free seat it can** — never sleep with a free seat and ready
 work. The wake model is a **pure fixed poll**: every non-terminal state schedules the **same fixed
-`ScheduleWakeup(1800)`** (30 min). Idle notifications are **not** relied upon; whatever a turn finds it
+`ScheduleWakeup(900)`** (15 min). Idle notifications are **not** relied upon; whatever a turn finds it
 re-derives from GitHub and handles.
 - **Workers active, a capped backlog, or the frontier empty** (`stop_at` not reached) →
-  `waiting`/`idle`: schedule the **fixed `ScheduleWakeup(1800)`**, capped so it never sleeps past
+  `waiting`/`idle`: schedule the **fixed `ScheduleWakeup(900)`**, capped so it never sleeps past
   `stop_at`; **do not exit** (continuous service). One cadence for all of these — no jittered fallback,
   no shorter backlog wake, no recovery-probe wake. A held recovery candidate (§6 "hold if recent") is
   simply re-evaluated on the next fixed tick. Drop `active_worker_ids` entries as workers report and are
@@ -363,7 +363,7 @@ Changing `stop_at` (run longer / stop sooner) splits into two paths:
   and creates a new one** for the new time, then runs Step 2. This is the **only** ~0-latency path for
   **shortening**, and it is sole-writer-clean.
 - **Passive raw header edit** while Loop A sleeps — allowed but only **eventually observed** (≤ one
-  poll, ~30 min): Loop A recreates Loop B and acts on the new `stop_at` on its next wake. Discouraged
+  poll, ~15 min): Loop A recreates Loop B and acts on the new `stop_at` on its next wake. Discouraged
   (it races the sole-writer model) in favor of the active path.
 
 ## Emitting control events


### PR DESCRIPTION
## What

1. **Compute-utilization policy (new, parameterized).** Adds a `{{COMPUTE_POLICY}}` operating
   principle to the per-task cycle playbook; `create-cycle` now detects the compute environment,
   interviews for the policy, and renders it (never left raw). Default is **aggressive local
   utilization** — all CPUs/GPUs, parallelize, never single-thread a parallelizable job,
   background long jobs. Cluster/SLURM submission is **gated** on a named account/partition, and
   the up-to-5-worker oversubscription cap is an explicit project override.
2. **Loop A cadence 30 min → 15 min.** `ScheduleWakeup(1800)` → `(900)` across the skill, plus
   the two coupled constants (lease `expires_at` "~2× the poll", merge-hold `+ 900 + skew_grace`).
3. Bumps `task-loop` to `0.10.0`.

## Placement rationale

Decided via `discuss-with-codex` (3 rounds) — see
`docs/superpowers/specs/2026-06-14-task-loop-general-rules-placement-conclusion.md`. The rule is
project-parameterized, so it lives in the rendered playbook, not the agent system prompt
(re-render = reviewable diff; no silent cross-project behavior change).

Follow-up (separate issue): single-source the non-parameterized worker contract via a canonical
asset + drift unittest + CI.

Closes #127.
