### PR TITLE
Make task-loop setup skills check existing config

### DIFF
--- a/docs/superpowers/plans/2026-06-17-task-loop-idempotent-setup.md
+++ b/docs/superpowers/plans/2026-06-17-task-loop-idempotent-setup.md
@@ -1,0 +1,152 @@
+# Task-loop Idempotent Setup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update both task-loop setup skills so they check existing machine/repo setup before running setup steps.
+
+**Architecture:** Keep the CLI unchanged and encode the idempotent setup policy in both skill documents. `status` is the early connectivity check, `init` remains the idempotent repo-registration check, and smoke testing becomes conditional.
+
+**Tech Stack:** Markdown skills, YAML frontmatter validation, `task-loop` CLI via `uv`, GitHub CLI.
+
+## Global Constraints
+
+- Modify `task-loop/skills/setup/SKILL.md` and `task-loop/codex-skills/setup/SKILL.md` only for setup behavior.
+- Do not change `task-loop/cli/task-loop`.
+- Claude setup keeps Agent Teams and `${CLAUDE_PLUGIN_ROOT}` paths.
+- Codex setup must not introduce `Agent Teams`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `${CLAUDE_PLUGIN_ROOT}`, `discuss-with-codex`, or `TodoWrite`.
+- `status` proves machine credentials, Supabase connectivity, schema visibility, and git remote project derivation.
+- `init` is idempotent and ensures the repo project row exists.
+- Smoke test is required when setup changed or when the user asks for write proof; otherwise it is optional.
+
+---
+
+### Task 1: Update setup skills
+
+**Files:**
+- Modify: `task-loop/skills/setup/SKILL.md`
+- Modify: `task-loop/codex-skills/setup/SKILL.md`
+
+**Interfaces:**
+- Consumes: existing task-loop CLI commands `status`, `login`, `init`, `add`, and `close`.
+- Produces: setup instructions that skip unnecessary work when setup is already valid.
+
+- [ ] **Step 1: Run red content checks**
+
+Run:
+
+```bash
+! rg -q "Check existing setup first" task-loop/skills/setup/SKILL.md
+! rg -q "Check Existing Setup First" task-loop/codex-skills/setup/SKILL.md
+```
+
+Expected: both commands exit 0 because the sections are absent before implementation.
+
+- [ ] **Step 2: Update Claude setup skill**
+
+In `task-loop/skills/setup/SKILL.md`:
+
+- Add a new section after Step 0 named `Step 1 - Check existing setup first`.
+- Move the existing Supabase project/schema/login/init/verify sections down by one step number.
+- State that `uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop status` is the first setup check.
+- State that successful `status` means credentials, Supabase REST connectivity, schema visibility, and project-id derivation are working.
+- State that successful `status` means to skip Supabase project creation, schema application, and `login`.
+- State that `uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop init` is safe to run because it is idempotent and ensures the repo row exists.
+- State that the smoke test is only needed if setup changed or the user asks for write proof.
+- Keep the Agent Teams section intact.
+
+- [ ] **Step 3: Update Codex setup skill**
+
+In `task-loop/codex-skills/setup/SKILL.md`:
+
+- Add a new section after System Tools named `Check Existing Setup First`.
+- State that `uv run task-loop/cli/task-loop status` is the first setup check in this repo checkout.
+- State that successful `status` means credentials, Supabase REST connectivity, schema visibility, and project-id derivation are working.
+- State that successful `status` means to skip Supabase project creation, schema application, and `login`.
+- State that `uv run task-loop/cli/task-loop init` is safe to run because it is idempotent and ensures the repo row exists.
+- State that the smoke test is only needed if setup changed or the user asks for write proof.
+- Keep the setup/preflight-only note.
+
+- [ ] **Step 4: Run green content checks**
+
+Run:
+
+```bash
+rg -q "Check existing setup first" task-loop/skills/setup/SKILL.md
+rg -q "Check Existing Setup First" task-loop/codex-skills/setup/SKILL.md
+rg -q "skip Supabase project creation, schema application, and" task-loop/skills/setup/SKILL.md
+rg -q "skip Supabase project creation, schema application, and" task-loop/codex-skills/setup/SKILL.md
+rg -q "idempotent" task-loop/skills/setup/SKILL.md
+rg -q "idempotent" task-loop/codex-skills/setup/SKILL.md
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 5: Validate skills and CLI status**
+
+Run:
+
+```bash
+uv run --with pyyaml python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py task-loop/codex-skills/setup
+uv run task-loop/cli/task-loop status
+```
+
+Expected:
+
+```text
+Skill is valid!
+aeghnnsw/cc-toolkit: no tasks
+```
+
+- [ ] **Step 6: Check Codex forbidden terms and formatting**
+
+Run:
+
+```bash
+uv run --with pyyaml python - <<'PY'
+from pathlib import Path
+text = Path("task-loop/codex-skills/setup/SKILL.md").read_text()
+for term in ("Agent Teams", "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "${CLAUDE_PLUGIN_ROOT}", "discuss-with-codex", "TodoWrite"):
+    assert term not in text, term
+PY
+git diff --check
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add task-loop/skills/setup/SKILL.md task-loop/codex-skills/setup/SKILL.md
+git commit -m "feat: make task-loop setup skills check existing config"
+```
+
+### Task 2: Final validation and PR
+
+**Files:**
+- Verify: changed files
+
+**Interfaces:**
+- Consumes: Task 1.
+- Produces: pushed branch and PR closing #148.
+
+- [ ] **Step 1: Run final verification**
+
+Run:
+
+```bash
+uv run --with pyyaml python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py task-loop/codex-skills/setup
+uv run task-loop/cli/task-loop status
+git diff --check
+git status --short --branch
+```
+
+Expected: skill validation succeeds, CLI status returns this repo, no whitespace errors, and the branch is clean before push.
+
+- [ ] **Step 2: Push and create PR**
+
+Run:
+
+```bash
+git push -u origin feat-148-idempotent-task-loop-setup
+gh pr create --title "Make task-loop setup skills check existing config" --body "Updates both task-loop setup skills to check existing machine and repo setup before walking through setup steps.\n\nSuccessful status now skips project creation, schema application, and login; init remains the idempotent repo readiness check.\n\nCloses #148" --base master --head feat-148-idempotent-task-loop-setup
+```

--- a/docs/superpowers/specs/2026-06-17-task-loop-idempotent-setup-design.md
+++ b/docs/superpowers/specs/2026-06-17-task-loop-idempotent-setup-design.md
@@ -1,0 +1,96 @@
+# Design - task-loop idempotent setup skills
+
+Issue: #148
+
+## Goal
+
+Update both task-loop setup skills so they first check whether the machine and
+current repo are already configured for the hosted Supabase task board. If setup
+is already valid, they should report that status and skip unnecessary setup
+steps.
+
+## Current Behavior
+
+Both setup skills describe a mostly linear flow:
+
+1. check tools and required skills;
+2. create or reuse a Supabase project;
+3. apply schema;
+4. run `task-loop login`;
+5. run `task-loop init`;
+6. run an `add/status/close` smoke test.
+
+That flow works for a new machine, but it does not clearly handle an already
+configured machine and repo.
+
+## CLI Semantics
+
+`task-loop status` proves:
+
+- task-loop credentials are available through env vars or local config;
+- the Supabase REST endpoint is reachable;
+- the schema is sufficiently present for the `tasks` query;
+- the current git remote can be converted into an `owner/repo` project id.
+
+It does not prove the project row exists, because it only queries `tasks`.
+
+`task-loop init` is idempotent and upserts the current repo's project row. Use it
+as the repo-registration check when full readiness is needed.
+
+The smoke test (`add`, `status`, `close`) proves write access, schema functions,
+and repo registration.
+
+## Design
+
+Add an early "Check existing setup first" section to both setup skills.
+
+The check-first flow is:
+
+1. Run the system tool checks (`uv --version`, and `gh auth status` for later
+   loop readiness).
+2. Run `uv run .../cli/task-loop status`.
+3. If `status` succeeds:
+   - report that machine credentials, Supabase connectivity, schema visibility,
+     and git-remote project derivation are working;
+   - skip Supabase project creation, schema application, and `login`;
+   - run `uv run .../cli/task-loop init` when the user wants full readiness,
+     because it is idempotent and ensures the repo row exists;
+   - run the smoke test only if setup changed or the user asks for an
+     end-to-end write proof.
+4. If `status` fails:
+   - if it reports `TASK_LOOP_URL` or `TASK_LOOP_KEY` missing, run `login`;
+   - if it reports an HTTP/schema/table/function error, apply or re-apply
+     `db/schema.sql`;
+   - if it cannot derive the project from git remote, fix the remote or use the
+     CLI `--project owner/repo` override;
+   - after the fix, run `init`;
+   - run the smoke test.
+
+## File Changes
+
+Update:
+
+- `task-loop/skills/setup/SKILL.md`
+- `task-loop/codex-skills/setup/SKILL.md`
+
+Do not change the CLI in this issue. A future `doctor` command can provide a
+more exact machine/schema/repo diagnostic if needed.
+
+## Runtime-Specific Notes
+
+The Claude setup skill keeps its Agent Teams section and
+`${CLAUDE_PLUGIN_ROOT}` command paths.
+
+The Codex setup skill stays setup/preflight only and keeps Codex command paths.
+It must not introduce Claude-only terms.
+
+## Acceptance Criteria
+
+- Both setup skills include the check-first flow before setup steps.
+- Both setup skills say successful `status` skips project creation, schema
+  application, and `login`.
+- Both setup skills explain that `init` is idempotent and is the repo readiness
+  check.
+- Both setup skills reserve the smoke test for changed setup or explicit proof.
+- Existing CLI behavior is unchanged.
+- Codex setup skill still validates and stays concise.

--- a/task-loop/codex-skills/setup/SKILL.md
+++ b/task-loop/codex-skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Use when setting up task-loop in Codex, configuring the Supabase backend, saving task-loop credentials, registering a repo, checking prerequisites, running preflight, or performing a setup smoke test.
+description: Use when setting up task-loop in Codex, checking existing task-loop setup, configuring Supabase, saving credentials, registering a repo, checking prerequisites, running preflight, or performing a setup smoke test.
 ---
 
 # Task-loop Setup
@@ -40,6 +40,38 @@ gh auth status
 
 If `uv` is missing, stop and ask the user to install it. If `gh` is missing or unauthenticated, setup can save task-loop credentials but the later loop cannot run GitHub work.
 
+## Check Existing Setup First
+
+Before walking through setup, check whether this machine and repo already work:
+
+```bash
+uv run task-loop/cli/task-loop status
+```
+
+If `status` succeeds, report that:
+
+- machine credentials are available through env vars or local config;
+- Supabase REST connectivity works;
+- the schema is visible enough for the `tasks` query;
+- the current git remote can be derived as the task-loop project id.
+
+Then skip Supabase project creation, schema application, and `login`.
+For full repo readiness, still run the idempotent repo registration check:
+
+```bash
+uv run task-loop/cli/task-loop init
+```
+
+`init` upserts this repo's `projects` row, so it is safe to run even when the repo is already registered. Run the smoke test only if setup changed or the user asks for end-to-end write proof.
+
+If `status` fails, use the failure to choose the missing setup path:
+
+- `TASK_LOOP_URL` or `TASK_LOOP_KEY` missing: run `login`.
+- HTTP errors, missing relations, missing functions, or schema-looking failures: apply or re-apply `task-loop/db/schema.sql`.
+- Cannot derive the project from git remote: fix the repo remote or use the CLI `--project owner/repo` override.
+
+After fixing the reported gap, run `init`, then run the smoke test.
+
 ## Supabase Project
 
 Task-loop uses the user's hosted Supabase project. If the user does not already have one, have them create it in the Supabase dashboard and collect:
@@ -61,6 +93,8 @@ The schema is idempotent.
 
 ## Save Credentials
 
+Skip this step when `status` already succeeds unless the user wants to rotate credentials.
+
 Run:
 
 ```bash
@@ -71,6 +105,8 @@ The CLI prompts for the Project URL and API key and writes a local `0600` config
 
 ## Register Repository
 
+Run this after new setup, after fixing a failed setup check, or after a successful `status` when the user wants full repo readiness. The command is idempotent.
+
 From the repository root, run:
 
 ```bash
@@ -80,6 +116,8 @@ uv run task-loop/cli/task-loop init
 The project id is derived from `git remote get-url origin`.
 
 ## Smoke Test
+
+Run this when setup changed, when the setup check failed and was fixed, or when the user asks for end-to-end write proof. If `status` succeeded and no setup changed, this is optional.
 
 Run:
 

--- a/task-loop/skills/setup/SKILL.md
+++ b/task-loop/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: This skill should be used when the user asks to "set up task-loop", "configure the Supabase backend", "connect the task-loop database", "save Supabase credentials", "onboard a repo to task-loop", "check task-loop prerequisites", "verify task-loop dependencies", "enable agent teams", "preflight", or otherwise prepare a machine/repo to run the task-loop harness. It walks through the one-time-per-account Supabase project + schema, the one-time-per-machine credential save (task-loop login) and Agent Teams enablement, the one-time-per-repo registration (task-loop init), and the required plugin skills, then verifies connectivity.
+description: This skill should be used when the user asks to "set up task-loop", "configure the Supabase backend", "connect the task-loop database", "save Supabase credentials", "onboard a repo to task-loop", "check existing task-loop setup", "check task-loop prerequisites", "verify task-loop dependencies", "enable agent teams", "preflight", or otherwise prepare a machine/repo to run the task-loop harness. It checks existing machine/repo setup first, then walks through missing Supabase, credential, repo-registration, Agent Teams, and required-skill setup only as needed.
 ---
 
 # Task-loop setup
@@ -15,7 +15,7 @@ Setup happens at three granularities, each done once:
 | Layer | Once per… | Action |
 |---|---|---|
 | Supabase project + schema | **account** | create a project, apply `db/schema.sql` |
-| credentials (`URL` + `KEY`) + Agent Teams | **machine** | `task-loop login` (0600); enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` (Step 6) |
+| credentials (`URL` + `KEY`) + Agent Teams | **machine** | `task-loop login` (0600); enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` (Step 7) |
 | repo registration | **repo** | `task-loop init` |
 
 (The required plugin *skills* — Step 0 — are session/project state, re-checked every run by `run-cycle`'s preconditions, not just here.)
@@ -35,9 +35,41 @@ Setup happens at three granularities, each done once:
   A skill is loadable iff it appears in the session's available-skills list (match the
   `plugin:skill` name, owner-verified — a same-named personal skill is not the dependency).
   `specify-aims` / `create-cycle` need these; `run-cycle` re-checks them every session before
-  dispatching (Step 6 enables what `run-cycle` also needs).
+  dispatching (Step 7 enables what `run-cycle` also needs).
 
-## Step 1 — Supabase project (once per account)
+## Step 1 — Check existing setup first
+
+Before walking through setup, check whether this machine and repo already work:
+
+```
+uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop status
+```
+
+If `status` succeeds, report that:
+- machine credentials are available (env vars or the local config file);
+- Supabase REST connectivity works;
+- the schema is visible enough for the `tasks` query;
+- the current git remote can be derived as the task-loop project id.
+
+Then skip Supabase project creation, schema application, and `task-loop login`.
+For full repo readiness, still run the idempotent repo registration check:
+
+```
+uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop init
+```
+
+`init` upserts this repo's `projects` row, so it is safe to run even when the repo
+is already registered. Run the smoke test in Step 6 only if setup changed or the
+user asks for end-to-end write proof.
+
+If `status` fails, use the failure to choose the missing setup path:
+- `TASK_LOOP_URL` or `TASK_LOOP_KEY` missing → run Step 4 (`login`).
+- HTTP errors, missing relations, missing functions, or schema-looking failures → run Step 3.
+- Cannot derive the project from git remote → fix the repo remote or use the CLI `--project owner/repo` override.
+
+After fixing the reported gap, run Step 5 (`init`) and then Step 6 (smoke test).
+
+## Step 2 — Supabase project (once per account)
 
 If the user has no project yet:
 1. Create a project at https://supabase.com (the free tier is fine). This is the
@@ -50,7 +82,7 @@ If the user has no project yet:
 
 If they already have a shared task-loop project, reuse its URL + key — do **not** make a new one.
 
-## Step 2 — Apply the schema (once per project)
+## Step 3 — Apply the schema (once per project)
 
 PostgREST (the REST API the CLI uses) cannot run DDL, so the schema is applied once,
 out-of-band:
@@ -60,7 +92,7 @@ out-of-band:
 
 This creates `projects` + `tasks`, the `claimable` view, and the `task_add` / `task_claim` functions.
 
-## Step 3 — Save credentials (once per machine)
+## Step 4 — Save credentials (once per machine)
 
 ```
 uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop login
@@ -69,15 +101,18 @@ It prompts for the Project URL and the API key (hidden) and writes them to
 `$XDG_CONFIG_HOME/task-loop/config` (default `~/.config/task-loop/config`) at mode 0600.
 The CLI reads credentials env-first (`TASK_LOOP_URL` / `TASK_LOOP_KEY`), then this file.
 
-## Step 4 — Register the repo (once per repo)
+Skip this step when Step 1 `status` already succeeds unless the user wants to rotate credentials.
+
+## Step 5 — Register the repo (once per repo)
 
 From inside the repo (the project id is auto-derived from `git remote get-url origin`):
 ```
 uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop init
 ```
-Upserts this repo's `projects` row. Repeat in each repo that uses task-loop.
+Upserts this repo's `projects` row. Repeat in each repo that uses task-loop. This command is
+idempotent; run it after successful Step 1 when the user wants full repo readiness.
 
-## Step 5 — Verify
+## Step 6 — Verify
 
 ```
 uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop add "setup smoke test"   # prints e.g. 001
@@ -85,8 +120,10 @@ uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop status                   # lists the 
 uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop close 001                # closes it
 ```
 A clean `add → status → close` confirms the URL, key, schema, and repo registration are all good.
+Run this smoke test when setup changed, when Step 1 failed and was fixed, or when the user asks for
+end-to-end write proof. If Step 1 succeeded and no setup changed, the smoke test is optional.
 
-## Step 6 — Enable Agent Teams (once per machine; needed by `run-cycle`)
+## Step 7 — Enable Agent Teams (once per machine; needed by `run-cycle`)
 
 `run-cycle` spawns `cycle-worker` **teammates**, which require **experimental Agent Teams** (off by
 default) and Claude Code **≥ v2.1.32**. `specify-aims` / `create-cycle` do **not** need it.
@@ -104,7 +141,7 @@ Report `claude --version` (must be ≥ v2.1.32 — tell the user to update if ol
 
 ## Notes
 
-- **The Supabase MCP is not required.** Setup and the running harness use only the REST `URL` + `KEY`. If the Supabase MCP happens to be connected it can optionally run the schema for you (it can execute DDL, which the REST API cannot), but it is never a dependency — when in doubt, apply the schema via the SQL editor (Step 2).
-- **Per-account / per-machine / per-repo** are independent: a new machine repeats Steps 3 + 6 (and confirms Step 0 skills); a new repo only repeats Step 4.
+- **The Supabase MCP is not required.** Setup and the running harness use only the REST `URL` + `KEY`. If the Supabase MCP happens to be connected it can optionally run the schema for you (it can execute DDL, which the REST API cannot), but it is never a dependency — when in doubt, apply the schema via the SQL editor (Step 3).
+- **Per-account / per-machine / per-repo** are independent: a new machine repeats Steps 4 + 7 (and confirms Step 0 skills); a new repo only repeats Step 5.
 - The key is a machine-local 0600 secret — never commit it, never put it in `settings.json`.
 - Setup is standalone; it is not part of the `specify-aims → create-cycle → run-cycle` workflow.

--- a/task-loop/skills/setup/SKILL.md
+++ b/task-loop/skills/setup/SKILL.md
@@ -117,8 +117,9 @@ idempotent; run it after successful Step 1 when the user wants full repo readine
 ```
 uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop add "setup smoke test"   # prints e.g. 001
 uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop status                   # lists the task
-uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop close 001                # closes it
+uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop close <seq>              # closes it
 ```
+Replace `<seq>` with the sequence printed by `add`.
 A clean `add → status → close` confirms the URL, key, schema, and repo registration are all good.
 Run this smoke test when setup changed, when Step 1 failed and was fixed, or when the user asks for
 end-to-end write proof. If Step 1 succeeded and no setup changed, the smoke test is optional.


### PR DESCRIPTION
Updates both task-loop setup skills to check existing machine and repo setup before walking through setup steps.

Successful status now skips project creation, schema application, and login; init remains the idempotent repo readiness check.

Closes #148