### PR TITLE
task-loop: three-part specify-aims proposal + concision cleanup

### DIFF
--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development: control protocol, preflight/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.12.0"
+  "version": "0.13.0"
 }

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -18,16 +18,17 @@ single-sequencer event log) + numbered decision records, so a cold agent can con
 Three skills, run in order, plus one agent:
 
 ```
-a. /specify-aims   → docs/task-loop/proposal.md   (Charter + Roadmap; collaborative + codex)
+a. /specify-aims   → docs/task-loop/proposal.md   (aims + plan + roadmap; collaborative + codex)
 b. /create-cycle   → docs/task-loop/task-loop.md   (project parameters + scaffolding)
 c. /run-cycle      → orchestrator: /loop self-paced + Agent Team + drain-on-signal
                      cycle-worker (agent): executes one task's cycle
 ```
 
 1. **`specify-aims`** — brainstorm the project goal *with you* and pressure-test it with
-   `discuss-with-codex`, then write `docs/task-loop/proposal.md`: a **Charter** (stable
-   aims/success/constraints/non-goals — human-gated) and a **Roadmap** (living stages +
-   hypothesis ledger — orchestrator-authored).
+   `discuss-with-codex`, then write `docs/task-loop/proposal.md` in three parts: **Specific Aims &
+   Goal** (stable aims/success/constraints/non-goals — human-gated), an **Implementation Plan**
+   (proposed stages + milestones), and a **Living Roadmap** (progress + hypothesis ledger —
+   orchestrator-authored).
 2. **`create-cycle`** — render the project-specific `docs/task-loop/task-loop.md` (the worker's
    tailored step-by-step cycle plus this project's parameters; the `cycle-worker` agent holds only
    the general principles and invariants and follows this file) from auto-detected/interviewed
@@ -72,7 +73,7 @@ The **`preflight`** skill sets this for you (and reminds you to restart). The `s
 
 | Path | Owner | Purpose |
 |---|---|---|
-| `docs/task-loop/proposal.md` | `specify-aims`, then orchestrator | Charter + Roadmap (living research spine) |
+| `docs/task-loop/proposal.md` | `specify-aims`, then orchestrator | specific aims + implementation plan + living roadmap (the project's living spine) |
 | `docs/task-loop/task-loop.md` | `create-cycle` | this project's tailored step-by-step cycle + parameters; each worker follows it strictly (general principles + invariants live in the `cycle-worker` agent) |
 | `docs/task-loop/directions.md` | you | human steering channel (read first each round) |
 | `docs/task-loop/logs/NNN_<task>.md` | worker | one git-tracked per-cycle record (**Rubric** + **Decision log** sections); `NNN` = zero-padded iteration index from `001` (orchestrator-assigned, tracks cycles chronologically) |
@@ -85,7 +86,7 @@ The **`preflight`** skill sets this for you (and reminds you to restart). The `s
 task-loop/
 ├── skills/
 │   ├── preflight/        # standalone: verify required skills + enable Agent Teams (run once)
-│   ├── specify-aims/     # step a: author the proposal (Charter + Roadmap)
+│   ├── specify-aims/     # step a: author the proposal (aims + plan + roadmap)
 │   ├── create-cycle/     # step b: render task-loop.md + scaffolding
 │   └── run-cycle/        # step c: the orchestrator (state machine in references/)
 ├── agents/

--- a/task-loop/skills/create-cycle/SKILL.md
+++ b/task-loop/skills/create-cycle/SKILL.md
@@ -46,8 +46,8 @@ so the project's cycle stays current with the template.
 ## Process
 
 ### 1. Read the proposal
-Read `docs/task-loop/proposal.md`. The Charter's Aim + Success criteria become the
-**north star**; the Roadmap stages + hypotheses inform what tasks will look like. If the
+Read `docs/task-loop/proposal.md`. The Specific Aims (Aim + Success criteria) define the project
+**goal**; the Implementation Plan's stages + hypotheses inform what tasks will look like. If the
 proposal is missing, stop and direct the user to `specify-aims` first.
 
 ### 2. Auto-detect what the repo already tells you
@@ -87,7 +87,7 @@ ambiguous answers with `dev-skills:discuss-with-codex`:
   `cores ÷ workers`) here."* Only pressure-test with `discuss-with-codex` when the project has
   shared-cluster quota/etiquette constraints (then name the account/partition and any per-worker
   cap).
-- The **north star** phrasing → `{{NORTH_STAR}}` (from the Charter).
+- The project **goal** phrasing → `{{GOAL}}` (from the Specific Aims).
 
 ### 4. Render the cycle file
 Copy `assets/task-loop-skeleton.md` to `docs/task-loop/task-loop.md` and replace each

--- a/task-loop/skills/create-cycle/assets/directions-template.md
+++ b/task-loop/skills/create-cycle/assets/directions-template.md
@@ -18,7 +18,7 @@ Conventions:
 - Newest direction at the top; keep it short and imperative.
 - Date each note. Strike through or delete a note once the loop has acted on it, so the file
   reflects only *current* standing direction.
-- A note here overrides the loop's defaults but **not** the Charter or the correctness
+- A note here overrides the loop's defaults but **not** the Specific Aims or the correctness
   contracts — if a direction conflicts with those, the loop flags it (via
   `discuss-with-codex`) rather than silently breaking them.
 

--- a/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
+++ b/task-loop/skills/create-cycle/assets/task-loop-skeleton.md
@@ -13,7 +13,7 @@ file** against the current cycle template (this keeps the cycle from drifting be
 
 ## Project parameters (filled by create-cycle)
 
-- **North star / done:** {{NORTH_STAR}}
+- **Goal / done:** {{GOAL}}
 - **Source-of-truth docs (read every task):** `docs/task-loop/proposal.md` plus {{SOURCE_DOCS}}
 - **Steering file (read first):** `docs/task-loop/directions.md`
 - **Correctness contracts (not optional polish):** {{CONTRACTS}}

--- a/task-loop/skills/run-cycle/SKILL.md
+++ b/task-loop/skills/run-cycle/SKILL.md
@@ -139,7 +139,7 @@ Each `/loop` turn, in order (details in `references/orchestrator-loop.md`):
    + revision-compatible + (status `ready` **or** `active` with no live worker — an orphaned attempt
    recovered via `adopt_from_branch`); a **live** worker, `merged`, or `stale` is excluded. **Select**
    up to **5 concurrent `cycle-worker` teammates** (documented guideline, not enforced) by
-   `directions.md` priority, then oldest `ready_since`, then `proposal.md` Roadmap order, reserving ≥1
+   `directions.md` priority, then oldest `ready_since`, then `proposal.md` Implementation-Plan order, reserving ≥1
    seat for the oldest (starvation-free). **Active workers never suppress dispatch, but a lead never
    *intentionally* exceeds 5 in flight** (best-effort per-session cap; a manual double-start
    takeover may transiently exceed it, correctness-safe via attempt fencing). **Dispatch** each

--- a/task-loop/skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/skills/run-cycle/references/orchestrator-loop.md
@@ -151,7 +151,7 @@ For each known task issue (every `tasks[*].issue_number`):
   merge), just emit `PLAN_REVISION_BUMP{plan_revision: N, proposal_sha: <merged SHA>}`; otherwise
   author it, `gh pr merge` it (orchestrator is the sole editor of `proposal.md`), then emit the
   bump. Never emit the bump before the proposal PR is on `master`.
-- Recompute the dependency frontier from the Roadmap + declared `depends_on_tasks` /
+- Recompute the dependency frontier from the Implementation Plan + declared `depends_on_tasks` /
   `depends_on_hypotheses`. Mark every task in the invalidated subgraph `TASK_STALE` and **halt
   its dispatch**. If a finding's blast radius can't be mapped confidently, **freeze broadly**.
 
@@ -274,7 +274,7 @@ creates ≤5 issues this turn).
   replayed log — identical across resumes.
 - **Select** up to the number of free seats (deterministic, starvation-free): order by (1)
   `directions.md` priority, then (2) **oldest** `ready_since`, then (3) the task/stage declaration
-  order in the **`docs/task-loop/proposal.md` Roadmap** (the task source §4 computes the frontier
+  order in the **`docs/task-loop/proposal.md` Implementation Plan** (the task source §4 computes the frontier
   from — *not* the worker's cycle file `task-loop.md`) as the final tie-break. **Reserve ≥1 of
   the 5 seats for the oldest dispatchable task** (a max-skip rule) so a stream of high-priority work
   cannot starve it.

--- a/task-loop/skills/specify-aims/SKILL.md
+++ b/task-loop/skills/specify-aims/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: specify-aims
-description: This skill should be used when the user asks to "specify aims", "initialize the proposal", "set up the task-loop proposal", "define the project goal and stages", "start a task-loop project", or "write the charter" — i.e. to create the living proposal/implementation doc that drives a task-loop autonomous development project. It produces docs/task-loop/proposal.md (a Charter + Roadmap), brainstorming the aims with the user and pressure-testing the goal and stage decomposition with discuss-with-codex.
+description: This skill should be used when the user asks to "specify aims", "initialize the proposal", "set up the task-loop proposal", "define the project aims and stages", "plan the project stages and milestones", or "start a task-loop project" — i.e. to author the living proposal that drives a task-loop autonomous development project. It produces docs/task-loop/proposal.md with three parts — specific aims & goal, an implementation plan (stages + milestones), and a living roadmap (progress) — brainstorming the aims with the user and pressure-testing the goal and stage decomposition with discuss-with-codex.
 version: 0.1.0
 ---
 
@@ -9,12 +9,11 @@ version: 0.1.0
 ## Overview
 
 This is the **first step** of the task-loop workflow (`specify-aims` → `create-cycle` →
-`run-cycle`). It produces the **living research spine** for a project:
-`docs/task-loop/proposal.md`, a single durable doc with two zones — a **Charter** (stable
-aims / success criteria / constraints / non-goals) and a **Roadmap** (living stages + a
-hypothesis ledger). The proposal does not need to be perfect; it must state the goal
-clearly and decompose the work into rough, dependency-ordered stages. The task-loop refines
-the Roadmap as work validates or rejects hypotheses.
+`run-cycle`). It produces the project's **living spine**, `docs/task-loop/proposal.md` — a single
+durable doc in **three parts**: the **Specific Aims & Goal**, the **Implementation Plan** (stages +
+milestones), and the **Living Roadmap** (progress), each defined under Output below. The proposal
+need not be perfect; it must state the goal clearly and decompose the work into rough,
+dependency-ordered stages, which the task-loop then refines as work validates or rejects hypotheses.
 
 This is the one task-loop step that is **collaborative with the user** — later steps run
 autonomously. Brainstorm the aims with the user, and pressure-test the goal and the stage
@@ -22,27 +21,30 @@ decomposition with `dev-skills:discuss-with-codex`.
 
 ## When to use / not use
 
-- **Use** to initialize (or substantially re-aim) a task-loop project's proposal.
-- **Do not use** to edit a Roadmap during an active run. Once the loop is running, **only
-  the orchestrator** edits `proposal.md` (via `run-cycle`), because the proposal is the
-  durable narrative — not the live coordination primitive. This skill owns only the initial
-  authoring.
+- **Use** to author a new proposal, or to re-aim one **before the loop has started** (no control
+  issue yet).
+- **Do not use** once the project has a **control issue** (i.e. `run-cycle` has started). From that
+  point the control log holds the authoritative plan revision and **only the orchestrator** edits
+  `proposal.md` (via `run-cycle`); re-aiming is then a loop-reset / plan-revision decision, not a
+  `specify-aims` edit.
 
 ## Output: `docs/task-loop/proposal.md`
 
-Two zones with different change bars (scaffold in `assets/proposal-template.md`):
+Three parts with different change bars (scaffold in `assets/proposal-template.md`):
 
-- **Charter (stable, human-gated):** Aim, Success criteria, Constraints, Non-goals. This is
-  the north star; the autonomous loop never edits it. Changing it later is a
-  stop-condition-class decision escalated to the user.
-- **Roadmap (living, orchestrator-authored):** dependency-ordered Stages — each with a goal,
-  declared dependencies, rough acceptance, and **hypotheses** — plus a **hypothesis ledger**
-  (`open` / `validated` / `rejected`). The orchestrator updates this zone as the project
-  progresses.
+- **Specific Aims & Goal (stable, human-gated):** Aim, Success criteria, Constraints, Non-goals.
+  The autonomous loop never edits this; changing it later is a stop-condition-class decision
+  escalated to the user.
+- **Implementation Plan (proposed, orchestrator-revised):** dependency-ordered Stages — each with a
+  goal, declared dependencies, rough acceptance, and the **hypotheses** it rests on — plus coarse
+  **milestones**. The orchestrator revises this (bumping `plan_revision`) when a finding changes the
+  plan.
+- **Living Roadmap (progress, orchestrator-authored):** the running status — current stage,
+  milestones reached, and a **hypothesis ledger** tracking each hypothesis as `open` / `validated` /
+  `rejected`. Updated as work lands.
 
-Frontmatter carries `plan_revision: 1` — the durable roadmap revision *committed to git*. The
-authoritative *live* counter lives in the control-event log (and may run ahead of this); the
-frontmatter is the narrative copy.
+Frontmatter starts at `plan_revision: 1`; `run-cycle` owns later plan-revision bumps and the
+plan/roadmap edits — the Specific Aims stay human-gated.
 
 ## Process
 
@@ -52,19 +54,19 @@ exists and what "done" might plausibly mean.
 
 ### 2. Brainstorm the aim with the user
 Invoke `superpowers:brainstorming` and draw out, one question at a time:
-- the **north-star goal** and *why* it matters;
+- the **goal** and *why* it matters;
 - what **done** looks like (success criteria — binary / checkable where possible);
 - **constraints** (budget, compute, data access, required engines/tech, environment);
 - **non-goals** (explicitly out of scope);
-- the rough **stages/phases** and their order.
+- the rough **stages** and their order, and the **milestones** that mark demonstrable progress.
 
 Keep it lightweight — aim for clarity, not completeness.
 
-### 3. Decompose into dependency-ordered stages
-For each stage, capture: goal, what it depends on (prior stages / hypotheses), rough
-acceptance, and the **hypotheses** it rests on (falsifiable assumptions). Declaring
-hypotheses now is what later lets the running loop scope an invalidation to an affected
-subgraph instead of freezing everything.
+### 3. Decompose into a dependency-ordered plan
+For each stage, capture: goal, what it depends on (prior stages / hypotheses), rough acceptance, and
+the **hypotheses** it rests on (falsifiable assumptions). Then mark a few **milestones** — coarse,
+demonstrable checkpoints spanning stages. Declaring hypotheses now is what later lets the running
+loop scope an invalidation to an affected subgraph instead of freezing everything.
 
 ### 4. Pressure-test with Codex
 Use `dev-skills:discuss-with-codex` proactively on the aims and the decomposition. Hold a
@@ -72,39 +74,23 @@ genuine position and let Codex attack:
 - Is the goal **falsifiable** — is "done" actually checkable?
 - Are stages ordered by **real dependency**, or is the order arbitrary?
 - What is the **riskiest hypothesis**, and is it scheduled early?
-- Is anything in the Charter actually a Roadmap item (or vice versa)?
+- Is anything in the Specific Aims actually an Implementation-Plan item (or vice versa)?
 
 Fold the conclusions into the proposal; record any unresolved tension in the relevant stage.
 
 ### 5. Write the proposal
-Create `docs/task-loop/` if it does not exist (this is the first file there). Copy
-`assets/proposal-template.md` to `docs/task-loop/proposal.md` and fill it in. Write
-current-truth prose only (no "previously…"). Set frontmatter `plan_revision: 1`,
-`status: active`.
+For a new project, create `docs/task-loop/` and copy `assets/proposal-template.md` to
+`docs/task-loop/proposal.md` (it ships `plan_revision: 1`); to re-aim a pre-run proposal, edit the
+existing file in place rather than overwriting it. Fill in the three parts in current-truth prose
+(no "previously…").
 
 ### 6. Commit on a branch + PR
-The proposal is durable git state. Create a branch, commit `docs/task-loop/proposal.md`, and
-open a PR with clean, attribution-free text. After this, the proposal is the project's durable
-spine: **once the loop is running**, only the orchestrator edits it (via `run-cycle`). Until
-then, re-run `specify-aims` to revise it.
-
-## Key principles
-
-- **Clear, not perfect.** A crisp goal plus rough stages beats an exhaustive plan the loop
-  will rewrite anyway.
-- **Charter is sacred; Roadmap is fluid.** Put stable intent in the Charter and evolving
-  plans in the Roadmap; keeping them separate is what stops the goal from drifting every
-  time the plan adjusts.
-- **Declare hypotheses.** They are the units the loop validates/rejects and the edges it
-  reasons about when scoping invalidation.
-- **Deliberate, don't hand-wave.** Route every fuzzy aim or decomposition question through
-  `discuss-with-codex`.
+The proposal is durable git state. Create a branch, commit `docs/task-loop/proposal.md`, and open a
+PR with clean, attribution-free text.
 
 ## Additional resources
 
-- **`assets/proposal-template.md`** — the two-zone proposal scaffold to copy into the
+- **`assets/proposal-template.md`** — the three-part proposal scaffold to copy into the
   project.
 - Design rationale: `docs/superpowers/specs/2026-06-13-task-loop-plugin-design.md` (§4) and
-  `docs/superpowers/specs/2026-06-13-living-proposal-ownership-conclusion.md` (why the
-  Charter is not the live coordination primitive, and why only the orchestrator edits the
-  proposal once the loop runs).
+  `docs/superpowers/specs/2026-06-13-living-proposal-ownership-conclusion.md`.

--- a/task-loop/skills/specify-aims/assets/proposal-template.md
+++ b/task-loop/skills/specify-aims/assets/proposal-template.md
@@ -1,19 +1,18 @@
 ---
 plan_revision: 1
-status: active
 ---
 
 # <Project Name> — Proposal
 
-## Charter (stable — human-gated)
+## Specific Aims & Goal — *stable, human-gated*
 
-> The north star. Changes to this zone are a stop-condition-class decision; the
-> task-loop never edits the Charter autonomously.
+> The goal and the definition of done. The task-loop never edits this zone autonomously; changing it
+> is a stop-condition-class decision escalated to you.
 
 ### Aim
-<One paragraph: what this project is trying to achieve, and why it matters.>
+<One paragraph: what this project achieves, and why it matters.>
 
-### Success criteria (what "done" looks like)
+### Success criteria (definition of done)
 - <Binary / checkable where possible — e.g. "benchmark X reproduces value Y within tolerance Z".>
 - <...>
 
@@ -23,37 +22,50 @@ status: active
 ### Non-goals
 - <Explicitly out of scope, to stop scope creep.>
 
-## Roadmap (living — orchestrator-authored)
+## Implementation Plan — *proposed, orchestrator-revised*
 
-> Dependency-ordered stages and their hypotheses. The orchestrator updates this
-> zone via dedicated, codex-reviewed PRs as work validates or rejects hypotheses.
-> Each `plan_revision` bump is materialized here before dependent tasks dispatch.
+> The dependency-ordered stages and milestones planned to reach the Aim — kept rough on purpose. The
+> orchestrator revises this and bumps `plan_revision` when a finding changes the plan. Each stage
+> declares the falsifiable **hypotheses** it rests on — the units the loop validates, and the edges it
+> reasons about when scoping an invalidation.
 
-### Stage 1 — <name>
+### Stages (dependency-ordered)
+
+**Stage 1 — <name>**
 - **Goal:** <what this stage delivers>
 - **Depends on:** <prior stages / hypotheses, or "none">
-- **Rough acceptance:** <how we will know it is done>
-- **Hypotheses:**
-  - `H1.1` (open): <a falsifiable assumption this stage rests on>
+- **Acceptance:** <how we will know it is done>
+- **Hypotheses:** `H1.1` — <a falsifiable assumption this stage rests on>
 
-### Stage 2 — <name>
+**Stage 2 — <name>**
 - **Goal:** <...>
 - **Depends on:** Stage 1
-- **Rough acceptance:** <...>
-- **Hypotheses:**
-  - `H2.1` (open): <...>
+- **Acceptance:** <...>
+- **Hypotheses:** `H2.1` — <...>
 
 <add stages as needed — keep them rough; the loop refines them>
 
-## Hypothesis ledger
+### Milestones
+> Coarse, demonstrable checkpoints spanning stages.
+- **M1 — <name>:** <what it proves, e.g. "Stages 1–2: end-to-end run on toy input">
+- **M2 — <name>:** <...>
 
-> The **canonical roll-up** of every `Hx.y` declared inline under the stages above. Every
-> inline hypothesis must appear here; this table is authoritative for status. The orchestrator
-> updates `Status` as findings land.
+## Living Roadmap — *progress, orchestrator-authored*
 
-| ID | Statement | Status | Evidence / disposition |
-|------|-----------|--------|------------------------|
-| H1.1 | <falsifiable assumption> | open | |
-| H2.1 | <falsifiable assumption> | open | |
+> The running status, updated as work lands. The orchestrator owns this zone during a run; it records
+> progress — it is not the plan itself.
+
+### Progress
+- **Current stage:** <Stage N — short status, or "not started">
+- **Milestones reached:** <M1 …, or "none yet">
+
+### Hypothesis ledger
+> Tracks the status of every `Hx.y` declared in the Implementation Plan, by ID. Statements live with
+> their stage above; do not restate them here.
+
+| ID   | Status | Evidence / disposition |
+|------|--------|------------------------|
+| H1.1 | open   |                        |
+| H2.1 | open   |                        |
 
 <status ∈ {open, validated, rejected}>


### PR DESCRIPTION
Restructure the task-loop `specify-aims` proposal into three parts and tighten the skill.

**Proposal structure** (was Charter + Roadmap):
- **Specific Aims & Goal** — stable, human-gated
- **Implementation Plan** — proposed stages + milestones
- **Living Roadmap** — progress + hypothesis ledger

**Other changes:**
- Drop the "north star" term; rename the `{{NORTH_STAR}}` cycle placeholder to `{{GOAL}}`.
- Update create-cycle, run-cycle, the directions template, and README to the new zone names.
- Concision/accuracy cleanup (per a Codex deliberation): one canonical orchestrator-ownership rule, drop the dead proposal `status` field, sharpen the re-aim boundary to control-issue existence, remove the restating Key principles section.
- Bump task-loop to 0.13.0.
