### PR TITLE
Add Codex task-loop specify-aims

### DIFF
--- a/docs/superpowers/plans/2026-06-18-task-loop-codex-specify-aims.md
+++ b/docs/superpowers/plans/2026-06-18-task-loop-codex-specify-aims.md
@@ -1,0 +1,158 @@
+# Task-loop Codex Specify-aims Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the Codex `task-loop:specify-aims` skill while keeping later task-loop steps pending.
+
+**Architecture:** Add a Codex-specific skill folder under the existing `codex-skills/` tree. Reuse the proposal template contract from the Claude skill, but rewrite instructions for Codex and use `dev-skills:pressure-test` as the adversarial review step. Update only Codex setup wording so the installed plugin accurately reports supported Codex workflow steps.
+
+**Tech Stack:** Markdown `SKILL.md`, YAML frontmatter, Codex plugin skill discovery, `quick_validate.py`, JSON manifest validation.
+
+## Global Constraints
+
+- Codex-facing task-loop skills must not mention `discuss-with-codex`, `CLAUDE_PLUGIN_ROOT`, `Agent Teams`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, or `TodoWrite`.
+- `task-loop/.codex-plugin/plugin.json` must continue to point `skills` at `./codex-skills/`.
+- Top-level `task-loop/skills/` must remain absent.
+- `create-cycle` and `run-cycle` remain pending Codex ports.
+
+---
+
+### Task 1: Add Codex Specify-aims Skill
+
+**Files:**
+- Create: `task-loop/codex-skills/specify-aims/SKILL.md`
+- Create: `task-loop/codex-skills/specify-aims/assets/proposal-template.md`
+- Modify: `task-loop/.codex-plugin/plugin.json`
+- Modify: `task-loop/codex-skills/setup/SKILL.md`
+
+**Interfaces:**
+- Consumes: existing Codex plugin manifest `skills: "./codex-skills/"`.
+- Produces: a discoverable `task-loop:specify-aims` skill and a bundled proposal template.
+
+- [ ] **Step 1: Confirm baseline**
+
+Run:
+
+```bash
+test ! -e task-loop/codex-skills/specify-aims/SKILL.md
+jq -e '.skills == "./codex-skills/"' task-loop/.codex-plugin/plugin.json
+test ! -e task-loop/skills
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Create the skill directory and template asset**
+
+Create `task-loop/codex-skills/specify-aims/assets/`.
+
+Copy the content of `task-loop/claude-skills/specify-aims/assets/proposal-template.md` to:
+
+```text
+task-loop/codex-skills/specify-aims/assets/proposal-template.md
+```
+
+Expected: the template remains byte-for-byte compatible unless a Codex-only issue is found.
+
+- [ ] **Step 3: Write `SKILL.md`**
+
+Create `task-loop/codex-skills/specify-aims/SKILL.md` with:
+
+```markdown
+---
+name: specify-aims
+description: Use when starting a task-loop project in Codex, defining project aims and stages, initializing docs/task-loop/proposal.md, re-aiming a proposal before a run starts, or planning task-loop milestones and success criteria.
+---
+
+# Specify Aims
+
+Author or re-aim the task-loop proposal for a Codex-run project. This is the first workflow step after setup. It creates or updates `docs/task-loop/proposal.md`; `create-cycle` and `run-cycle` remain separate pending Codex ports.
+
+## Output
+
+Write `docs/task-loop/proposal.md` with three zones from `assets/proposal-template.md`:
+
+- **Specific Aims & Goal:** stable, human-gated aim, success criteria, constraints, and non-goals.
+- **Implementation Plan:** dependency-ordered stages, rough acceptance, milestones, and falsifiable hypotheses.
+- **Living Roadmap:** progress and hypothesis ledger. Leave this initialized for later orchestrator ownership.
+
+The template frontmatter includes `incorporated_through: 0`. Preserve it for new proposals.
+
+## Process
+
+1. Read the repository docs, README, existing `docs/task-loop/` files, and the user's stated direction.
+2. If `docs/task-loop/proposal.md` exists, gate any re-aim before editing:
+   - Parse the proposal frontmatter and read `incorporated_through`.
+   - If `incorporated_through` is exactly `0`, treat the proposal as pre-run.
+   - If `incorporated_through` is greater than `0`, refuse to edit Specific Aims and direct the user to steering or stop-then-re-aim.
+   - If `incorporated_through` is missing or not parseable, stop and require explicit user confirmation before editing Specific Aims.
+   - Also check for `docs/task-loop/task-loop.md`, `docs/task-loop/directions.md`, and task-loop CLI status when available, but do not rely on those instead of the frontmatter marker.
+3. Use `superpowers:brainstorming` to clarify the aim, success criteria, constraints, non-goals, stages, milestones, and key hypotheses. Ask only for information that cannot be inferred from the repo or the user's prompt.
+4. Draft dependency-ordered stages. Each stage must name its goal, dependencies, rough acceptance, and at least one falsifiable hypothesis when a real assumption exists.
+5. Use `dev-skills:pressure-test` on the aim, success criteria, and stage decomposition before writing the final proposal. The pressure-test packet must include the draft proposal, repo evidence used, assumptions, and decision boundary.
+6. Create `docs/task-loop/` if needed. For a new project, copy `assets/proposal-template.md` to `docs/task-loop/proposal.md`; for a pre-run re-aim, edit the existing proposal in place.
+7. Fill the proposal in current-truth prose. Do not leave angle-bracket placeholders. Keep Specific Aims stable and human-gated. Initialize progress as not started and all new hypotheses as `open`.
+8. Commit the proposal on a branch and open a PR with concise, attribution-free text when the user asked this skill to author durable proposal state.
+
+## Pressure-test Focus
+
+Ask the critic to attack:
+
+- whether success criteria are binary or checkable;
+- whether stages are ordered by real dependency;
+- whether the riskiest hypotheses appear early enough;
+- whether anything in Specific Aims belongs in the Implementation Plan instead;
+- whether constraints or non-goals are missing enough to make later task selection unsafe.
+```
+
+- [ ] **Step 4: Update setup wording**
+
+In `task-loop/codex-skills/setup/SKILL.md`, change the overview from setup/preflight-only to setup/preflight plus specify-aims support, and list only `create-cycle` and `run-cycle` as pending Codex ports.
+
+- [ ] **Step 5: Update Codex plugin metadata**
+
+In `task-loop/.codex-plugin/plugin.json`:
+
+- change `description` so it names setup, preflight, and specify-aims proposal support;
+- add keywords `specify-aims`, `proposal`, `aims`, and `planning`;
+- change `interface.shortDescription` so it is not setup-only;
+- change `interface.longDescription` so it says setup/preflight and specify-aims are supported, while `create-cycle` and `run-cycle` remain pending;
+- add a default prompt such as `Specify aims for this task-loop project.`
+
+- [ ] **Step 6: Validate**
+
+Run:
+
+```bash
+uv run --with pyyaml python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py task-loop/codex-skills/specify-aims
+uv run --with pyyaml python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py task-loop/codex-skills/setup
+jq . task-loop/.codex-plugin/plugin.json
+jq -e '(.description | contains("setup")) and (.description | contains("specify-aims")) and (.keywords | index("specify-aims"))' task-loop/.codex-plugin/plugin.json
+rg -q "incorporated_through" task-loop/codex-skills/specify-aims/SKILL.md
+python - <<'PY'
+from pathlib import Path
+forbidden = ("discuss-with-codex", "CLAUDE_PLUGIN_ROOT", "Agent Teams", "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "TodoWrite")
+for path in Path("task-loop/codex-skills").glob("*/SKILL.md"):
+    text = path.read_text()
+    bad = [term for term in forbidden if term in text]
+    if bad:
+        raise SystemExit(f"{path}: forbidden Codex-facing terms {bad}")
+print("codex skill text OK")
+PY
+```
+
+Expected: all commands exit 0 and the final script prints `codex skill text OK`.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add task-loop/.codex-plugin/plugin.json task-loop/codex-skills/specify-aims task-loop/codex-skills/setup/SKILL.md
+git commit -m "Add Codex task-loop specify-aims skill"
+```
+
+## Self-Review
+
+- **Spec coverage:** The task creates the new Codex skill, copies the template, replaces `discuss-with-codex` with `pressure-test`, adds an operational `incorporated_through` re-aim guard, updates setup wording and plugin metadata, and validates Codex-facing terms.
+- **Placeholder scan:** The proposed skill text contains no TODO/TBD placeholders. The proposal template intentionally contains user-fillable angle-bracket placeholders because it is an output scaffold.
+- **Type consistency:** File paths and skill names match the existing `codex-skills/` layout and manifest.

--- a/docs/superpowers/specs/2026-06-18-task-loop-codex-specify-aims-conclusion.md
+++ b/docs/superpowers/specs/2026-06-18-task-loop-codex-specify-aims-conclusion.md
@@ -1,0 +1,38 @@
+# Task-loop Codex Specify-aims Pressure-test Conclusion
+
+## Settled Position
+
+Add Codex `task-loop:specify-aims` as the next task-loop Codex slice after setup.
+The skill lives under `task-loop/codex-skills/specify-aims/`, uses the same proposal
+output contract as the Claude skill, and replaces `dev-skills:discuss-with-codex`
+with `dev-skills:pressure-test`.
+
+## Key Decisions
+
+- Keep `create-cycle` and `run-cycle` pending.
+- Copy the proposal template into the Codex skill so the skill is self-contained.
+- Update `task-loop/.codex-plugin/plugin.json` so marketplace metadata no longer describes the plugin as setup-only.
+- Update Codex setup wording so supported Codex scope is setup, preflight, and `specify-aims`.
+- Add an explicit `incorporated_through` frontmatter gate before re-aim edits.
+
+## Objections And Dispositions
+
+Round 1:
+- **Objection:** Updating only setup wording leaves `.codex-plugin/plugin.json` advertising setup/preflight-only support.
+- **Disposition:** Conceded. Added plugin metadata updates to the design, plan, implementation, and validation.
+
+Round 2:
+- **Objection:** The re-aim safety gate was too vague and could rewrite human-gated Specific Aims after execution starts.
+- **Disposition:** Conceded. Added an explicit `incorporated_through` frontmatter gate to the skill, design, and plan.
+
+Round 3:
+- **Objection:** No substantive objection.
+- **Disposition:** Converged.
+
+## Unresolved Tensions
+
+None for this slice. Codex `create-cycle`, `run-cycle`, and the worker execution model remain separate work.
+
+## Ending Condition
+
+Converged.

--- a/docs/superpowers/specs/2026-06-18-task-loop-codex-specify-aims-design.md
+++ b/docs/superpowers/specs/2026-06-18-task-loop-codex-specify-aims-design.md
@@ -1,0 +1,96 @@
+# Task-loop Codex Specify-aims Design
+
+## Goal
+
+Add Codex support for the first task-loop workflow step after setup: `task-loop:specify-aims`.
+The skill must let Codex author or re-aim `docs/task-loop/proposal.md` while keeping `create-cycle`
+and `run-cycle` out of scope.
+
+## Current State
+
+`task-loop` now separates runtime-specific skills:
+
+- Claude skills live in `task-loop/claude-skills/`.
+- Codex skills live in `task-loop/codex-skills/`.
+- There is no top-level `task-loop/skills/` directory.
+
+Codex currently exposes only `task-loop:setup`. The Claude `specify-aims` skill already defines the
+proposal shape and process, but it depends on `dev-skills:discuss-with-codex`, which is a
+Claude-to-Codex workflow and is not the right Codex dependency.
+
+## Design
+
+Create `task-loop/codex-skills/specify-aims/SKILL.md` and copy the existing proposal template asset
+to `task-loop/codex-skills/specify-aims/assets/proposal-template.md`.
+
+The Codex skill keeps the same output contract as Claude:
+
+- `docs/task-loop/proposal.md`
+- Specific Aims & Goal
+- Implementation Plan
+- Living Roadmap
+- `incorporated_through` frontmatter marker
+
+The Codex skill changes the deliberation dependency:
+
+- Use `superpowers:brainstorming` to shape the aim with the user.
+- Use `dev-skills:pressure-test` to challenge the aim, success criteria, and stage decomposition.
+- Do not mention or invoke `dev-skills:discuss-with-codex`.
+
+The skill should be instruction-only. No scripts are needed for this slice because authoring the
+proposal is a judgment-heavy workflow, not a deterministic transform.
+
+## Scope
+
+In scope:
+
+- Add Codex `specify-aims` skill and template asset.
+- Update Codex plugin metadata so marketplace text no longer describes the plugin as setup-only.
+- Add `specify-aims`, proposal, aims, and planning discovery terms to Codex plugin metadata.
+- Update Codex setup wording so support is no longer described as setup/preflight only.
+- Update Codex setup pending-port text to list only `create-cycle` and `run-cycle`.
+- Validate the new skill and guard against Claude-only terms in Codex-facing files.
+
+Out of scope:
+
+- Codex `create-cycle`.
+- Codex `run-cycle`.
+- Codex worker/subagent execution model.
+- Reworking Claude skills or shared task-loop documentation.
+
+## Skill Behavior
+
+The skill should:
+
+1. Confirm the repository state and read relevant project docs.
+2. If `docs/task-loop/proposal.md` exists, parse its frontmatter before editing.
+   `incorporated_through: 0` is the only automatic pre-run re-aim state.
+   `incorporated_through > 0` refuses Specific Aims edits and directs the user
+   to steering or stop-then-re-aim. Missing or unparseable frontmatter requires
+   explicit user confirmation before editing Specific Aims.
+3. Collaboratively clarify the goal, success criteria, constraints, non-goals, stages, and milestones.
+4. Decompose the work into dependency-ordered stages with falsifiable hypotheses.
+5. Pressure-test the aim and stage decomposition with `dev-skills:pressure-test`.
+6. Write or update `docs/task-loop/proposal.md` using the bundled template.
+7. Keep the Specific Aims stable and human-gated once a run starts.
+8. Commit and open a PR when the skill is used to author durable proposal state.
+
+## Validation
+
+Run:
+
+```bash
+uv run --with pyyaml python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py task-loop/codex-skills/specify-aims
+uv run --with pyyaml python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py task-loop/codex-skills/setup
+jq . task-loop/.codex-plugin/plugin.json
+jq -e '(.description | contains("setup")) and (.description | contains("specify-aims")) and (.keywords | index("specify-aims"))' task-loop/.codex-plugin/plugin.json
+```
+
+Also verify:
+
+- `task-loop/codex-skills/specify-aims/SKILL.md` exists.
+- The Codex skill tree includes `setup` and `specify-aims`.
+- Codex-facing task-loop skill files do not contain `discuss-with-codex`,
+  `CLAUDE_PLUGIN_ROOT`, `Agent Teams`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, or `TodoWrite`.
+- `task-loop/codex-skills/specify-aims/SKILL.md` contains an explicit `incorporated_through`
+  re-aim guard.

--- a/task-loop/.codex-plugin/plugin.json
+++ b/task-loop/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "task-loop",
   "version": "0.15.0",
-  "description": "Task-loop setup and preflight support for Codex.",
+  "description": "Task-loop setup, preflight, and specify-aims proposal support for Codex.",
   "author": {
     "name": "Steven",
     "email": "aeghnnsw@users.noreply.github.com"
@@ -13,13 +13,17 @@
     "setup",
     "preflight",
     "supabase",
-    "workflow"
+    "workflow",
+    "specify-aims",
+    "proposal",
+    "aims",
+    "planning"
   ],
   "skills": "./codex-skills/",
   "interface": {
     "displayName": "Task Loop",
-    "shortDescription": "Setup and preflight for task-loop in Codex.",
-    "longDescription": "Use Task Loop to configure the hosted Supabase task board, save local credentials, register a repository, and verify setup. Codex support is rolling out in phases; this slice supports setup and preflight only.",
+    "shortDescription": "Setup, preflight, and proposal aims for task-loop in Codex.",
+    "longDescription": "Use Task Loop to configure the hosted Supabase task board, save local credentials, register a repository, verify setup, and author the initial task-loop proposal with specify-aims. Codex support is rolling out in phases; create-cycle and run-cycle remain pending.",
     "developerName": "Steven",
     "category": "Developer Tools",
     "capabilities": [
@@ -28,7 +32,8 @@
     ],
     "defaultPrompt": [
       "Set up task-loop for this repo.",
-      "Check task-loop prerequisites."
+      "Check task-loop prerequisites.",
+      "Specify aims for this task-loop project."
     ]
   }
 }

--- a/task-loop/codex-skills/setup/SKILL.md
+++ b/task-loop/codex-skills/setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: setup
-description: Use when setting up task-loop in Codex, checking existing task-loop setup, configuring Supabase, saving credentials, registering a repo, checking prerequisites, running preflight, or performing a setup smoke test.
+description: Use when setting up task-loop in Codex, checking existing task-loop setup, configuring Supabase, saving credentials, registering a repo, checking prerequisites, running preflight, performing a setup smoke test, or preparing to use task-loop specify-aims.
 ---
 
 # Task-loop Setup
 
-Prepare this machine and repository for task-loop's hosted task board. This Codex skill supports setup and preflight only. `specify-aims`, `create-cycle`, and `run-cycle` are pending Codex ports.
+Prepare this machine and repository for task-loop's hosted task board. Codex support currently includes setup, preflight, and `specify-aims`; `create-cycle` and `run-cycle` are pending Codex ports.
 
 ## Preconditions
 
@@ -138,4 +138,4 @@ Report:
 - whether repo registration succeeded;
 - smoke-test sequence and closure result;
 - missing required skills, if any;
-- that Codex task-loop support is currently setup/preflight only.
+- that Codex task-loop support currently includes setup, preflight, and `specify-aims`; `create-cycle` and `run-cycle` remain pending.

--- a/task-loop/codex-skills/specify-aims/SKILL.md
+++ b/task-loop/codex-skills/specify-aims/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: specify-aims
+description: Use when starting a task-loop project in Codex, defining project aims and stages, initializing docs/task-loop/proposal.md, re-aiming a proposal before a run starts, or planning task-loop milestones and success criteria.
+---
+
+# Specify Aims
+
+Author or re-aim the task-loop proposal for a Codex-run project. This is the
+first workflow step after setup. It creates or updates
+`docs/task-loop/proposal.md`; `create-cycle` and `run-cycle` remain separate
+pending Codex ports.
+
+## Output
+
+Write `docs/task-loop/proposal.md` with three zones from
+`assets/proposal-template.md`:
+
+- **Specific Aims & Goal:** stable, human-gated aim, success criteria,
+  constraints, and non-goals.
+- **Implementation Plan:** dependency-ordered stages, rough acceptance,
+  milestones, and falsifiable hypotheses.
+- **Living Roadmap:** progress and hypothesis ledger. Leave this initialized
+  for later orchestrator ownership.
+
+The template frontmatter includes `incorporated_through: 0`. Preserve it for new
+proposals.
+
+## Process
+
+1. Read the repository docs, README, existing `docs/task-loop/` files, and the
+   user's stated direction.
+2. If `docs/task-loop/proposal.md` exists, gate any re-aim before editing:
+   - Parse the proposal frontmatter and read `incorporated_through`.
+   - If `incorporated_through` is exactly `0`, treat the proposal as pre-run.
+   - If `incorporated_through` is greater than `0`, refuse to edit Specific
+     Aims and direct the user to steering or stop-then-re-aim.
+   - If `incorporated_through` is missing or not parseable, stop and require
+     explicit user confirmation before editing Specific Aims.
+   - Also check for `docs/task-loop/task-loop.md`, `docs/task-loop/directions.md`,
+     and task-loop CLI status when available, but do not rely on those instead
+     of the frontmatter marker.
+3. Use `superpowers:brainstorming` to clarify the aim, success criteria,
+   constraints, non-goals, stages, milestones, and key hypotheses. Ask only for
+   information that cannot be inferred from the repo or the user's prompt.
+4. Draft dependency-ordered stages. Each stage must name its goal,
+   dependencies, rough acceptance, and at least one falsifiable hypothesis when
+   a real assumption exists.
+5. Use `dev-skills:pressure-test` on the aim, success criteria, and stage
+   decomposition before writing the final proposal. The pressure-test packet
+   must include the draft proposal, repo evidence used, assumptions, and
+   decision boundary.
+6. Create `docs/task-loop/` if needed. For a new project, copy
+   `assets/proposal-template.md` to `docs/task-loop/proposal.md`; for a pre-run
+   re-aim, edit the existing proposal in place.
+7. Fill the proposal in current-truth prose. Do not leave angle-bracket
+   placeholders. Keep Specific Aims stable and human-gated. Initialize progress
+   as not started and all new hypotheses as `open`.
+8. Commit the proposal on a branch and open a PR with concise,
+   attribution-free text when the user asked this skill to author durable
+   proposal state.
+
+## Pressure-test Focus
+
+Ask the critic to attack:
+
+- whether success criteria are binary or checkable;
+- whether stages are ordered by real dependency;
+- whether the riskiest hypotheses appear early enough;
+- whether anything in Specific Aims belongs in the Implementation Plan instead;
+- whether constraints or non-goals are missing enough to make later task
+  selection unsafe.

--- a/task-loop/codex-skills/specify-aims/assets/proposal-template.md
+++ b/task-loop/codex-skills/specify-aims/assets/proposal-template.md
@@ -1,0 +1,71 @@
+---
+incorporated_through: 0   # seq of the last merged task reflected here (orchestrator-maintained; 0 = none yet)
+---
+
+# <Project Name> — Proposal
+
+## Specific Aims & Goal — *stable, human-gated*
+
+> The goal and the definition of done. The task-loop never edits this zone autonomously; changing it
+> is a stop-condition-class decision escalated to you.
+
+### Aim
+<One paragraph: what this project achieves, and why it matters.>
+
+### Success criteria (definition of done)
+- <Binary / checkable where possible — e.g. "benchmark X reproduces value Y within tolerance Z".>
+- <...>
+
+### Constraints
+- <Budget, compute, data access, required tech/engines, environment, no-go areas.>
+
+### Non-goals
+- <Explicitly out of scope, to stop scope creep.>
+
+## Implementation Plan — *proposed, orchestrator-revised*
+
+> The dependency-ordered stages and milestones planned to reach the Aim — kept rough on purpose. The
+> orchestrator reconciles this each loop from merged findings when the plan changes. Each stage
+> declares the falsifiable **hypotheses** it rests on — the units the loop validates, and the edges it
+> reasons about when scoping an invalidation.
+
+### Stages (dependency-ordered)
+
+**Stage 1 — <name>**
+- **Goal:** <what this stage delivers>
+- **Depends on:** <prior stages / hypotheses, or "none">
+- **Acceptance:** <how we will know it is done>
+- **Hypotheses:** `H1.1` — <a falsifiable assumption this stage rests on>
+
+**Stage 2 — <name>**
+- **Goal:** <...>
+- **Depends on:** Stage 1
+- **Acceptance:** <...>
+- **Hypotheses:** `H2.1` — <...>
+
+<add stages as needed — keep them rough; the loop refines them>
+
+### Milestones
+> Coarse, demonstrable checkpoints spanning stages.
+- **M1 — <name>:** <what it proves, e.g. "Stages 1–2: end-to-end run on toy input">
+- **M2 — <name>:** <...>
+
+## Living Roadmap — *progress, orchestrator-authored*
+
+> The running status, updated as work lands. The orchestrator owns this zone during a run; it records
+> progress — it is not the plan itself.
+
+### Progress
+- **Current stage:** <Stage N — short status, or "not started">
+- **Milestones reached:** <M1 …, or "none yet">
+
+### Hypothesis ledger
+> Tracks the status of every `Hx.y` declared in the Implementation Plan, by ID. Statements live with
+> their stage above; do not restate them here.
+
+| ID   | Status | Evidence / disposition |
+|------|--------|------------------------|
+| H1.1 | open   |                        |
+| H2.1 | open   |                        |
+
+<status ∈ {open, validated, rejected}>


### PR DESCRIPTION
Adds the Codex `task-loop:specify-aims` skill with the proposal template, pressure-test workflow, and re-aim guard. Updates Codex setup and plugin metadata so support is described as setup, preflight, and specify-aims while create-cycle/run-cycle remain pending.

Closes #152