### PR TITLE
Fix task-loop CLI invocation and sequence setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,6 @@
 
 ### Changed
 
+- task-loop: run CLI setup examples with `uv run --script` and add guarded `set-seq` support.
 - task-loop: add structured CLI state output and CAS-only task issue repair for orchestrators.
 - README: document Codex marketplace support, current dev-skills coverage, and the task-loop plugin's current Claude/Codex support status.

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -44,18 +44,21 @@ dispatch. Codex `run-cycle` and worker dispatch are pending.
 ## The task DB + CLI
 
 All task state lives in the user's own hosted **Supabase** project (one shared across their repos;
-repos are rows). The only thing that talks to it is the **`task-loop` CLI** — a single `uv run` script,
-REST-only:
+repos are rows). The only thing that talks to it is the **`task-loop` CLI** — a single PEP 723
+`uv run --script` script, REST-only:
 
 ```
 task-loop status [--json] | add "<title>" [--dep N…] [--issue N] | claim [--json] |
-task-loop set-issue SEQ --issue N [--json] | close SEQ | reset SEQ | init | login
+task-loop set-issue SEQ --issue N [--json] | task-loop set-seq N [--force] [--json] |
+task-loop close SEQ | reset SEQ | init | login
 ```
 
 The orchestrator uses it; workers never do. `claim` is atomic (`FOR UPDATE SKIP LOCKED`) — the only
 dispatch lock, so multiple orchestrators (one per ecosystem) need no further coordination.
 `set-issue` is compare-and-set only: it fills `issue` only for an `open` or `working` task whose
 issue is still missing, and never overwrites an existing unit-of-work identity.
+`set-seq` adjusts the repo-scoped next task sequence and refuses values that would collide with
+existing tasks unless `--force` is explicit.
 
 ## Prerequisites
 

--- a/task-loop/claude-skills/run-cycle/SKILL.md
+++ b/task-loop/claude-skills/run-cycle/SKILL.md
@@ -102,11 +102,14 @@ multi-orchestrator notes.
 ## Helpers — the `task-loop` CLI (the only DB access)
 
 `task-loop status [--json] | add "<title>" [--dep N…] [--issue N] | claim [--json] |
-task-loop set-issue SEQ --issue N [--json] | close SEQ | reset SEQ` — run via
-`uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop …`. Use `--json` when the orchestrator needs durable
-`seq`/`status`/`title`/`deps`/`issue` state. `set-issue` is compare-and-set only: it fills a missing
-task issue without overwriting an existing unit identity. Project (`owner/repo`) auto-detected from
-the git remote. GitHub (issues / PRs / merge) via `gh`. Never bypass the CLI to touch the DB.
+task-loop set-issue SEQ --issue N [--json] | task-loop set-seq N [--force] [--json] |
+task-loop close SEQ | reset SEQ`
+— run via `uv run --script ${CLAUDE_PLUGIN_ROOT}/cli/task-loop …`. Use `--json` when the
+orchestrator needs durable `seq`/`status`/`title`/`deps`/`issue` state. `set-issue` is
+compare-and-set only: it fills a missing task issue without overwriting an existing unit identity.
+`set-seq` adjusts the repo-scoped next task sequence and refuses collisions unless `--force` is
+explicit. Project (`owner/repo`) auto-detected from the git remote. GitHub (issues / PRs / merge) via
+`gh`. Never bypass the CLI to touch the DB.
 
 ## Additional resources
 

--- a/task-loop/claude-skills/setup/SKILL.md
+++ b/task-loop/claude-skills/setup/SKILL.md
@@ -25,7 +25,7 @@ Setup happens at three granularities, each done once:
 
 ## Step 0 — Prerequisites
 
-- **`uv`** (runs the CLI; the CLI is a single `uv run` script with inline deps). Verify `uv --version`.
+- **`uv`** (runs the CLI; the CLI is a PEP 723 script with inline deps). Verify `uv --version`.
 - **`gh`**, authenticated (`gh auth status`) — the orchestrator uses it for PRs/merges. Not needed for the CLI itself, but required to run the loop later.
 - **Required plugin skills** — the harness invokes 8 skills from two plugins; install both (via `/plugin`):
   - **`superpowers`** — `brainstorming`, `writing-plans`, `test-driven-development`,
@@ -42,7 +42,7 @@ Setup happens at three granularities, each done once:
 Before walking through setup, check whether this machine and repo already work:
 
 ```
-uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop status
+uv run --script ${CLAUDE_PLUGIN_ROOT}/cli/task-loop status
 ```
 
 If `status` succeeds, report that:
@@ -55,7 +55,7 @@ Then skip Supabase project creation, schema application, and `task-loop login`.
 For full repo readiness, still run the idempotent repo registration check:
 
 ```
-uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop init
+uv run --script ${CLAUDE_PLUGIN_ROOT}/cli/task-loop init
 ```
 
 `init` upserts this repo's `projects` row, so it is safe to run even when the repo
@@ -95,7 +95,7 @@ This creates `projects` + `tasks`, the `claimable` view, and the `task_add` / `t
 ## Step 4 — Save credentials (once per machine)
 
 ```
-uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop login
+uv run --script ${CLAUDE_PLUGIN_ROOT}/cli/task-loop login
 ```
 It prompts for the Project URL and the API key (hidden) and writes them to
 `$XDG_CONFIG_HOME/task-loop/config` (default `~/.config/task-loop/config`) at mode 0600.
@@ -107,7 +107,7 @@ Skip this step when Step 1 `status` already succeeds unless the user wants to ro
 
 From inside the repo (the project id is auto-derived from `git remote get-url origin`):
 ```
-uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop init
+uv run --script ${CLAUDE_PLUGIN_ROOT}/cli/task-loop init
 ```
 Upserts this repo's `projects` row. Repeat in each repo that uses task-loop. This command is
 idempotent; run it after successful Step 1 when the user wants full repo readiness.
@@ -115,9 +115,9 @@ idempotent; run it after successful Step 1 when the user wants full repo readine
 ## Step 6 — Verify
 
 ```
-uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop add "setup smoke test"   # prints e.g. 001
-uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop status                   # lists the task
-uv run ${CLAUDE_PLUGIN_ROOT}/cli/task-loop close <seq>              # closes it
+uv run --script ${CLAUDE_PLUGIN_ROOT}/cli/task-loop add "setup smoke test"   # prints e.g. 001
+uv run --script ${CLAUDE_PLUGIN_ROOT}/cli/task-loop status                   # lists the task
+uv run --script ${CLAUDE_PLUGIN_ROOT}/cli/task-loop close <seq>              # closes it
 ```
 Replace `<seq>` with the sequence printed by `add`.
 A clean `add → status → close` confirms the URL, key, schema, and repo registration are all good.

--- a/task-loop/cli/task-loop
+++ b/task-loop/cli/task-loop
@@ -6,7 +6,7 @@
 """task-loop — DB-only CLI for the Supabase task-loop harness.
 
 Run it with uv (no install needed beyond uv itself):
-    uv run task-loop/cli/task-loop <command> ...
+    uv run --script task-loop/cli/task-loop <command> ...
 or, since it is executable: ./task-loop/cli/task-loop <command> ...
 
 Credentials — env vars, or the machine-local config written once by
@@ -93,6 +93,16 @@ def _check(r: httpx.Response) -> httpx.Response:
     return r
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be >= 1")
+    return parsed
+
+
 # --- commands ---------------------------------------------------------------
 
 def cmd_init(c, proj, a):
@@ -177,6 +187,50 @@ def cmd_set_issue(c, proj, a):
         print(f"issue not set for {int(a.seq):03d}")
 
 
+def cmd_set_seq(c, proj, a):
+    project_rows = _check(c.get("/projects", params={
+        "id": f"eq.{proj}",
+        "select": "next_seq",
+    })).json()
+    if not project_rows:
+        sys.exit(f"task-loop: project {proj!r} not registered — run `task-loop init`")
+    old_next_seq = int(project_rows[0]["next_seq"])
+
+    task_rows = _check(c.get("/tasks", params={
+        "project_id": f"eq.{proj}",
+        "select": "seq",
+        "order": "seq.desc",
+        "limit": "1",
+    })).json()
+    max_task_seq = int(task_rows[0]["seq"]) if task_rows else None
+    if max_task_seq is not None and a.next_seq <= max_task_seq and not a.force:
+        sys.exit(
+            f"task-loop: next_seq {a.next_seq:03d} would collide with existing "
+            f"task {max_task_seq:03d}; use a value above {max_task_seq:03d} "
+            "or pass --force"
+        )
+
+    rows = _check(c.patch(
+        "/projects",
+        params={"id": f"eq.{proj}"},
+        headers={"Prefer": "return=representation"},
+        json={"next_seq": a.next_seq},
+    )).json()
+    if not rows:
+        sys.exit(f"task-loop: project {proj!r} was not updated")
+    next_seq = int(rows[0].get("next_seq", a.next_seq))
+    result = {
+        "project": proj,
+        "old_next_seq": old_next_seq,
+        "next_seq": next_seq,
+        "max_task_seq": max_task_seq,
+    }
+    if getattr(a, "json", False):
+        print(json.dumps(result))
+        return
+    print(f"next_seq {proj}: {old_next_seq:03d} -> {next_seq:03d}")
+
+
 def cmd_status(c, proj, a):
     rows = _check(c.get("/tasks", params={
         "project_id": f"eq.{proj}",
@@ -228,6 +282,12 @@ def main():
     s.add_argument("--issue", type=int, required=True)
     s.add_argument("--json", action="store_true", help="print the updated task row as JSON")
     s.set_defaults(fn=cmd_set_issue)
+
+    s = sub.add_parser("set-seq", help="set this project's next task sequence")
+    s.add_argument("next_seq", type=_positive_int, help="next seq to assign, e.g. 19 for 019")
+    s.add_argument("--force", action="store_true", help="allow a value at or below existing task seqs")
+    s.add_argument("--json", action="store_true", help="print the counter update as JSON")
+    s.set_defaults(fn=cmd_set_seq)
 
     s = sub.add_parser("close", help="close a task")
     s.add_argument("seq", type=int)

--- a/task-loop/codex-skills/setup/SKILL.md
+++ b/task-loop/codex-skills/setup/SKILL.md
@@ -10,8 +10,8 @@ Prepare this machine and repository for task-loop's hosted task board. Codex sup
 ## Preconditions
 
 - Work from the repository root.
-- Use the plugin checkout path when running commands in this repository: `uv run task-loop/cli/task-loop ...`.
-- If task-loop is installed from the Codex plugin cache, first locate the installed plugin root and run `uv run <plugin-root>/cli/task-loop ...`.
+- Use the plugin checkout path when running commands in this repository: `uv run --script task-loop/cli/task-loop ...`.
+- If task-loop is installed from the Codex plugin cache, first locate the installed plugin root and run `uv run --script <plugin-root>/cli/task-loop ...`.
 - Never commit Supabase credentials. The CLI stores credentials in `$XDG_CONFIG_HOME/task-loop/config` or `~/.config/task-loop/config` with mode `0600`.
 
 ## Required Skills
@@ -67,7 +67,7 @@ A new or restarted Codex session may be required before a newly installed custom
 Before walking through setup, check whether this machine and repo already work:
 
 ```bash
-uv run task-loop/cli/task-loop status
+uv run --script task-loop/cli/task-loop status
 ```
 
 If `status` succeeds, report that:
@@ -81,7 +81,7 @@ Then skip Supabase project creation, schema application, and `login`.
 For full repo readiness, still run the idempotent repo registration check and the Codex agent sync:
 
 ```bash
-uv run task-loop/cli/task-loop init
+uv run --script task-loop/cli/task-loop init
 ```
 
 `init` upserts this repo's `projects` row, so it is safe to run even when the repo is already registered. Run the smoke test only if setup changed or the user asks for end-to-end write proof.
@@ -120,7 +120,7 @@ Skip this step when `status` already succeeds unless the user wants to rotate cr
 Run:
 
 ```bash
-uv run task-loop/cli/task-loop login
+uv run --script task-loop/cli/task-loop login
 ```
 
 The CLI prompts for the Project URL and API key and writes a local `0600` config file.
@@ -132,7 +132,7 @@ Run this after new setup, after fixing a failed setup check, or after a successf
 From the repository root, run:
 
 ```bash
-uv run task-loop/cli/task-loop init
+uv run --script task-loop/cli/task-loop init
 ```
 
 The project id is derived from `git remote get-url origin`.
@@ -144,9 +144,9 @@ Run this when setup changed, when the setup check failed and was fixed, or when 
 Run:
 
 ```bash
-uv run task-loop/cli/task-loop add "setup smoke test"
-uv run task-loop/cli/task-loop status
-uv run task-loop/cli/task-loop close <seq>
+uv run --script task-loop/cli/task-loop add "setup smoke test"
+uv run --script task-loop/cli/task-loop status
+uv run --script task-loop/cli/task-loop close <seq>
 ```
 
 Replace `<seq>` with the sequence printed by `add`. The smoke test proves credentials, schema, and repo registration are working.

--- a/task-loop/tests/test_cli_state.py
+++ b/task-loop/tests/test_cli_state.py
@@ -34,15 +34,17 @@ class FakeResponse:
 
 
 class FakeClient:
-    def __init__(self, *, get_data=None, post_data=None, patch_data=None):
+    def __init__(self, *, get_data=None, get_responses=None, post_data=None, patch_data=None):
         self.get_data = get_data
+        self.get_responses = list(get_responses or [])
         self.post_data = post_data
         self.patch_data = patch_data
         self.calls = []
 
     def get(self, path, **kwargs):
         self.calls.append(("get", path, kwargs))
-        return FakeResponse(self.get_data)
+        data = self.get_responses.pop(0) if self.get_responses else self.get_data
+        return FakeResponse(data)
 
     def post(self, path, **kwargs):
         self.calls.append(("post", path, kwargs))
@@ -161,6 +163,83 @@ class TaskLoopCliStateTests(unittest.TestCase):
         self.assertEqual(kwargs["params"]["status"], "in.(open,working)")
         self.assertEqual(kwargs["json"], {"issue": 42})
         self.assertEqual(json.loads(output), row)
+
+    def test_set_seq_updates_project_counter_when_above_existing_tasks(self):
+        client = FakeClient(
+            get_responses=[
+                [{"next_seq": 1}],
+                [{"seq": 18}],
+            ],
+            patch_data=[{"next_seq": 19}],
+        )
+
+        output = capture_stdout(
+            self.cli.cmd_set_seq,
+            client,
+            "owner/repo",
+            types.SimpleNamespace(next_seq=19, force=False, json=True),
+        )
+
+        self.assertEqual(client.calls[0][0], "get")
+        self.assertEqual(client.calls[0][1], "/projects")
+        self.assertEqual(client.calls[0][2]["params"]["id"], "eq.owner/repo")
+        self.assertEqual(client.calls[0][2]["params"]["select"], "next_seq")
+        self.assertEqual(client.calls[1][0], "get")
+        self.assertEqual(client.calls[1][1], "/tasks")
+        self.assertEqual(client.calls[1][2]["params"]["project_id"], "eq.owner/repo")
+        self.assertEqual(client.calls[1][2]["params"]["select"], "seq")
+        self.assertEqual(client.calls[1][2]["params"]["order"], "seq.desc")
+        self.assertEqual(client.calls[1][2]["params"]["limit"], "1")
+        self.assertEqual(client.calls[2][0], "patch")
+        self.assertEqual(client.calls[2][1], "/projects")
+        self.assertEqual(client.calls[2][2]["params"]["id"], "eq.owner/repo")
+        self.assertEqual(client.calls[2][2]["json"], {"next_seq": 19})
+        self.assertEqual(
+            json.loads(output),
+            {
+                "project": "owner/repo",
+                "old_next_seq": 1,
+                "next_seq": 19,
+                "max_task_seq": 18,
+            },
+        )
+
+    def test_set_seq_refuses_value_that_would_collide_with_existing_task(self):
+        client = FakeClient(
+            get_responses=[
+                [{"next_seq": 20}],
+                [{"seq": 18}],
+            ],
+        )
+
+        with self.assertRaises(SystemExit):
+            self.cli.cmd_set_seq(
+                client,
+                "owner/repo",
+                types.SimpleNamespace(next_seq=18, force=False, json=False),
+            )
+
+        self.assertEqual([call[0] for call in client.calls], ["get", "get"])
+
+    def test_set_seq_force_allows_lower_counter(self):
+        client = FakeClient(
+            get_responses=[
+                [{"next_seq": 20}],
+                [{"seq": 18}],
+            ],
+            patch_data=[{"next_seq": 18}],
+        )
+
+        output = capture_stdout(
+            self.cli.cmd_set_seq,
+            client,
+            "owner/repo",
+            types.SimpleNamespace(next_seq=18, force=True, json=False),
+        )
+
+        self.assertEqual(client.calls[2][0], "patch")
+        self.assertEqual(client.calls[2][2]["json"], {"next_seq": 18})
+        self.assertEqual(output, "next_seq owner/repo: 020 -> 018")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Runs task-loop CLI examples with `uv run --script` so host project dependencies are ignored, and adds guarded `set-seq` support for onboarding repos with existing task numbering.

Closes #160
Closes #161