### PR TITLE
Add structured task-loop CLI state commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@
 
 ### Changed
 
+- task-loop: add structured CLI state output and CAS-only task issue repair for orchestrators.
 - README: document Codex marketplace support, current dev-skills coverage, and the task-loop plugin's current Claude/Codex support status.

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -48,11 +48,14 @@ repos are rows). The only thing that talks to it is the **`task-loop` CLI** — 
 REST-only:
 
 ```
-task-loop status | add "<title>" [--dep N…] [--issue N] | claim | close SEQ | reset SEQ | init | login
+task-loop status [--json] | add "<title>" [--dep N…] [--issue N] | claim [--json] |
+task-loop set-issue SEQ --issue N [--json] | close SEQ | reset SEQ | init | login
 ```
 
 The orchestrator uses it; workers never do. `claim` is atomic (`FOR UPDATE SKIP LOCKED`) — the only
 dispatch lock, so multiple orchestrators (one per ecosystem) need no further coordination.
+`set-issue` is compare-and-set only: it fills `issue` only for an `open` or `working` task whose
+issue is still missing, and never overwrites an existing unit-of-work identity.
 
 ## Prerequisites
 

--- a/task-loop/claude-skills/run-cycle/SKILL.md
+++ b/task-loop/claude-skills/run-cycle/SKILL.md
@@ -101,9 +101,12 @@ multi-orchestrator notes.
 
 ## Helpers — the `task-loop` CLI (the only DB access)
 
-`task-loop status | add "<title>" [--dep N…] [--issue N] | claim | close SEQ | reset SEQ` — run via
-`uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop …`. Project (`owner/repo`) auto-detected from the git
-remote. GitHub (issues / PRs / merge) via `gh`. Never bypass the CLI to touch the DB.
+`task-loop status [--json] | add "<title>" [--dep N…] [--issue N] | claim [--json] |
+task-loop set-issue SEQ --issue N [--json] | close SEQ | reset SEQ` — run via
+`uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop …`. Use `--json` when the orchestrator needs durable
+`seq`/`status`/`title`/`deps`/`issue` state. `set-issue` is compare-and-set only: it fills a missing
+task issue without overwriting an existing unit identity. Project (`owner/repo`) auto-detected from
+the git remote. GitHub (issues / PRs / merge) via `gh`. Never bypass the CLI to touch the DB.
 
 ## Additional resources
 

--- a/task-loop/cli/task-loop
+++ b/task-loop/cli/task-loop
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import getpass
+import json
 import os
 import re
 import subprocess
@@ -118,6 +119,9 @@ def cmd_claim(c, proj, a):
     data = _check(c.post("/rpc/task_claim", json={"p_project": proj})).json()
     if isinstance(data, list):
         data = data[0] if data else None
+    if getattr(a, "json", False):
+        print(json.dumps(data))
+        return
     if not data:
         print("none")
         return
@@ -151,12 +155,37 @@ def cmd_reset(c, proj, a):
     print(f"reset {int(a.seq):03d}" if rows else f"task {int(a.seq):03d} not working")
 
 
+def cmd_set_issue(c, proj, a):
+    rows = _check(c.patch(
+        "/tasks",
+        params={
+            "project_id": f"eq.{proj}",
+            "seq": f"eq.{a.seq}",
+            "issue": "is.null",
+            "status": "in.(open,working)",
+        },
+        headers={"Prefer": "return=representation"},
+        json={"issue": a.issue},
+    )).json()
+    row = rows[0] if rows else None
+    if getattr(a, "json", False):
+        print(json.dumps(row))
+        return
+    if row:
+        print(f"set issue for {int(a.seq):03d} to #{int(a.issue)}")
+    else:
+        print(f"issue not set for {int(a.seq):03d}")
+
+
 def cmd_status(c, proj, a):
     rows = _check(c.get("/tasks", params={
         "project_id": f"eq.{proj}",
         "order": "seq",
         "select": "seq,status,title,deps,issue",
     })).json()
+    if getattr(a, "json", False):
+        print(json.dumps(rows))
+        return
     if not rows:
         print(f"{proj}: no tasks")
         return
@@ -191,7 +220,14 @@ def main():
     s.set_defaults(fn=cmd_add)
 
     s = sub.add_parser("claim", help="atomically claim the next ready task")
+    s.add_argument("--json", action="store_true", help="print the claimed task row as JSON")
     s.set_defaults(fn=cmd_claim)
+
+    s = sub.add_parser("set-issue", help="fill a missing task issue without overwriting one")
+    s.add_argument("seq", type=int)
+    s.add_argument("--issue", type=int, required=True)
+    s.add_argument("--json", action="store_true", help="print the updated task row as JSON")
+    s.set_defaults(fn=cmd_set_issue)
 
     s = sub.add_parser("close", help="close a task")
     s.add_argument("seq", type=int)
@@ -202,6 +238,7 @@ def main():
     s.set_defaults(fn=cmd_reset)
 
     s = sub.add_parser("status", help="list this project's tasks")
+    s.add_argument("--json", action="store_true", help="print full task rows as JSON")
     s.set_defaults(fn=cmd_status)
 
     s = sub.add_parser("login", help="save Supabase creds to the machine-local config")

--- a/task-loop/tests/test_cli_state.py
+++ b/task-loop/tests/test_cli_state.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.machinery
+import importlib.util
+import io
+import json
+import pathlib
+import types
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CLI_PATH = ROOT / "cli" / "task-loop"
+
+
+def load_cli():
+    loader = importlib.machinery.SourceFileLoader("task_loop_cli", str(CLI_PATH))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    status_code = 200
+    text = ""
+
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+class FakeClient:
+    def __init__(self, *, get_data=None, post_data=None, patch_data=None):
+        self.get_data = get_data
+        self.post_data = post_data
+        self.patch_data = patch_data
+        self.calls = []
+
+    def get(self, path, **kwargs):
+        self.calls.append(("get", path, kwargs))
+        return FakeResponse(self.get_data)
+
+    def post(self, path, **kwargs):
+        self.calls.append(("post", path, kwargs))
+        return FakeResponse(self.post_data)
+
+    def patch(self, path, **kwargs):
+        self.calls.append(("patch", path, kwargs))
+        return FakeResponse(self.patch_data)
+
+
+def capture_stdout(fn, *args):
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        fn(*args)
+    return out.getvalue().strip()
+
+
+class TaskLoopCliStateTests(unittest.TestCase):
+    def setUp(self):
+        self.cli = load_cli()
+
+    def test_status_json_includes_full_task_rows(self):
+        rows = [
+            {
+                "seq": 1,
+                "status": "open",
+                "title": "First task",
+                "deps": [],
+                "issue": 11,
+            },
+            {
+                "seq": 2,
+                "status": "working",
+                "title": "Second task",
+                "deps": [1],
+                "issue": None,
+            },
+        ]
+        client = FakeClient(get_data=rows)
+
+        output = capture_stdout(
+            self.cli.cmd_status,
+            client,
+            "owner/repo",
+            types.SimpleNamespace(json=True),
+        )
+
+        self.assertEqual(json.loads(output), rows)
+
+    def test_status_json_prints_empty_array_for_empty_board(self):
+        client = FakeClient(get_data=[])
+
+        output = capture_stdout(
+            self.cli.cmd_status,
+            client,
+            "owner/repo",
+            types.SimpleNamespace(json=True),
+        )
+
+        self.assertEqual(json.loads(output), [])
+
+    def test_claim_json_returns_claimed_task_row(self):
+        task = {
+            "seq": 7,
+            "status": "working",
+            "title": "Claimed task",
+            "deps": [2, 3],
+            "issue": 42,
+        }
+        client = FakeClient(post_data=task)
+
+        output = capture_stdout(
+            self.cli.cmd_claim,
+            client,
+            "owner/repo",
+            types.SimpleNamespace(json=True),
+        )
+
+        self.assertEqual(json.loads(output), task)
+
+    def test_claim_json_returns_null_when_no_task_is_ready(self):
+        client = FakeClient(post_data=None)
+
+        output = capture_stdout(
+            self.cli.cmd_claim,
+            client,
+            "owner/repo",
+            types.SimpleNamespace(json=True),
+        )
+
+        self.assertIsNone(json.loads(output))
+
+    def test_set_issue_only_fills_missing_issue_without_overwriting_identity(self):
+        row = {
+            "seq": 7,
+            "status": "working",
+            "title": "Needs issue",
+            "deps": [],
+            "issue": 42,
+        }
+        client = FakeClient(patch_data=[row])
+
+        output = capture_stdout(
+            self.cli.cmd_set_issue,
+            client,
+            "owner/repo",
+            types.SimpleNamespace(seq=7, issue=42, json=True),
+        )
+
+        method, path, kwargs = client.calls[0]
+        self.assertEqual(method, "patch")
+        self.assertEqual(path, "/tasks")
+        self.assertEqual(kwargs["params"]["project_id"], "eq.owner/repo")
+        self.assertEqual(kwargs["params"]["seq"], "eq.7")
+        self.assertEqual(kwargs["params"]["issue"], "is.null")
+        self.assertEqual(kwargs["params"]["status"], "in.(open,working)")
+        self.assertEqual(kwargs["json"], {"issue": 42})
+        self.assertEqual(json.loads(output), row)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds JSON output for task-loop status and claim, plus a CAS-only set-issue command for repairing issue-less tasks without overwriting unit identity.

Closes #158