### PR TITLE
Add Loop C drain monitor docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- task-loop: document Loop C post-`stop_at` drain monitoring and bump plugin manifests to `0.17.0`.
 - task-loop: bump plugin manifests to `0.16.0` so Claude and Codex refresh cached run-cycle support.
 - task-loop: add conservative manual Codex `run-cycle` support with observable worker dispatch gates.
 - task-loop: document optional `set-seq` setup step before smoke testing existing task histories.

--- a/docs/superpowers/specs/2026-06-15-task-loop-orchestrator-pass-conclusion.md
+++ b/docs/superpowers/specs/2026-06-15-task-loop-orchestrator-pass-conclusion.md
@@ -50,24 +50,25 @@ finished" was too strong.)
 `task-loop claim` protects `open → working` (atomic, `FOR UPDATE SKIP LOCKED`) but **not**
 `working → open`. A PR is a durable artifact (merge is safe for any orchestrator); a PR-absent
 `working` task is **ambiguous** — without a durable ownership/liveness marker you cannot distinguish
-"alive but pre-PR" from "dead". So **reset has exactly two triggers**:
+"alive but pre-PR" from "dead". Current reset has exactly three positive no-live-owner cases:
 
 - **(a) In-session observed death** — this orchestrator spawned the teammate this session and saw it
   die / finish without a PR → auto `reset`. Always safe.
 - **(b) Human direct CLI** — the operator runs `task-loop reset <seq>` out-of-band (only the human
   knows whether another orchestrator is live).
+- **(c) Single-orchestrator cold start** — on a fresh session in the default single-orchestrator mode,
+  prior-session workers died with their session, so opaque `working`-no-PR tasks are reclaimable.
 
-A **cold / fresh / foreign** tick **never** auto-resets an opaque `working`-no-PR task — it only
-**surfaces** it ("`012` looks orphaned; if no orchestrator is live, run `task-loop reset 012`"). It
-still merges PR-present tasks and dispatches claimable. `directions.md` **never** triggers reset (it is
-standing steering, not a consumable queue; a stale `reset 012` line would re-fire and kill a new live
+A declared **multi-orchestrator foreign** tick never auto-resets an opaque `working`-no-PR task — it
+only **surfaces** it ("`012` looks orphaned; if no orchestrator is live, run `task-loop reset 012`").
+It still merges PR-present tasks and dispatches claimable. `directions.md` **never** triggers reset (it
+is standing steering, not a consumable queue; a stale `reset 012` line would re-fire and kill a new live
 worker). **No lease / heartbeat / attempt-id / timer / ownership marker is added.**
 
-**Accepted cost:** running multiple concurrent orchestrators on one project loses *automatic* recovery
-of pre-PR orphans (a human `reset` handles the rare stuck one). Single-orchestrator operation —
-including sequential cross-machine (stop here, start there) — keeps full auto-recovery, because
-Agent-Teams teammates die with their session, so the spawning session is the only one that ever has a
-live teammate to observe.
+**Accepted cost:** declared concurrent multi-orchestrator operation loses *automatic* recovery of
+foreign pre-PR orphans (a human `reset` handles the rare stuck one). Single-orchestrator operation —
+including crash/restart and sequential cross-machine (stop here, start there) — keeps full
+auto-recovery because prior-session Agent-Teams teammates die with their session.
 
 ### 3. Proposal update is a reconcile sweep, not a patch
 The orchestrator is the sole editor of `proposal.md`. Concurrent orchestrators patching it from a stale
@@ -141,24 +142,29 @@ disagreement.)
 Holes found → fixes (all now in `run-cycle` SKILL + `references/orchestrator-loop.md` and §8–§9 above):
 
 1. **Stuck / never-mergeable PR spins forever** — the worker opens a PR then idles, so a red/stuck PR
-   is never repaired; "something `working` = progress" masked it, and `stop_at` draining ("stop when no
-   `working` remains") never fired. → **Real-progress predicate** (a gate-failed/stuck working task is
-   *not* progress) + step-3 PR classification; drain waits only for real-progress.
+   is never repaired; "something `working` = progress" masked it. → Step-3 PR classification is total:
+   merge success, update behind-base PRs, or close non-mergeable attempts and re-attack on the next
+   active materialization pass.
 2. **Livelock guard needs durable per-unit retry accounting the DB lacks** — re-materializing a failed
-   unit as a new task looks "fresh" each time, so a K-failure guard can't fire. → **No auto-recreation;
-   the GitHub issue is the durable per-unit identity** (1:1, never duplicated). Gate-failed/stuck →
-   label `needs-human`, leave the task; retry is human-only.
+   unit as a new task looks "fresh" each time, so a K-failure guard can't fire. → The **GitHub issue is
+   the durable per-unit identity** (1:1, never duplicated), and all PRs that `Refs #<issue>` are the
+   attempt history. Gate-failed/stuck/conflicted attempts are diagnosed and re-materialized as
+   materially different re-attacks on active ticks; if classified during drain-only mode, the open issue
+   and PR history make the re-attack recoverable on the next active run.
 3. **"Unmet + board empty" is a *planning* gap with no task → silent terminal stall** (nothing
-   surfaced). → before idling, **guarantee a durable surfaced blocker**: per-unit `needs-human` issues,
-   plus a proposal-level `needs-human: proposal-unmet-no-planned-work` for a planning gap. Also
-   **head-SHA-atomic merge** (`--match-head-commit`) to defeat a green→red flap between classify and merge.
+   surfaced). → while active and the goal is unmet, step 5 must materialize the next diagnosed,
+   AIM-aligned work: planned stages, blockers, re-attacks, direction/finding work, and drain-deferred
+   open issues. Also **head-SHA-atomic merge** (`--match-head-commit`) defeats a green→red flap between
+   classify and merge.
 4. **Gate-green but merge-blocked** (PR conflicted / behind a required base after `main` moved) — the
    atomic merge rejects for a non-head reason and nothing surfaces it → per-unit stall. → **`MERGEABLE`
-   includes GitHub merge-state (clean, not behind)**; any deterministic merge rejection →
-   `needs-human: merge-blocked`. **PR classification is now total** over states.
+   includes GitHub merge-state (clean, not behind)**; behind-base is mechanically updated by the
+   orchestrator, and deterministic conflicts are diagnosed and re-attacked. **PR classification is now
+   total** over states.
 
-**Settled closure invariant:** every tick, a `working` task is exactly one of *merge-and-close*,
-*pending-within-a-bound*, or *`needs-human` (surfaced, not progress, not blocking drain)*; the board is
-never left empty short of the goal without a durable surfaced blocker; nothing failed is auto-recreated.
-⟹ every tick **advances a task, finishes the goal, or has durably asked for help** — and the run always
-terminates (goal-met, or surfaced-and-idle, or `stop_at`). Codex: converged, no further objections.
+**Settled closure invariant:** on active ticks, every `working` task is classified as mergeable,
+pending within a CI bound, behind-base, blocked, failed/stuck/conflicted, or no-PR/liveness-gated. The
+board is never left empty short of the goal; step 5 creates the next diagnosed, AIM-aligned work unless
+the run is drain-only. During drain-only mode, new starts are forbidden, but failed/blocked/stuck
+attempts remain recoverable through the open issue and PR history for the next active run. Codex:
+converged, no further objections.

--- a/docs/superpowers/specs/2026-06-15-task-loop-orchestrator-pass-conclusion.md
+++ b/docs/superpowers/specs/2026-06-15-task-loop-orchestrator-pass-conclusion.md
@@ -9,6 +9,11 @@ a Loop B to stop it).
 **Companion:** the authoritative design spec
 `2026-06-15-task-loop-supabase-harness-design.md` (this conclusion refines §7–§9 of it).
 
+**Stop-model supersession:** §4 below records the original Loop A/Loop B stop decision. The current
+stop model is superseded by `2026-06-19-task-loop-loop-c-drain-monitor-design.md`: Loop B is the
+`stop_at` transition that creates recurring Loop C, and Loop C drains observable in-flight work before
+generation cancellation.
+
 Codex was adversarial-correct on all four contested points; the settled design below is the operator's
 6-step pass with four hard corrections folded in.
 
@@ -80,20 +85,22 @@ Study-logs are git-tracked on the default branch, so "complete merged evidence" 
 proposal may carry an "incorporated through task `<seq>`" marker to make "not yet reflected" cheap. No
 lock needed — the reconcile sweep is convergent.
 
-### 4. Stop model — Loop B is a non-destructive nudge; Loop A self-stops
-- **Loop A** = the fixed-interval `/loop` running the pass. Its tick is the **sole stop decision**:
-  when `now ≥ stop_at` and the board is drained, Loop A cancels **its own** schedule id and stops.
-- **Loop B** = a one-time job at `stop_at` that **wakes/nudges Loop A** so it stops at ~`stop_at`
-  instead of up to one interval late. It is **non-destructive** — it never force-stops or deletes
-  anything, so a **stale Loop B fire is harmless** (the woken tick re-checks the current `stop_at` and
-  continues if it was extended).
-- **`stop_at` is embedded as a literal in Loop A's recurring `/loop` prompt** — every tick self-checks
-  it with zero stored state.
-- Jobs carry a **`run_generation`** literal in their names (`task-loop-<project>-<gen>-A` / `-B`), so a
-  stale job touches only its own generation, never "whatever A exists for this project." Re-invoking
-  `/run-cycle` best-effort cancels all `task-loop-<project>-*` and creates a fresh generation.
-- **No Supabase runtime cell, no stored schedule handle, no local file** — generation + naming +
-  embedded `stop_at` suffice.
+### 4. Stop model — superseded by Loop C drain monitor
+
+This original decision is superseded by `2026-06-19-task-loop-loop-c-drain-monitor-design.md`. The
+current model keeps Loop B non-destructive but makes it the `stop_at` transition that installs recurring
+Loop C. Loop C, not Loop A, is the post-`stop_at` drain/cancellation authority.
+
+Current decision:
+- **Loop A** = fixed-interval active pass before `stop_at`; after `stop_at` it runs drain-only and must
+  not cancel the generation before Loop B/Loop C exists.
+- **Loop B** = one-time non-destructive `stop_at` transition. It validates its generation from schedule
+  names, installs recurring Loop C, and never dispatches, materializes re-attacks, or force-stops live
+  work.
+- **Loop C** = recurring drain monitor. It drains observable in-flight workers/monitored jobs and
+  PR-present work, then cancels the generation's schedules.
+- **No Supabase runtime cell, no stored schedule handle, no local file** — generation names plus
+  embedded prompts suffice.
 
 ---
 
@@ -109,8 +116,9 @@ lock needed — the reconcile sweep is convergent.
    reset is in-session or direct CLI only; directions only surface.
 5. **Git serializes text, not planning semantics** (R5) — clean-merge-incoherent-meaning. *Conceded;*
    proposal update is a reconcile sweep from current default + complete evidence.
-6. **A destructive Loop B with a fixed name kills a newer run** (R6) → Loop B non-destructive +
-   `run_generation` naming; Loop A self-stops on its own schedule id. *Conceded.*
+6. **A destructive Loop B with a fixed name kills a newer run** (R6) → Loop B is non-destructive,
+   jobs are generation-named, and current post-`stop_at` cancellation is handled by Loop C for that
+   generation. *Conceded.*
 
 ## Unresolved tensions
 None substantive. The one residual is **operational, not a bug**: concurrent multi-orchestrator

--- a/docs/superpowers/specs/2026-06-15-task-loop-supabase-harness-design.md
+++ b/docs/superpowers/specs/2026-06-15-task-loop-supabase-harness-design.md
@@ -3,7 +3,7 @@
 **Date:** 2026-06-15
 **Status:** design agreed; **fully built**. Components: `db/schema.sql`, `cli/task-loop`, `skills/setup` (live-verified), `references/pr-findings.md`, `agents/cycle-worker`, `skills/create-cycle` + `task-loop-skeleton.md`, `skills/run-cycle`. Old harness retired: old `scripts/` + tests removed, `preflight` folded into `setup`, `specify-aims` slimmed, README + `plugin.json` updated.
 **Supersedes:** the GitHub-issue-comment control-log harness (`scripts/control_log.py`, `scripts/gh_store.py`, old `run-cycle`).
-**Companion docs:** orchestrator-pass deliberation `2026-06-15-task-loop-orchestrator-pass-conclusion.md` (refines §7–§9 below); **persistence-model closure `2026-06-16-task-loop-persistence-loop-conclusion.md` (this revision — supersedes the human-wait branches in §8/§9)**; earlier redesign record `2026-06-15-task-loop-supabase-harness-redesign-conclusion.md`; diagrams `2026-06-15-task-loop-harness-diagram.md`.
+**Companion docs:** orchestrator-pass deliberation `2026-06-15-task-loop-orchestrator-pass-conclusion.md` (refines §7–§9 below, with its original stop model superseded by `2026-06-19-task-loop-loop-c-drain-monitor-design.md`); **persistence-model closure `2026-06-16-task-loop-persistence-loop-conclusion.md` (supersedes the human-wait branches in §8/§9, with its original bounded-drain stop model superseded by the 2026-06-19 Loop C design)**; earlier redesign record `2026-06-15-task-loop-supabase-harness-redesign-conclusion.md`; diagrams `2026-06-15-task-loop-harness-diagram.md`.
 
 This is the single source of truth for the redesigned harness. It records *what* we are building and *why* the non-obvious cuts were made (several reverse earlier drafts).
 
@@ -124,15 +124,17 @@ Three independent granularities, each done once:
 
 The orchestrator runs under a **fixed-interval Loop A** (default 15 min). Each tick is one idempotent
 pass over (DB + GitHub + `directions.md`) — no start/resume/recover distinction. **Loop B** is a
-one-time job at `stop_at` that *non-destructively* wakes Loop A; **Loop A is the sole stop authority**
-(a tick with `now ≥ stop_at` + a drained board cancels its own generation-named schedules and stops).
-Both jobs carry a `run_generation` so a stale job never touches a newer run. Full algorithm +
-rationale: `skills/run-cycle` and the deliberation `…-orchestrator-pass-conclusion.md`.
+one-time job at `stop_at` that acts as the stop transition: it validates its generation, creates
+recurring **Loop C**, and does not dispatch, re-attack, or force-stop live work. **Loop C** drains
+observable in-flight workers/monitored jobs and PR-present work, then cancels the generation's
+`-A`/`-B`/`-C` jobs. Jobs carry a `run_generation` so a stale job never touches a newer run. Full
+algorithm + rationale: `skills/run-cycle` and the deliberation `…-orchestrator-pass-conclusion.md`.
 
 Each tick, **in order** (steering first — it gates everything irreversible):
 
-0. **Read state + stop check.** `task-loop status` + open PRs/issues + `directions.md`. `now ≥ stop_at`
-   → drain (skip dispatch; finish in-flight; stop when no `working` remains).
+0. **Read state + phase check.** `task-loop status` + open PRs/issues + `directions.md`. `now ≥ stop_at`
+   → drain-only (skip materialization/dispatch; finish observable in-flight work and landed PRs under
+   Loop C).
 1. **Honor steering.** Apply `directions.md` (highest priority) *before* any merge — pause/freeze,
    "don't merge #X", priorities, blockers. Steering is an **exogenous trigger** (a tick does real work
    on new directions, not only on completions).
@@ -145,30 +147,35 @@ Each tick, **in order** (steering first — it gates everything irreversible):
    **Behind base only** → `gh pr update-branch` (mechanical sync; merge next pass). **Gate-failed /
    stuck / conflict** (check red, review failed, genuine conflict / deterministic rejection, or pending
    past bound / never posts) → **diagnose and re-attack, never give up**: `gh pr close` + `task-loop
-   close <seq>`, then step 5 materializes the **next attempt against the same issue** with a
-   materially-different, escalated, AIM-aligned strategy. (Recreation is safe because it is *diagnosed
+   close <seq>`, then step 5 materializes the **next attempt against the same issue** on an active tick
+   with a materially-different, escalated, AIM-aligned strategy. In drain-only mode, keep the issue open
+   and defer materialization to the next active run. (Recreation is safe because it is *diagnosed
    escalation*, not blind repetition — reversing the old "close-recreate spins → surface `needs-human`"
-   rule — and `stop_at` bounds it.) **Pending** → leave for next pass.
+   rule — and `stop_at` bounds new starts.) **Pending** → leave for next pass.
 4. **Findings → `proposal.md` (reconcile sweep).** The orchestrator is the **sole editor** of
    `proposal.md`. When merged findings change the roadmap, **recompute** the affected sections from
    *current default + the complete set of merged study-logs not yet reflected* (never a stale patch),
    PR it, merge it; regenerate if the base moved. Convergent under concurrent orchestrators — no lock.
-5. **Materialize tasks (idempotent) — the goal-driver that never gives up.** Ensure the board carries
-   the next work toward the **Success criteria**: planned stages not yet tasked (seed + decomposition,
+5. **Materialize tasks (idempotent; skip while draining) — the goal-driver that never gives up.**
+   Ensure the board carries the next work toward the **Success criteria**: planned stages not yet
+   tasked (seed + decomposition,
    **including the riskiest / heavy-lifting work — never deferred for easy wins**), discovered blockers,
-   `--dep` re-creation (re-linking the issue), direction-/finding-driven tasks, and **re-attacks** of
-   every attempt step 3 closed non-mergeable. A re-attack is **diagnosed** (`discuss-with-codex`: what
+   `--dep` re-creation (re-linking the issue), direction-/finding-driven tasks, drain-deferred open
+   issues with no active task, and **re-attacks** of every attempt step 3 closed non-mergeable. A
+   re-attack is **diagnosed** (`discuss-with-codex`: what
    failed, what's untried), **materially different** from prior attempts on that issue, and **escalates
    the class of approach** when the same obstacle recurs. **AIM-fidelity:** every new task is
    codex-checked against the Success criteria — keep only AIM-aligned work, never drift to an easier
    goal. Create or adopt the issue, then `task-loop add … --issue N`; never duplicate. While the goal is
-   unmet this **always** adds the next task(s); there is no give-up exit.
+   unmet and the run is active this **always** adds the next task(s); there is no give-up exit.
 6. **Dispatch** (skip if draining). `task-loop claim` loop → spawn one `cycle-worker` per claim (`seq`,
    title, issue, branch), record its id, up to a soft capacity.
 7. **Goal check / terminate.** Evaluate the **Success criteria** against the repo (run them; don't infer
-   from "tasks closed"). **Met** → done (drain + stop). **Unmet** → **always continue**: step 5 keeps
-   the board carrying the next diagnosed, AIM-aligned work, so there is **no exhaustion terminal and no
-   idle-on-difficulty** — the only non-goal terminal is **`stop_at`** (Loop B guarantees it fires). If
+   from "tasks closed"). **Met** → done (drain observable in-flight work + stop). **Unmet** →
+   **always continue**: step 5 keeps the board carrying the next diagnosed, AIM-aligned work, so there
+   is **no exhaustion terminal and no
+   idle-on-difficulty** — the only non-goal terminal is **`stop_at`** (Loop B guarantees the drain
+   transition fires). If
    escalations converge on something genuinely beyond the loop's reach, drop a **non-blocking** note for
    async human steering (`directions.md`) and **keep attacking other angles** — never wait, never
    redefine the goal. *(Closure re-verified adversarially for the persistence model —
@@ -185,11 +192,13 @@ with no human-wait**. Single-orchestrator is an *operator deployment declaration
 detection; accidental concurrency degrades to **bounded waste** (a reset may clobber a peer's branch →
 that unit is re-attacked), never unrecoverable. Only **declared multi-orchestrator** operation refuses
 to reclaim a foreign orphan (it surfaces it); `directions.md` never triggers reset. **Termination** is
-independent of all this: at `stop_at` the drain is **bounded** (it waits only for genuinely-pending PRs,
-never for orphans/stuck), so the run always stops within a bounded time.
+independent of all this: at `stop_at` Loop C waits only for positively live in-session workers,
+monitored detached jobs, and PR-present work; opaque no-PR rows follow the reset rule and do not block
+the drain forever.
 
-**Recovery is just the next tick.** PR-present `working` tasks integrate; PR-absent ones are held +
-surfaced. **The run finishes when the Success criteria are met** (goal achieved, step 7) **or** at
+**Recovery is just the next tick.** PR-present `working` tasks integrate; PR-absent ones are reset with
+positive no-live-owner knowledge, surfaced under declared multi-orchestrator ambiguity, or left
+recoverable. **The run finishes when the Success criteria are met** (goal achieved, step 7) **or** at
 `stop_at` (the time bound). An empty board with the goal **unmet** is *never* a stop — step 5
 materializes the next diagnosed, AIM-aligned work. So the loop always advances the goal, finishes it, or
 runs out the clock having genuinely kept trying — it never quietly gives up short of the goal.
@@ -235,7 +244,7 @@ Every task is **paired with a GitHub issue** at creation (open new or adopt exis
 - `references/pr-findings.md` — the study-log + PR contract (the `success/failed/blocked` outcomes).
 - `agents/cycle-worker` — thin, isolated worker: follows `task-loop.md` via a TodoWrite, worktree-isolated, work → PR → report → idle; no merge/DB/issue/plan.
 - `skills/create-cycle` + `assets/task-loop-skeleton.md` — renders the worker's per-project cycle + general rules (simple model; old control-issue/attempt machinery stripped).
-- `skills/run-cycle` (SKILL + `references/orchestrator-loop.md`) — the §8 6-step pass, reset rule, proposal reconcile, Loop A/Loop B stop model.
+- `skills/run-cycle` (SKILL + `references/orchestrator-loop.md`) — the §8 6-step pass, reset rule, proposal reconcile, Loop A/Loop B/Loop C drain model.
 
 **Retirement / cleanup — done:**
 1. Removed old `scripts/` (`control_log.py`/`gh_store.py`) + their tests.
@@ -251,12 +260,18 @@ Every task is **paired with a GitHub issue** at creation (open new or adopt exis
 
 ## 13. Resolved decisions (were open questions)
 
-Most settled in the orchestrator-pass deliberation (`…-orchestrator-pass-conclusion.md`):
+Most settled in the orchestrator-pass deliberation (`…-orchestrator-pass-conclusion.md`), with the
+stop model updated by `2026-06-19-task-loop-loop-c-drain-monitor-design.md`:
 
 - **Pass shape** → a **6-step, directions-first pass** (§8): read state + steering → liveness → merge → reconcile `proposal.md` → materialize tasks → dispatch. Steering is read *before* any irreversible action and is an exogenous trigger.
-- **Reset rule** → reset only on in-session observed death **or** a human `task-loop reset`; cold/foreign ticks surface but never auto-reset opaque `working`-no-PR tasks; `directions.md` never triggers reset (§8). Honest cost: concurrent multi-orchestrator loses auto pre-PR recovery; single/sequential keeps it.
+- **Reset rule** → reset only with positive no-live-owner knowledge: in-session observed death, human
+  `task-loop reset`, or the default single-orchestrator cold-start reclaim; declared multi-orchestrator
+  foreign/opaque tasks are surfaced instead. `directions.md` never triggers reset (§8).
 - **`proposal.md` updates** → the orchestrator is the **sole editor**, and each update is a **reconcile sweep** (recompute from current default + the complete merged-evidence set), never a stale patch — convergent under concurrency, no lock.
-- **Stop model** → fixed-interval **Loop A** self-stops (sole stop authority); **Loop B** is a *non-destructive* early-wake; both jobs are `run_generation`-named; `stop_at` rides in Loop A's prompt — no DB cell, no stored handle, no local file.
+- **Stop model** → fixed-interval **Loop A** runs active ticks; **Loop B** is the non-destructive
+  `stop_at` transition that creates recurring **Loop C**; Loop C drains observable in-flight
+  workers/monitored jobs and PR-present work before cancelling the generation. Jobs are
+  `run_generation`-named; `stop_at` rides in prompts — no DB cell, no stored handle, no local file.
 - **Study-log / findings format** → settled: `docs/task-loop/logs/<seq>_<task>.md` (Outcome + rubric + evidence + findings), committed in the PR; PR body = `Refs #<issue>` + Outcome + pointer (`references/pr-findings.md`).
 - **Issue ↔ task pairing** → paired at creation; PR `Refs` (never `Closes`); orchestrator closes on success, re-links on blocked. Close-vs-keep is its judgment.
 - **Worker scope** → does its one task, isolates in its own worktree, reports findings in the PR; no merge / DB / issue / plan management.

--- a/docs/superpowers/specs/2026-06-15-task-loop-supabase-harness-design.md
+++ b/docs/superpowers/specs/2026-06-15-task-loop-supabase-harness-design.md
@@ -150,8 +150,8 @@ Each tick, **in order** (steering first — it gates everything irreversible):
    close <seq>`, then step 5 materializes the **next attempt against the same issue** on an active tick
    with a materially-different, escalated, AIM-aligned strategy. In drain-only mode, keep the issue open
    and defer materialization to the next active run. (Recreation is safe because it is *diagnosed
-   escalation*, not blind repetition — reversing the old "close-recreate spins → surface `needs-human`"
-   rule — and `stop_at` bounds new starts.) **Pending** → leave for next pass.
+   escalation*, not blind repetition — reversing the prior surface-and-wait rule — and `stop_at` bounds
+   new starts.) **Pending** → leave for next pass.
 4. **Findings → `proposal.md` (reconcile sweep).** The orchestrator is the **sole editor** of
    `proposal.md`. When merged findings change the roadmap, **recompute** the affected sections from
    *current default + the complete set of merged study-logs not yet reflected* (never a stale patch),
@@ -218,7 +218,7 @@ Every task is **paired with a GitHub issue** at creation (open new or adopt exis
 
 ## 10. Task lifecycle
 
-- States: **`open → working → closed`** (monotone). The only backward edge is **`reset` (`working → open`)**, allowed only with positive "no live owner" knowledge — in-session observed death or a human `task-loop reset` (§8 reset rule), never a blind cold/foreign reset.
+- States: **`open → working → closed`** (monotone). The only backward edge is **`reset` (`working → open`)**, allowed only with positive "no live owner" knowledge: in-session observed death, human `task-loop reset`, or default single-orchestrator cold-start reclaim (§8 reset rule). Declared multi-orchestrator foreign/opaque tasks are surfaced instead of blindly reset.
 - **`blocked` is derived**, not a stored state: `open` with an unmet dependency (`claimable` excludes it). A worker that *discovers* it's blocked → the orchestrator **closes the task and creates a new one** carrying the remaining work + the blocking dep.
 - A task **only** leaves `open`/`working` by being `closed`; nothing is silently dropped (a closed task's reason lives in its PR; a blocked task's work lives in its replacement).
 
@@ -276,7 +276,7 @@ stop model updated by `2026-06-19-task-loop-loop-c-drain-monitor-design.md`:
 - **Issue ↔ task pairing** → paired at creation; PR `Refs` (never `Closes`); orchestrator closes on success, re-links on blocked. Close-vs-keep is its judgment.
 - **Worker scope** → does its one task, isolates in its own worktree, reports findings in the PR; no merge / DB / issue / plan management.
 - **Capacity / concurrency** → not prescribed (soft knob). **Branch naming** → implementer's choice (`tl/<seq>` default; stale branch deleted on reset). **Multi-machine launch** → out of harness scope.
-- **Persistence / no-human-wait (this revision)** → the loop **never gives up short of the goal** and **never waits on a human decision** (humans steer *direction* only, async via `directions.md`). Every non-mergeable attempt is **diagnosed** (`discuss-with-codex`) and **re-attacked** with a **materially-different, AIM-aligned** strategy, **escalating the class of approach** when the same obstacle recurs (decided: *diagnosis + escalation teeth*, with *codex as the diagnosis / AIM-fidelity engine*); merge-blocked → behind-base `gh pr update-branch`, else a diagnosed next attempt. The GitHub **issue is the persistent unit identity; a task is one attempt**. Terminal states reduce to **goal-met** or **`stop_at`** — no exhaustion/idle terminal. This **reverses** the old "close-recreate spins → surface `needs-human`" rule: recreation is safe because it is diagnosed escalation (not blind repetition) and `stop_at` bounds it. Worker-side: *don't skip the heavy lifting* — `failed`/`blocked` are last resorts backed by evidence, not escape hatches. Closure re-verified adversarially (`…-2026-06-16-task-loop-persistence-loop-conclusion.md`).
+- **Persistence / no-human-wait (this revision)** → the loop **never gives up short of the goal** and **never waits on a human decision** (humans steer *direction* only, async via `directions.md`). Every non-mergeable attempt is **diagnosed** (`discuss-with-codex`) and **re-attacked** with a **materially-different, AIM-aligned** strategy, **escalating the class of approach** when the same obstacle recurs (decided: *diagnosis + escalation teeth*, with *codex as the diagnosis / AIM-fidelity engine*); merge-blocked → behind-base `gh pr update-branch`, else a diagnosed next attempt. The GitHub **issue is the persistent unit identity; a task is one attempt**. Terminal states reduce to **goal-met** or **`stop_at`** — no exhaustion/idle terminal. This **reverses** the prior surface-and-wait rule: recreation is safe because it is diagnosed escalation (not blind repetition) and `stop_at` bounds it. Worker-side: *don't skip the heavy lifting* — `failed`/`blocked` are last resorts backed by evidence, not escape hatches. Closure re-verified adversarially (`…-2026-06-16-task-loop-persistence-loop-conclusion.md`).
 
 **Still genuinely open:**
 - Which **CI / Action produces the independent review check** and how it's bound to the PR head.

--- a/docs/superpowers/specs/2026-06-16-task-loop-persistence-loop-conclusion.md
+++ b/docs/superpowers/specs/2026-06-16-task-loop-persistence-loop-conclusion.md
@@ -8,18 +8,20 @@ OBJECTIONS)**.
 **Subject files:** `task-loop/skills/run-cycle/references/orchestrator-loop.md`, `…/run-cycle/SKILL.md`,
 `task-loop/references/pr-findings.md`, `task-loop/db/schema.sql`.
 **Supersedes** the human-wait closure addendum in `2026-06-15-task-loop-orchestrator-pass-conclusion.md`.
+**Stop-model supersession:** the bounded-drain termination text below is superseded by
+`2026-06-19-task-loop-loop-c-drain-monitor-design.md`: `stop_at` now bounds new starts, Loop B installs
+recurring Loop C, and Loop C drains observable in-flight work before generation cancellation.
 
 ## Settled position
 
 The loop rests on **two hard, independent guarantees plus one adversarially-enforced bias**:
 
-- **(T) Termination — rests on `stop_at` alone.** Loop A embeds `stop_at`; Loop B is a non-destructive
-  wake; at `stop_at` the tick runs a **bounded drain** — it waits only for **genuinely-pending** PRs
-  (those within the **CI bound**: a configurable max age of the PR head commit for required checks to
-  post/finish, default ~30 min), **never** for opaque `working`-no-PR orphans or stuck tasks — then
-  cancels its schedules and stops. The run always terminates within a bounded time of `stop_at` and
-  never hangs. Crash/restart **self-heals**: a single-orchestrator cold start reclaims every opaque
-  orphan (reset case (c)), so recovery never waits on a human.
+- **(T) Termination / drain — updated by the 2026-06-19 Loop C design.** The original bounded-drain text
+  below is historical. Current semantics: `stop_at` stops new starts, Loop B installs recurring Loop C,
+  and Loop C waits only for positively live in-session workers/monitored detached jobs and PR-present
+  work before cancelling the generation. Opaque `working`-no-PR rows follow the reset rule and do not
+  block the drain forever. Crash/restart **self-heals**: a single-orchestrator cold start reclaims every
+  opaque orphan (reset case (c)), so recovery never waits on a human.
 - **(P) Progress — rests on a never-empty board.** While the goal is unmet, step 5 always materializes
   the next work (planned-stage decomposition, blockers, and a **diagnosed re-attack** for every
   non-mergeable attempt). Step 7: unmet ⇒ always continue.
@@ -40,7 +42,9 @@ Terminal states reduce to **goal-met** or **`stop_at`**. Humans steer *direction
 - **No-give-up replaces the old surface-and-idle / `needs-human` branches**, *reversing* the prior
   "close-recreate spins → surface `needs-human`" rule: recreation is safe **because** it is diagnosed
   escalation (not blind repetition) and `stop_at` bounds it.
-- **Drain is bounded** (genuinely-pending PRs only); orphans/stuck never block termination.
+- **Drain model updated:** the historical bounded PR-only drain is superseded by Loop C, which drains
+  observable live workers/monitored jobs and PR-present work while still never hanging on opaque no-PR
+  rows.
 - **Reset rule gains case (c)** — single-orchestrator cold-start reclaim — so crash/restart self-heals
   without a human. Single-orchestrator is an **operator deployment declaration**, not runtime detection.
 - **Anti-laziness enforced at three points:** materialize (the riskiest/heavy work must be *on the
@@ -50,9 +54,10 @@ Terminal states reduce to **goal-met** or **`stop_at`**. Humans steer *direction
 ## Strongest objections and how each resolved
 
 1. **`stop_at` can't force termination — an opaque `working`-no-PR orphan blocks the drain forever, and
-   that waits on a human.** *Conceded — a real bug introduced in the rewrite.* Fixed with the **bounded
-   drain** (genuinely-pending PRs only; orphans/stuck never block) + **reset case (c)** (single-orch
-   cold-start reclaim). Termination now rests on `stop_at` unconditionally; crash/restart self-heals.
+   that waits on a human.** *Conceded — a real bug introduced in the rewrite.* Current fix: Loop C waits
+   only for positively live in-session workers/monitored jobs and PR-present work; opaque no-PR rows
+   follow the reset rule and never block the drain forever. Crash/restart self-heals through reset case
+   (c) in single-orchestrator mode.
 2. **Duplicate attempts aren't structurally prevented (materialization is lock-free).** *Conceded as
    bounded, non-fatal, scoped.* Possible only under *declared* multi-orchestrator; the issue is the unit
    identity and at most one attempt merges; the default single-orchestrator mode incurs none. Kept the

--- a/docs/superpowers/specs/2026-06-16-task-loop-persistence-loop-conclusion.md
+++ b/docs/superpowers/specs/2026-06-16-task-loop-persistence-loop-conclusion.md
@@ -39,9 +39,9 @@ Terminal states reduce to **goal-met** or **`stop_at`**. Humans steer *direction
 - The GitHub **issue is the persistent unit-of-work identity; a task is one *attempt***. Attempt history
   is derived from the issue's PR set — **no** DB attempt-counter / strategy-class column (semantic
   novelty can't be a schema field without brittleness).
-- **No-give-up replaces the old surface-and-idle / `needs-human` branches**, *reversing* the prior
-  "close-recreate spins → surface `needs-human`" rule: recreation is safe **because** it is diagnosed
-  escalation (not blind repetition) and `stop_at` bounds it.
+- **No-give-up replaces the old surface-and-idle branches**, *reversing* the prior surface-and-wait
+  rule: recreation is safe **because** it is diagnosed escalation (not blind repetition) and `stop_at`
+  bounds new starts.
 - **Drain model updated:** the historical bounded PR-only drain is superseded by Loop C, which drains
   observable live workers/monitored jobs and PR-present work while still never hanging on opaque no-PR
   rows.

--- a/docs/superpowers/specs/2026-06-19-task-loop-loop-c-drain-monitor-conclusion.md
+++ b/docs/superpowers/specs/2026-06-19-task-loop-loop-c-drain-monitor-conclusion.md
@@ -1,0 +1,16 @@
+# Task-loop Loop C Drain Monitor Pressure-Test Conclusion
+
+The initial Loop C design failed pressure testing until these points were tightened:
+
+- Loop A must not cancel the generation at `stop_at` before Loop B installs Loop C.
+- The "finish long work" guarantee must be scoped to observable in-session workers, monitored detached
+  jobs, and PR-present tasks; hidden opaque no-PR rows cannot be treated as live.
+- Drain-only classification must leave failed/blocked/stuck attempts recoverable without starting new
+  attempts after `stop_at`.
+- Stale generation checks must use schedule names because there is no DB cell, stored handle, or local
+  runtime file.
+- Codex docs must describe manual drain-only passes only, not unattended scheduling.
+
+The implemented wording addresses those objections by making Loop B the stop transition, making Loop C
+the post-`stop_at` cancellation authority, deferring drain-time re-attacks to the next active run, and
+updating the README plus authoritative design spec alongside the skill files.

--- a/docs/superpowers/specs/2026-06-19-task-loop-loop-c-drain-monitor-conclusion.md
+++ b/docs/superpowers/specs/2026-06-19-task-loop-loop-c-drain-monitor-conclusion.md
@@ -14,3 +14,9 @@ The initial Loop C design failed pressure testing until these points were tighte
 The implemented wording addresses those objections by making Loop B the stop transition, making Loop C
 the post-`stop_at` cancellation authority, deferring drain-time re-attacks to the next active run, and
 updating the README plus authoritative design spec alongside the skill files.
+
+Follow-up PR review found one more stale contradiction: older conclusion text still described a
+pre-revision reset/retry model. The PR now updates those historical summaries to the current model:
+default single-orchestrator cold-start reclaim is valid, declared multi-orchestrator foreign orphans
+are surfaced, and drain-deferred failed/blocked attempts are recoverable through the open issue and PR
+history on the next active run.

--- a/docs/superpowers/specs/2026-06-19-task-loop-loop-c-drain-monitor-design.md
+++ b/docs/superpowers/specs/2026-06-19-task-loop-loop-c-drain-monitor-design.md
@@ -1,0 +1,34 @@
+# Task-loop Loop C Drain Monitor Design
+
+## Decision
+
+Issue #169 changes Claude `run-cycle` stop handling from a one-shot bounded drain to a post-`stop_at`
+drain monitor.
+
+Initial `/run-cycle` still creates only:
+
+- **Loop A**: fixed-interval active pass.
+- **Loop B**: one-shot `stop_at` transition.
+
+When Loop B fires, it validates its generation from schedule names, creates recurring **Loop C**, and
+runs or wakes one drain tick. Loop B never dispatches, materializes re-attacks, or force-stops live
+work.
+
+Loop C runs the drain subset only: steering, liveness, PR merge/classification, and proposal
+reconciliation. It skips materialization and dispatch. It cancels the generation only when no
+positively live in-session worker or monitored detached job remains and no PR-present `working` task
+still needs merge/classification.
+
+## Boundaries
+
+`stop_at` means "no new starts," not "abandon work already launched." Loop C waits only for observable
+live work or PR-present work. Opaque `working`-no-PR rows without positive live ownership follow the
+existing reset rule and never block the drain forever.
+
+Codex support remains manual. A Codex post-`stop_at` pass can follow the same drain-only subset, but
+Codex does not schedule unattended Loop A/B/C jobs yet.
+
+## Versioning
+
+Both task-loop plugin manifests move from `0.16.0` to `0.17.0` so Claude and Codex refresh cached
+skill docs.

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development on a hosted Supabase task board: the task-loop CLI, setup/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "skills": "./claude-skills/"
 }

--- a/task-loop/.codex-plugin/plugin.json
+++ b/task-loop/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-loop",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Task-loop setup, preflight, specify-aims, create-cycle scaffolding, and manual run-cycle support for Codex.",
   "author": {
     "name": "Steven",

--- a/task-loop/README.md
+++ b/task-loop/README.md
@@ -24,7 +24,7 @@ Claude Code supports the full task-loop workflow today:
 setup           → Supabase project + schema, creds, repo init, Agent Teams, required skills
 a. specify-aims → docs/task-loop/proposal.md   (aims + plan + roadmap; collaborative + codex)
 b. create-cycle → docs/task-loop/task-loop.md  (the worker's per-project cycle + parameters)
-c. run-cycle    → orchestrator: fixed-interval Loop A + a non-destructive Loop B stop nudge
+c. run-cycle    → orchestrator: fixed-interval Loop A + Loop B stop transition → Loop C drain monitor
                   cycle-worker (agent): executes one task's cycle in its own worktree
 ```
 
@@ -35,7 +35,9 @@ c. run-cycle    → orchestrator: fixed-interval Loop A + a non-destructive Loop
    write `proposal.md`: Specific Aims & Goal (human-gated) + Implementation Plan + Living Roadmap.
 3. **`create-cycle`** — render `docs/task-loop/task-loop.md` (the worker's tailored cycle + general
    rules + parameters) and scaffold `directions.md` + `logs/`.
-4. **`run-cycle`** — the orchestrator (above); the `cycle-worker` agent does each task.
+4. **`run-cycle`** — the orchestrator (above); the `cycle-worker` agent does each task. In Claude,
+   `stop_at` stops new starts and Loop B installs Loop C to monitor observable in-flight workers/PRs
+   until the drain is complete.
 
 Codex support is rolling out in phases. Codex currently supports setup/preflight,
 `specify-aims`, `create-cycle`, syncing the `task_loop_cycle_worker` custom agent, and a conservative

--- a/task-loop/claude-skills/run-cycle/SKILL.md
+++ b/task-loop/claude-skills/run-cycle/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-cycle
 description: This skill should be used when the user asks to "run cycle", "run the task loop", "start the orchestrator", "drive the autonomous loop", or to begin autonomous, orchestrated execution of a task-loop project. It runs the orchestrator under a fixed-interval loop; each tick honors human steering, merges ready PRs, diagnoses and re-attacks any failed/blocked/stuck attempt with a materially-different AIM-aligned strategy (it never gives up short of the goal or the time bound), reconciles the roadmap, and dispatches the next work. Idempotent — every tick re-derives state from the task DB + GitHub + directions.md.
-version: 0.3.0
+version: 0.4.0
 ---
 
 # Run Cycle
@@ -23,7 +23,8 @@ failed / blocked / stuck attempt is **diagnosed** (`dev-skills:discuss-with-code
 with a materially-different, AIM-aligned strategy — escalating the approach when the same obstacle
 recurs, never idling on difficulty, never drifting to an easier goal. The GitHub **issue is the
 persistent unit-of-work identity**; each task is one **attempt** at it. Terminal states are
-**goal-met** or **`stop_at`** — nothing else.
+**goal-met** or **`stop_at`** — nothing else. After `stop_at`, the run enters a drain-only monitor:
+no new starts, but observable in-flight workers and landed PRs are processed before shutdown.
 
 The per-tick algorithm itself lives in **`references/orchestrator-loop.md`**; each Loop A tick **reads
 it and works it as a `TodoWrite`** (see *The pass*).
@@ -42,33 +43,40 @@ confirm the scaffolding is present: `docs/task-loop/{proposal.md, task-loop.md, 
 *Recommended:* branch protection requiring CI + an independent review check, with the orchestrator the
 only identity allowed to merge.
 
-## Control plane — fixed-interval Loop A, non-destructive Loop B
+## Control plane — Loop A, Loop B transition, Loop C drain monitor
 
-`run-cycle` sets up two scheduled jobs, both named with a fresh **`run_generation`** so a stale job can
-never touch a newer run:
+`run-cycle` initially sets up two scheduled jobs, both named with a fresh **`run_generation`** so a
+stale job can never touch a newer run. Loop C is created later by the stop transition, not at startup:
 
 - **Loop A** — a **fixed-interval** loop (default 15 min) whose prompt tells each tick to **read
   `references/orchestrator-loop.md` and complete its pass as a `TodoWrite`**. `stop_at` and
   `run_generation` are **embedded in the prompt**, so each tick sees them with zero stored state. Named
-  `task-loop-<project>-<gen>-A`.
-- **Loop B** — a **one-time** job at `stop_at` that **wakes Loop A to run a tick promptly**. It is
-  **non-destructive** — it never force-stops anything — so a stale fire is harmless: the woken tick
-  re-checks the *current* `stop_at` and continues if it was extended. Named `…-<gen>-B`.
+  `task-loop-<project>-<gen>-A`. After `stop_at`, Loop A must run drain-only and must not cancel the
+  generation before the Loop B/Loop C transition exists.
+- **Loop B** — a **one-time** job at `stop_at` that is the stop transition. It validates its generation
+  by schedule names (if a newer `task-loop-<project>-<newer-gen>-*` exists, it no-ops/cancels itself),
+  then creates or ensures **Loop C**. It may run/wake one drain tick, but it never dispatches new work,
+  never materializes re-attacks, and never force-stops live work. Named `...-<gen>-B`.
+- **Loop C** — a **recurring drain monitor** (default ~30 min) created by Loop B and named
+  `...-<gen>-C`. Each tick runs the drain subset only: steering, liveness, PR merge/classification,
+  and proposal reconciliation. It skips materialize re-attacks and dispatch.
 
-**Stopping is Loop A's own decision:** a tick stops the run (cancels its own `-A`/`-B` schedules) once
-**either** the proposal's **Success criteria are met** (goal achieved — the natural finish) **or**
-`now ≥ stop_at` (the time bound), after a **bounded drain** of genuinely-pending PRs (opaque orphans /
-stuck tasks never block it — see the reference). To change the bound, re-invoke `/run-cycle` — it mints
-a new generation, best-effort cancels every `task-loop-<project>-*` job, and recreates both. No DB cell,
-no stored handle, no local file.
+**Stopping after `stop_at` is Loop C's decision:** `stop_at` means "stop starting new work," not
+"abandon work already launched." Loop C cancels the generation's `-A`/`-B`/`-C` schedules and stops
+only when no positively live in-session worker or monitored detached job remains for this generation
+and no PR-present `working` task still needs merge/classification. Opaque `working`-no-PR rows without
+positive live ownership follow the reset rule in the reference and never block Loop C forever. To change
+the bound, re-invoke `/run-cycle` — it mints a new generation, best-effort cancels every
+`task-loop-<project>-*` job, and recreates Loop A + Loop B. No DB cell, no stored handle, no local file.
 
 ## Setup (on invocation)
 
 1. Confirm prerequisites (above). 2. Ask the run duration (default 24h) → compute `stop_at` (UTC); mint
 `run_generation` (`date -u +%s`). 3. Best-effort cancel stale `task-loop-<project>-*` jobs. 4. Ensure
 the cycle-worker **team** exists (recreate on a fresh session — teammates are ephemeral). 5. Create
-Loop A + Loop B; Loop A's prompt carries `stop_at` + `run_generation` and the instruction to **read
-`references/orchestrator-loop.md` and work it as a `TodoWrite` each tick**. Loop A then runs unattended.
+Loop A + Loop B only; Loop B's prompt creates Loop C at `stop_at`. Loop A's prompt carries `stop_at` +
+`run_generation` and the instruction to **read `references/orchestrator-loop.md` and work it as a
+`TodoWrite` each tick**. Loop A then runs unattended.
 
 ## The pass (each Loop A tick)
 
@@ -76,9 +84,10 @@ Loop A + Loop B; Loop A's prompt carries `stop_at` + `run_generation` and the in
 completed in order, every tick. Re-read the reference each tick (it is the single source of the
 algorithm and may have changed); never rely on a baked-in copy. In one line the pass is:
 
-> read state + stop-check → honor steering → liveness → merge / classify (read the **Outcome**; never
-> merge broken work) → reconcile `proposal.md` → materialize the next work (incl. **diagnosed
-> re-attacks**, escalating recurring obstacles, AIM-fidelity-checked) → dispatch → goal-check / terminate.
+> read state + phase-check → honor steering → liveness → merge / classify (read the **Outcome**; never
+> merge broken work) → reconcile `proposal.md` → materialize the next work while active (incl.
+> **diagnosed re-attacks**, escalating recurring obstacles, AIM-fidelity-checked) → dispatch while
+> active → goal-check / drain / terminate.
 
 The reference also holds the reset rule, proposal-reconcile detail, stop model, recovery, and
 multi-orchestrator notes.
@@ -89,6 +98,9 @@ multi-orchestrator notes.
 - **`task-loop claim` is the only dispatch lock** — no lease, no other guard.
 - **Never give up short of the goal** — every non-mergeable attempt is diagnosed and re-attacked with a
   materially-different, escalated, AIM-aligned strategy; the run ends only at **goal-met** or **`stop_at`**.
+- **After `stop_at`, no new starts** — Loop B installs Loop C; Loop C drains observable in-flight
+  workers/monitored jobs and PR-present work, then cancels the generation. It does not dispatch or
+  materialize re-attacks.
 - **Reset only with positive "no live owner" knowledge** — in-session observed death, a human
   `task-loop reset <seq>`, or a **single-orchestrator cold start** reclaiming opaque orphans (the
   default mode — prior-session workers die with their session, so none can be live). Only *declared*

--- a/task-loop/claude-skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/claude-skills/run-cycle/references/orchestrator-loop.md
@@ -107,7 +107,7 @@ Read the study-log **Outcome** *before* deciding — broken work is never merged
   obstacle has recurred. In drain-only mode, defer materialization to the next active run rather than
   starting a new attempt after `stop_at`.
   (Recreation is safe **because** it is diagnosed escalation, never blind repetition — and `stop_at`
-  bounds it; this reverses the old "close-recreate spins, surface `needs-human`" rule.)
+  bounds it; this reverses the prior surface-and-wait rule.)
 - **Genuinely pending** (required checks still running within the **CI bound** — a *configurable max
   age of the PR head commit* for required checks to post and finish, default ~30 min; past it, or a
   required context that never posts a check-run, the PR is **stuck**, above) → leave for next tick.
@@ -267,7 +267,7 @@ study-log **Outcome** is present and acceptable. Merge is **head-SHA-atomic**:
 gained commits between classification and merge is **rejected**, not merged stale. A **transient**
 rejection (head moved / gate race) → re-evaluate next tick; a **deterministic** rejection → re-attack
 via §3/§5 (**behind base** → `gh pr update-branch`; **conflict / other** → diagnose + a
-materially-different next attempt), **never an endless identical retry and never a `needs-human` wait**.
+materially-different next attempt), **never an endless identical retry and never a human-wait branch**.
 The orchestrator is the **sole merger** and makes the task-specific call ("is this outcome mergeable?")
 as it reads the PR. **Branch protection** (required
 CI + a review check posted by a CI workflow, **never** the worker) is the structural backstop no merge

--- a/task-loop/claude-skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/claude-skills/run-cycle/references/orchestrator-loop.md
@@ -26,29 +26,42 @@ AIM-aligned strategy (§3/§5/§7), never surrendered, idled, or redefined into 
 ## Control plane (set up once per invocation)
 
 `/run-cycle` mints a fresh **`run_generation`** (`date -u +%s`), best-effort cancels stale
-`task-loop-<project>-*` scheduled jobs, ensures the cycle-worker **team** exists, then creates:
+`task-loop-<project>-*` scheduled jobs, ensures the cycle-worker **team** exists, then creates Loop A
+and Loop B. Loop C is created only when the stop transition fires:
 
 - **Loop A** — a fixed-interval loop (default 15 min, `task-loop-<project>-<gen>-A`) running the pass
-  below, with `stop_at` + `run_generation` embedded in its prompt.
-- **Loop B** — a one-time job at `stop_at` (`…-<gen>-B`) that **wakes Loop A to run a tick promptly**;
-  **non-destructive** (a stale fire just makes Loop A run a tick that re-checks the current `stop_at`).
+  below, with `stop_at` + `run_generation` embedded in its prompt. Before `stop_at`, it runs the full
+  pass. At/after `stop_at`, it runs drain-only and must not cancel the generation before the Loop B/C
+  transition exists.
+- **Loop B** — a one-time job at `stop_at` (`...-<gen>-B`) that is the **stop transition**. It validates
+  its generation from schedule names: if a newer `task-loop-<project>-<newer-gen>-*` job exists, it
+  no-ops/cancels itself. Otherwise it creates or ensures Loop C and may run/wake one drain tick. It
+  never dispatches, never materializes re-attacks, and never force-stops live work.
+- **Loop C** — a recurring drain monitor (default ~30 min, `...-<gen>-C`) created by Loop B. It runs the
+  drain subset until no positively live in-session worker/monitored detached job remains for this
+  generation and no PR-present `working` task still needs merge/classification; then it cancels
+  `-A`/`-B`/`-C` for the generation and stops.
 
-Loop A is the **sole stop authority**: a tick stops the run (cancels its own `-A`/`-B` jobs) once
-**either** the proposal's **Success criteria are met** (goal achieved — the natural finish, step 7)
-**or** `now ≥ stop_at` (the time bound) — then it runs a **bounded drain** (merge genuinely-pending PRs;
-opaque `working`-no-PR orphans and stuck tasks never block it) and stops. Because every job is
-generation-named, a leftover job from an earlier run can only touch its own generation — never a newer
-run's Loop A.
+Because every job is generation-named, a leftover job from an earlier run can only touch its own
+generation. Generation checks use schedule names only — no DB cell, stored handle, or local runtime
+file.
 
 ## The pass
 
-### 0. Read state + stop check
-`task-loop status`; list open PRs/issues; read `directions.md`. If `now ≥ stop_at`, enter **draining**:
-skip **materialize re-attacks (step 5)** and **dispatch (step 6)** — no new work — but still run steps
-1–4 (steering, liveness, **merge** mergeable in-flight PRs, reconcile). Drain is **bounded**: wait only
-for **genuinely-pending** PRs (still within the CI bound), **never** for opaque `working`-no-PR orphans
-or stuck tasks. Once no genuinely-pending PR remains, cancel the `-A`/`-B` jobs and stop — any leftover
-`working` rows are recoverable state for the next run, never a reason to keep ticking.
+### 0. Read state + phase check
+`task-loop status`; list open PRs/issues; read `directions.md`. If `now ≥ stop_at`, enter
+**drain-only**: skip **materialize re-attacks (step 5)** and **dispatch (step 6)** — no new starts —
+but still run steps 1–4 (steering, liveness, **merge/classify** landed in-flight PRs, reconcile).
+
+Loop B is the normal creator of Loop C. If a Loop A tick happens after `stop_at` before Loop B has
+installed Loop C, it must not cancel the generation; it either leaves the generation alive for Loop B or
+best-effort ensures Loop C if Loop B is clearly absent/stale. Loop C self-closes only after:
+
+- no positively live in-session worker or monitored detached job remains for this generation; and
+- no PR-present `working` task still needs merge/classification.
+
+Opaque `working`-no-PR tasks without positive live ownership follow the Reset rule. They do not block
+Loop C forever; they are reset, surfaced, or left as recoverable state according to that rule.
 
 ### 1. Honor steering (first, before any irreversible action)
 `directions.md` is highest-priority and free-form; interpret it and apply its constraints **this tick,
@@ -77,9 +90,10 @@ Read the study-log **Outcome** *before* deciding — broken work is never merged
   bound head; if the head moved or the merge is rejected for a **transient** reason → re-evaluate next
   tick, defeating a green→red flap). Then `gh issue close <issue>`; `task-loop close <seq>` (its
   **Findings** feed step 5); **reap the idle teammate** (`TaskStop` the worker you spawned for that seq).
-- **`blocked`** (Outcome: blocked) → `task-loop close <seq>`; step 5 recreates the remaining work as a
-  `--dep` task, the issue stays **open**, re-linked there → reap. (Merge the partial PR only if it is
-  independently valuable — your call; otherwise `gh pr close <N>` as the record.)
+- **`blocked`** (Outcome: blocked) → `task-loop close <seq>`; on an active tick, step 5 recreates the
+  remaining work as a `--dep` task. In drain-only mode, defer recreation to the next active run. The
+  issue stays **open**, re-linked there → reap. (Merge the partial PR only if it is independently
+  valuable — your call; otherwise `gh pr close <N>` as the record.)
 - **`success` but behind base only** (green, no conflict, just behind a required up-to-date base) → run
   **`gh pr update-branch <N>`** — a *mechanical base-sync the orchestrator owns* (not task code) → CI
   re-runs → merge next tick. The cheapest re-attack: no new task.
@@ -88,8 +102,10 @@ Read the study-log **Outcome** *before* deciding — broken work is never merged
   rejection, or is pending **past the bound** / never posts) → **do not idle, do not surface-and-wait,
   do not merge broken work.** **Diagnose** the failure (study log + CI logs + the diff) and re-attack:
   close this attempt — `gh pr close <N>` (it stays as the record) + `task-loop close <seq>` — and let
-  **step 5 materialize the *next* attempt against the same issue** with a **materially-different,
-  AIM-aligned** strategy, *escalating the class of approach* if the same obstacle has recurred.
+  **step 5 materialize the *next* attempt against the same issue** on the next active tick with a
+  **materially-different, AIM-aligned** strategy, *escalating the class of approach* if the same
+  obstacle has recurred. In drain-only mode, defer materialization to the next active run rather than
+  starting a new attempt after `stop_at`.
   (Recreation is safe **because** it is diagnosed escalation, never blind repetition — and `stop_at`
   bounds it; this reverses the old "close-recreate spins, surface `needs-human`" rule.)
 - **Genuinely pending** (required checks still running within the **CI bound** — a *configurable max
@@ -98,8 +114,8 @@ Read the study-log **Outcome** *before* deciding — broken work is never merged
 - **No PR** → liveness applies (§Reset); never launder a merge done by someone else (*Merge gate*).
 
 Every task funnels `working → closed` (merged on success, else closed-as-attempt with its **work
-re-materialized** in step 5) — nothing is silently dropped, and **no difficulty is ever abandoned short
-of the goal.**
+re-materialized** in step 5 on an active tick or deferred from drain-only to the next active run) —
+nothing is silently dropped, and **no difficulty is ever abandoned short of the goal.**
 
 ### 4. Findings → proposal (reconcile sweep, NOT a patch)
 If merged findings change the roadmap / plan / milestones, **recompute** the affected `proposal.md`
@@ -111,6 +127,10 @@ reflected in it)** — never one orchestrator's stale local patch. Edit on a bra
 common case). This makes the update convergent even under concurrent orchestrators — no lock.
 
 ### 5. Materialize tasks (idempotent) — the goal-driver that never gives up
+Skip this step entirely in drain-only mode; `stop_at` forbids new starts. Drain-deferred blocked or
+failed attempts stay recoverable through the open GitHub issue and the PR attempt history, and the next
+active run materializes the next attempt here.
+
 This step keeps the board carrying the **next real work toward the Success criteria**; while the goal
 is unmet it is **never** allowed to go empty. From the reconciled `proposal.md` + merged findings +
 `directions.md` + the **attempts §3 just closed**, ensure a task exists for each unit that should:
@@ -130,6 +150,8 @@ is unmet it is **never** allowed to go empty. From the reconciled `proposal.md` 
   — **never re-file the same wall**. (Because the issue is the stable identity and its PR history is the
   attempt ledger, a re-attack is never mistaken for a fresh unit — the escalation always has the full
   record to act on.)
+- **drain-deferred re-attacks** — open task-loop issues whose latest task/PR attempt closed
+  non-successfully after `stop_at` and that currently have no open/working task.
 - **direction-instructed** and **finding-unlocked** tasks driving the goal.
 
 **AIM-fidelity (the other half of the constraint).** Every task this step creates must serve the
@@ -159,8 +181,9 @@ Stop when `claim` returns `none` or you reach capacity (the rest win a seat on a
 Evaluate the proposal's **Success criteria** against the repo — **run them** (commands/tests/artifacts,
 `superpowers:verification-before-completion`); don't infer from "tasks closed".
 
-- **Criteria met** → **done**: dispatch nothing, let in-flight PRs drain, cancel the `-A`/`-B` jobs,
-  stop. (The natural finish.)
+- **Criteria met** → **done**: dispatch nothing. If observable in-flight workers or PR-present working
+  tasks remain, enter the same drain-only behavior and stop when the Loop C self-close condition holds;
+  otherwise cancel the generation's jobs and stop. (The natural finish.)
 - **Criteria unmet** → **always continue.** §5 guarantees the board carries the next diagnosed,
   AIM-aligned work (re-attacks, decomposition, blockers), so the loop keeps driving. **There is no
   exhaustion terminal and no idle-on-difficulty** — a non-mergeable attempt is diagnosed and
@@ -174,24 +197,31 @@ via `directions.md` *asynchronously* — and **keep attacking other angles towar
 waiting for a reply; never redefine the goal into something easier. Humans steer *direction*; the loop
 never stops *trying*.
 
-**Drain / `stop_at`:** at `now ≥ stop_at` the tick stops dispatching and re-attacking, lets
-**genuinely-pending** in-flight PRs merge (a **bounded** wait, capped by the CI bound), then cancels the
-schedules and stops. **Opaque `working`-no-PR orphans and stuck tasks never block termination** — they
-are left as recoverable state for the next run (PR-present → mergeable later; PR-absent orphan →
-reclaimed by the next single-orchestrator cold start (§Reset case (c)) or a human reset). `stop_at` is
-the **sole** non-goal terminal; Loop B guarantees it fires; so the run **always** terminates within a
-bounded time of `stop_at`.
+**Drain / `stop_at`:** at `now ≥ stop_at`, the run stops dispatching and re-attacking. Loop B installs
+Loop C, and Loop C keeps the same live session around to process observable in-flight work:
 
-This is the closure guarantee, reframed for persistence. **Termination** rests on `stop_at` alone
-(Loop B + the §0 stop check make it always fire, and the drain is **bounded** — it waits only for
-genuinely-pending PRs, never for orphans/stuck — so `stop_at` forces a stop within bounded time, never
-hanging on an un-resettable task). **Goal progress** rests on §5 always materializing the next
-diagnosed, AIM-aligned work while the goal is unmet. These two are **independent and hard**. **Non-spin**
-is not a hard invariant but an **adversarially-enforced bias**: each re-attack reads the unit's full
-(derivable) attempt history and is pushed by `discuss-with-codex` to be materially different and escalate
-— so the budget is spent exploring, not blindly repeating, with `stop_at` as the backstop if a given
-round's novelty is imperfect. The loop therefore **advances the goal, finishes it, or runs out the clock
-having genuinely kept trying — it never hangs, never quietly gives up, and never drifts off the AIM.**
+- keep checking positively live workers you spawned this session and any monitored detached jobs they
+  reported;
+- merge/classify PR-present `working` tasks as they land;
+- run proposal reconciliation for merged findings;
+- skip materialization and dispatch.
+
+Loop C self-closes when no positively live in-flight worker/monitored job remains and no PR-present
+`working` task needs merge/classification. Opaque `working`-no-PR rows without positive live ownership
+never become hidden blockers: apply the Reset rule if you have positive no-live-owner knowledge, surface
+them under declared multi-orchestrator ambiguity, or leave them as recoverable state for the next run.
+If the session dies during Loop C, recovery is unchanged: the next `/run-cycle` re-derives from DB +
+GitHub and reclaims/surfaces according to the Reset rule.
+
+This is the closure guarantee, reframed for live-through workers. **`stop_at` bounds new starts, not
+post-stop observation of work already launched.** **Goal progress** rests on §5 always materializing the
+next diagnosed, AIM-aligned work while active and the goal is unmet. **Drain progress** rests on positive
+liveness and PR artifacts: Loop C waits only for work it can observe as live or PR-present, never for
+opaque no-PR rows with no live owner evidence. **Non-spin** is not a hard invariant but an
+**adversarially-enforced bias**: each re-attack reads the unit's full (derivable) attempt history and is
+pushed by `discuss-with-codex` to be materially different and escalate — so the active-run budget is
+spent exploring, not blindly repeating. The loop therefore **advances the goal, finishes it, or reaches
+`stop_at` having genuinely kept trying, then drains observable in-flight work without starting more.**
 
 ## Reset rule (the central invariant)
 

--- a/task-loop/codex-skills/run-cycle/SKILL.md
+++ b/task-loop/codex-skills/run-cycle/SKILL.md
@@ -9,6 +9,11 @@ Run one conservative Codex task-loop controller pass. The main Codex thread is
 the controller; do not create a separate orchestrator agent. Full unattended
 scheduling remains pending.
 
+Codex does not create unattended Loop A/B/C schedules today. When the user runs
+this skill for a post-`stop_at` drain pass, apply the same drain-only semantics
+as Claude Loop C manually: process steering, liveness, PR classification/merge,
+and proposal reconciliation; do not materialize re-attacks or dispatch new work.
+
 ## Preconditions
 
 - `task-loop:setup`, `task-loop:specify-aims`, and `task-loop:create-cycle`
@@ -40,6 +45,8 @@ Read these before taking controller actions:
 - A GitHub issue is the durable unit identity; a task is one attempt.
 - A current-attempt PR must match both `Refs #<issue>` and the task-specific
   study-log path `docs/task-loop/logs/<NNN>_...md`.
+- After `stop_at` or in an explicitly drain-only pass, no new starts: do not
+  claim, dispatch, or materialize re-attacks.
 
 ## Dispatch Gate
 
@@ -83,6 +90,7 @@ ambiguous, do not reset; leave the task `working` and report
    `uv run --script task-loop/cli/task-loop ...`; from an installed plugin use
    `uv run --script <plugin-root>/cli/task-loop ...`.
 2. Read the required references and current project docs.
-3. Work `references/orchestrator-loop.md` step by step.
+3. Work `references/orchestrator-loop.md` step by step. If this is a
+   post-`stop_at` drain pass, use its drain-only path and skip claims.
 4. Stop after one pass and report actions taken, skipped claims, dispatches,
    ambiguous working tasks, and remaining claimable work.

--- a/task-loop/codex-skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/codex-skills/run-cycle/references/orchestrator-loop.md
@@ -1,7 +1,8 @@
 # Codex Orchestrator Loop
 
 This is a manual single-pass controller algorithm for Codex. Re-run the skill
-for another pass. Do not schedule unattended Loop A/Loop B jobs from Codex yet.
+for another pass. Do not schedule unattended Loop A/Loop B/Loop C jobs from
+Codex yet.
 
 ## State Sources
 
@@ -10,6 +11,14 @@ for another pass. Do not schedule unattended Loop A/Loop B jobs from Codex yet.
 - GitHub through `gh` issues and PRs.
 - Git-tracked project files under `docs/task-loop/`.
 - Worker handoff messages observed in this Codex session.
+
+## Drain-Only Mode
+
+If invoked after `stop_at` or explicitly as a drain pass, model Claude Loop C
+manually: run steering, liveness, PR classification/merge, and proposal
+reconciliation, then report whether another manual drain pass is needed. Skip
+materialization and dispatch. Codex does not define unattended Loop A/B/C
+scheduling in this skill.
 
 ## 0. Read State
 
@@ -39,10 +48,13 @@ For each `working` task:
 - **PR with `Outcome: success` and clean gates:** merge using GitHub's current
   head-SHA protection, close the GitHub issue, then `task-loop close <seq>`.
 - **PR with `Outcome: blocked`:** close the attempt task, keep the issue open,
-  and materialize the blocker/remnant as a new task linked by dependency.
+  and materialize the blocker/remnant as a new task linked by dependency. In
+  drain-only mode, defer materialization to the next active run.
 - **PR with `Outcome: failed`, red gates, conflict, or stale pending state:**
   close the attempt task, read the attempt history for that issue, and
-  materialize a materially different re-attack against the same issue.
+  materialize a materially different re-attack against the same issue. In
+  drain-only mode, keep the issue open and defer the re-attack to the next
+  active run.
 - **Working with no PR:** reset only with positive no-live-worker evidence:
   observed in-session refusal/failure before task work or explicit human CLI
   reset. A Codex cold-start declaration is not proof that prior workers are
@@ -60,12 +72,16 @@ state plus all merged study logs not yet reflected. The controller is the only
 
 ## 4. Materialize Tasks
 
+Skip this step in drain-only mode.
+
 Ensure the board has the next goal-driving work, but add only tasks with
 durable unit identity:
 
 - proposal hypothesis IDs such as `H1.1`;
 - proposal milestone IDs such as `M1`;
 - issue-backed re-attacks from classified attempts;
+- drain-deferred open issues whose latest task/PR attempt closed
+  non-successfully after `stop_at` and have no open/working task;
 - direction-instructed work that names an explicit issue or durable unit marker.
 
 Before creating an issue, search for an existing issue carrying the same unit
@@ -76,6 +92,8 @@ Do not materialize free-form Findings text into tasks unless it already has a
 durable marker or is part of a diagnosed re-attack/blocker flow.
 
 ## 5. Dispatch Claimable Work
+
+Skip this step in drain-only mode.
 
 Default capacity is one task per manual pass unless the user explicitly asks
 for more.
@@ -117,4 +135,5 @@ End the pass with:
 - PRs merged or left pending;
 - any skipped claim reason;
 - ambiguous `working` tasks;
+- whether the drain appears complete or another manual drain pass is needed;
 - next recommended pass action.


### PR DESCRIPTION
Adds Loop C post-stop_at drain-monitor semantics for task-loop run-cycle, including Claude scheduling behavior, Codex manual drain-only behavior, updated design notes, and task-loop plugin version bumps.

Closes #169