### PR TITLE
Bump task-loop plugin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- task-loop: bump plugin manifests to `0.16.0` so Claude and Codex refresh cached run-cycle support.
 - task-loop: add conservative manual Codex `run-cycle` support with observable worker dispatch gates.
 - task-loop: document optional `set-seq` setup step before smoke testing existing task histories.
 - task-loop: run CLI setup examples with `uv run --script` and add guarded `set-seq` support.

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development on a hosted Supabase task board: the task-loop CLI, setup/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "skills": "./claude-skills/"
 }

--- a/task-loop/.codex-plugin/plugin.json
+++ b/task-loop/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-loop",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Task-loop setup, preflight, specify-aims, create-cycle scaffolding, and manual run-cycle support for Codex.",
   "author": {
     "name": "Steven",


### PR DESCRIPTION
Bumps the task-loop Claude and Codex plugin manifests to 0.16.0 so clients refresh cached run-cycle support.

Closes #167