### PR TITLE
Fix task-loop teammate shutdown docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- task-loop: replace Claude cycle-worker `TaskStop` reaping guidance with graceful teammate shutdown requests.
+- task-loop: require positive no-live-owner evidence before resetting fresh-session opaque workers.
 - task-loop: document Loop C post-`stop_at` drain monitoring and bump plugin manifests to `0.17.0`.
 - task-loop: bump plugin manifests to `0.16.0` so Claude and Codex refresh cached run-cycle support.
 - task-loop: add conservative manual Codex `run-cycle` support with observable worker dispatch gates.

--- a/docs/superpowers/specs/2026-06-15-task-loop-orchestrator-pass-conclusion.md
+++ b/docs/superpowers/specs/2026-06-15-task-loop-orchestrator-pass-conclusion.md
@@ -33,7 +33,7 @@ after merges. Each fixed-interval tick, in order:
    alive and ask for a progress line (skip if none dispatched).
 3. **Merge** (only PRs allowed by step 1) — for each `working` task with a ready PR (CI green +
    independent review check green), merge → `gh issue close <issue>` → `task-loop close <seq>`, then
-   reap the now-idle teammate.
+   request graceful shutdown of the now-idle teammate.
 4. **Findings → proposal (reconcile sweep)** — see §3 below.
 5. **Materialize tasks** — from the freshly-reconciled proposal + merged findings + directions: create
    discovered blocker tasks, re-create blocked tasks with their dependency, create direction-instructed
@@ -56,19 +56,18 @@ finished" was too strong.)
   die / finish without a PR → auto `reset`. Always safe.
 - **(b) Human direct CLI** — the operator runs `task-loop reset <seq>` out-of-band (only the human
   knows whether another orchestrator is live).
-- **(c) Single-orchestrator cold start** — on a fresh session in the default single-orchestrator mode,
-  prior-session workers died with their session, so opaque `working`-no-PR tasks are reclaimable.
+- **(c) Explicit operator no-live assertion** — the operator states the prior Agent Teams session is
+  terminated and no other orchestrator owns the task, then directs reclaim.
 
-A declared **multi-orchestrator foreign** tick never auto-resets an opaque `working`-no-PR task — it
-only **surfaces** it ("`012` looks orphaned; if no orchestrator is live, run `task-loop reset 012`").
-It still merges PR-present tasks and dispatches claimable. `directions.md` **never** triggers reset (it
-is standing steering, not a consumable queue; a stale `reset 012` line would re-fire and kill a new live
+Any fresh-session opaque `working`-no-PR task without that positive evidence is surfaced ("`012` looks
+orphaned; if no worker/orchestrator is live, run `task-loop reset 012`") instead of blindly reset. It
+still merges PR-present tasks and dispatches claimable. `directions.md` **never** triggers reset (it is
+standing steering, not a consumable queue; a stale `reset 012` line would re-fire and kill a new live
 worker). **No lease / heartbeat / attempt-id / timer / ownership marker is added.**
 
-**Accepted cost:** declared concurrent multi-orchestrator operation loses *automatic* recovery of
-foreign pre-PR orphans (a human `reset` handles the rare stuck one). Single-orchestrator operation —
-including crash/restart and sequential cross-machine (stop here, start there) — keeps full
-auto-recovery because prior-session Agent-Teams teammates die with their session.
+**Accepted cost:** crash/restart and sequential cross-machine recovery may need a human reset or
+explicit no-live assertion for pre-PR opaque rows. PR-present and claimable work still recovers on the
+next tick.
 
 ### 3. Proposal update is a reconcile sweep, not a patch
 The orchestrator is the sole editor of `proposal.md`. Concurrent orchestrators patching it from a stale

--- a/docs/superpowers/specs/2026-06-15-task-loop-supabase-harness-design.md
+++ b/docs/superpowers/specs/2026-06-15-task-loop-supabase-harness-design.md
@@ -12,7 +12,7 @@ This is the single source of truth for the redesigned harness. It records *what*
 ## 1. Goals & philosophy
 
 - **Simple and elegant over flexible.** Flexibility makes a harness fragile. Fewer states, fewer rules, one obvious path.
-- **Idempotent, stateless orchestrator.** All durable state lives in the world (Supabase DB + GitHub), never in the orchestrator. Running the loop *from anywhere, anytime* always does the same thing — there is **no** start/resume/recover mode.
+- **Idempotent durable decisions.** All durable state lives in the world (Supabase DB + GitHub), never in the orchestrator. Running the loop *from anywhere, anytime* converges on the same task/PR/proposal decisions — there is **no** start/resume/recover mode. Liveness and teammate cleanup can still depend on nondurable in-session handles.
 - **Relentless toward the goal; never gives up.** Short of the time bound the orchestrator never abandons the goal — every failed attempt is *diagnosed* and *re-attacked* with a materially-different, AIM-aligned strategy, escalating the approach when the same obstacle recurs. It never idles on difficulty, picks the easy task over the hard one, or drifts to an easier goal. Terminal states: **goal-met** or **`stop_at`** (§8).
 - **The orchestrator decides; the worker works.** The orchestrator never writes task code; the cycle-worker never touches the DB or merges.
 - **Two agent types only.** Everything else is deterministic, non-agent infrastructure (DB, CLI, GitHub, a hook).
@@ -68,7 +68,9 @@ tasks
 - **No `attempts` table / `attempt_id` / per-attempt branch ledger.** Recovery is "PR or no PR" (below); a worker's in-progress work before a PR is disposable local WIP. Nothing to track.
 - **No `findings` table.** Findings are written *in the PR* (study log); the orchestrator reads the PR. (Rationale §8.)
 - **No `worker` / `owner` column.** No orchestrator affinity; "is the worker alive" is the orchestrator's in-session knowledge, not DB state.
-- **No lease / heartbeat / `runtime` table.** The orchestrator owns its workers (observes death in-session); a fresh pass treats orphaned work as resettable. No timers.
+- **No lease / heartbeat / `runtime` table.** The orchestrator owns only the workers it can observe in
+  session. A fresh pass surfaces PR-absent opaque work unless there is positive no-live-owner evidence.
+  No timers.
 - **No `closed_as` / `priority` / `replaced_by` / `updated_at`.** Outcome lives in the PR; ordering is `created_at`/`seq`; "blocked" recreates a fresh task; the loop reads current state, not timestamps.
 
 ---
@@ -143,15 +145,16 @@ Each tick, **in order** (steering first — it gates everything irreversible):
 3. **Merge / classify** (only PRs steering allows) — per `working` task's PR. **Mergeable** (CI +
    review green **and** GitHub merge-state clean — no conflict/behind) → **head-SHA-atomic merge**
    (`gh pr merge --squash --match-head-commit <SHA>`, §9; a green→red flap is rejected) → on **success**
-   close issue + `task-loop close <seq>`; **blocked** → close task + work recreated in step 5 → reap.
-   **Behind base only** → `gh pr update-branch` (mechanical sync; merge next pass). **Gate-failed /
-   stuck / conflict** (check red, review failed, genuine conflict / deterministic rejection, or pending
-   past bound / never posts) → **diagnose and re-attack, never give up**: `gh pr close` + `task-loop
-   close <seq>`, then step 5 materializes the **next attempt against the same issue** on an active tick
-   with a materially-different, escalated, AIM-aligned strategy. In drain-only mode, keep the issue open
-   and defer materialization to the next active run. (Recreation is safe because it is *diagnosed
-   escalation*, not blind repetition — reversing the prior surface-and-wait rule — and `stop_at` bounds
-   new starts.) **Pending** → leave for next pass.
+   close issue + `task-loop close <seq>` + request worker shutdown; **blocked** → close task + work
+   recreated in step 5 + request worker shutdown. **Behind base only** → `gh pr update-branch`
+   (mechanical sync; merge next pass). **Gate-failed / stuck / conflict** (check red, review failed,
+   genuine conflict / deterministic rejection, or pending past bound / never posts) → **diagnose and
+   re-attack, never give up**: `gh pr close` + `task-loop close <seq>`, then step 5 materializes the
+   **next attempt against the same issue** on an active tick with a materially-different, escalated,
+   AIM-aligned strategy. In drain-only mode, keep the issue open and defer materialization to the next
+   active run. (Recreation is safe because it is *diagnosed escalation*, not blind repetition —
+   reversing the prior surface-and-wait rule — and `stop_at` bounds new starts.) **Pending** → leave for
+   next pass.
 4. **Findings → `proposal.md` (reconcile sweep).** The orchestrator is the **sole editor** of
    `proposal.md`. When merged findings change the roadmap, **recompute** the affected sections from
    *current default + the complete set of merged study-logs not yet reflected* (never a stale patch),
@@ -185,23 +188,20 @@ Each tick, **in order** (steering first — it gates everything irreversible):
 `claim` makes `open → working` atomic but **not** `working → open`. A PR is durable (any orchestrator
 may merge it); a PR-absent `working` task is **ambiguous** — alive-pre-PR vs dead — without an ownership
 marker (which we don't keep). So it is reset **only** with positive "no live owner" knowledge: **(a)**
-in-session observed death; **(b)** a human `task-loop reset <seq>`; or **(c)** a **single-orchestrator
-cold start** — a fresh session in the default single-orchestrator mode safely reclaims **every** opaque
-`working`-no-PR orphan (prior-session workers died with their session), so crash/restart **self-heals
-with no human-wait**. Single-orchestrator is an *operator deployment declaration*, not a runtime
-detection; accidental concurrency degrades to **bounded waste** (a reset may clobber a peer's branch →
-that unit is re-attacked), never unrecoverable. Only **declared multi-orchestrator** operation refuses
-to reclaim a foreign orphan (it surfaces it); `directions.md` never triggers reset. **Termination** is
-independent of all this: at `stop_at` Loop C waits only for positively live in-session workers,
-monitored detached jobs, and PR-present work; opaque no-PR rows follow the reset rule and do not block
-the drain forever.
+in-session observed death; **(b)** a human `task-loop reset <seq>`; or **(c)** an explicit operator
+assertion that the prior Agent Teams session is terminated and no other orchestrator owns the task. A
+fresh session alone is not proof. Opaque rows without positive evidence are surfaced instead of blindly
+reset, and `directions.md` never triggers reset. **Termination** is independent of all this: at
+`stop_at` Loop C waits only for positively live in-session workers for open/working tasks, monitored
+detached jobs, and PR-present work; opaque no-PR rows follow the reset rule and do not block the drain
+forever.
 
 **Recovery is just the next tick.** PR-present `working` tasks integrate; PR-absent ones are reset with
-positive no-live-owner knowledge, surfaced under declared multi-orchestrator ambiguity, or left
-recoverable. **The run finishes when the Success criteria are met** (goal achieved, step 7) **or** at
-`stop_at` (the time bound). An empty board with the goal **unmet** is *never* a stop — step 5
-materializes the next diagnosed, AIM-aligned work. So the loop always advances the goal, finishes it, or
-runs out the clock having genuinely kept trying — it never quietly gives up short of the goal.
+positive no-live-owner knowledge, surfaced for operator reset/assertion, or left recoverable. **The run
+finishes when the Success criteria are met** (goal achieved, step 7) **or** at `stop_at` (the time
+bound). An empty board with the goal **unmet** is *never* a stop — step 5 materializes the next
+diagnosed, AIM-aligned work. So the loop always advances the goal, finishes it, or runs out the clock
+having genuinely kept trying — it never quietly gives up short of the goal.
 
 ### Issues ↔ tasks
 Every task is **paired with a GitHub issue** at creation (open new or adopt existing; `tasks.issue` holds it). **The issue is the persistent unit-of-work identity; a task is one *attempt* at it.** On a successful merge the orchestrator **closes the issue**. On **blocked / gate-failed / conflict** it closes only the *task* (the attempt) but **keeps the issue open and re-links** it to the next attempt step 5 materializes — so the unit is pursued across attempts until success or `stop_at`. The issue closes **only on success** (or by human steering).
@@ -218,7 +218,7 @@ Every task is **paired with a GitHub issue** at creation (open new or adopt exis
 
 ## 10. Task lifecycle
 
-- States: **`open → working → closed`** (monotone). The only backward edge is **`reset` (`working → open`)**, allowed only with positive "no live owner" knowledge: in-session observed death, human `task-loop reset`, or default single-orchestrator cold-start reclaim (§8 reset rule). Declared multi-orchestrator foreign/opaque tasks are surfaced instead of blindly reset.
+- States: **`open → working → closed`** (monotone). The only backward edge is **`reset` (`working → open`)**, allowed only with positive "no live owner" knowledge: in-session observed death, human `task-loop reset`, or explicit operator no-live assertion (§8 reset rule). Other opaque tasks are surfaced instead of blindly reset.
 - **`blocked` is derived**, not a stored state: `open` with an unmet dependency (`claimable` excludes it). A worker that *discovers* it's blocked → the orchestrator **closes the task and creates a new one** carrying the remaining work + the blocking dep.
 - A task **only** leaves `open`/`working` by being `closed`; nothing is silently dropped (a closed task's reason lives in its PR; a blocked task's work lives in its replacement).
 
@@ -265,8 +265,8 @@ stop model updated by `2026-06-19-task-loop-loop-c-drain-monitor-design.md`:
 
 - **Pass shape** → a **6-step, directions-first pass** (§8): read state + steering → liveness → merge → reconcile `proposal.md` → materialize tasks → dispatch. Steering is read *before* any irreversible action and is an exogenous trigger.
 - **Reset rule** → reset only with positive no-live-owner knowledge: in-session observed death, human
-  `task-loop reset`, or the default single-orchestrator cold-start reclaim; declared multi-orchestrator
-  foreign/opaque tasks are surfaced instead. `directions.md` never triggers reset (§8).
+  `task-loop reset`, or explicit operator no-live assertion. Other opaque tasks are surfaced instead.
+  `directions.md` never triggers reset (§8).
 - **`proposal.md` updates** → the orchestrator is the **sole editor**, and each update is a **reconcile sweep** (recompute from current default + the complete merged-evidence set), never a stale patch — convergent under concurrency, no lock.
 - **Stop model** → fixed-interval **Loop A** runs active ticks; **Loop B** is the non-destructive
   `stop_at` transition that creates recurring **Loop C**; Loop C drains observable in-flight
@@ -276,7 +276,18 @@ stop model updated by `2026-06-19-task-loop-loop-c-drain-monitor-design.md`:
 - **Issue ↔ task pairing** → paired at creation; PR `Refs` (never `Closes`); orchestrator closes on success, re-links on blocked. Close-vs-keep is its judgment.
 - **Worker scope** → does its one task, isolates in its own worktree, reports findings in the PR; no merge / DB / issue / plan management.
 - **Capacity / concurrency** → not prescribed (soft knob). **Branch naming** → implementer's choice (`tl/<seq>` default; stale branch deleted on reset). **Multi-machine launch** → out of harness scope.
-- **Persistence / no-human-wait (this revision)** → the loop **never gives up short of the goal** and **never waits on a human decision** (humans steer *direction* only, async via `directions.md`). Every non-mergeable attempt is **diagnosed** (`discuss-with-codex`) and **re-attacked** with a **materially-different, AIM-aligned** strategy, **escalating the class of approach** when the same obstacle recurs (decided: *diagnosis + escalation teeth*, with *codex as the diagnosis / AIM-fidelity engine*); merge-blocked → behind-base `gh pr update-branch`, else a diagnosed next attempt. The GitHub **issue is the persistent unit identity; a task is one attempt**. Terminal states reduce to **goal-met** or **`stop_at`** — no exhaustion/idle terminal. This **reverses** the prior surface-and-wait rule: recreation is safe because it is diagnosed escalation (not blind repetition) and `stop_at` bounds it. Worker-side: *don't skip the heavy lifting* — `failed`/`blocked` are last resorts backed by evidence, not escape hatches. Closure re-verified adversarially (`…-2026-06-16-task-loop-persistence-loop-conclusion.md`).
+- **Persistence / no-human-wait (this revision)** → the loop **never gives up short of the goal** and
+  never waits on a human decision for a classified PR attempt (humans steer *direction* only, async via
+  `directions.md`; opaque no-PR rows still follow the reset rule). Every non-mergeable attempt is
+  **diagnosed** (`discuss-with-codex`) and **re-attacked** with a **materially-different, AIM-aligned**
+  strategy, **escalating the class of approach** when the same obstacle recurs (decided: *diagnosis +
+  escalation teeth*, with *codex as the diagnosis / AIM-fidelity engine*); merge-blocked → behind-base
+  `gh pr update-branch`, else a diagnosed next attempt. The GitHub **issue is the persistent unit
+  identity; a task is one attempt**. Terminal states reduce to **goal-met** or **`stop_at`** — no
+  exhaustion/idle terminal. This **reverses** the prior surface-and-wait rule for classified attempts:
+  recreation is safe because it is diagnosed escalation (not blind repetition) and `stop_at` bounds it.
+  Worker-side: *don't skip the heavy lifting* — `failed`/`blocked` are last resorts backed by evidence,
+  not escape hatches. Closure re-verified adversarially (`…-2026-06-16-task-loop-persistence-loop-conclusion.md`).
 
 **Still genuinely open:**
 - Which **CI / Action produces the independent review check** and how it's bound to the PR head.

--- a/docs/superpowers/specs/2026-06-19-task-loop-teammate-shutdown-conclusion.md
+++ b/docs/superpowers/specs/2026-06-19-task-loop-teammate-shutdown-conclusion.md
@@ -1,0 +1,100 @@
+# Task-Loop Teammate Shutdown Conclusion
+
+## Settled Position
+
+Claude `run-cycle` must not use `TaskStop` to clean up cycle-worker teammates. `TaskStop` is for
+background shell tasks, while Agent Teams teammates are shut down by asking the recorded teammate
+id/name to shut down.
+
+After task closure, the orchestrator sends a graceful shutdown request only when this session has the
+worker's teammate id/name for the closed seq. The worker stays idle until that request and approves it.
+If no in-session handle exists, shutdown is not attempted and the orchestrator surfaces that fact as a
+cleanup finding. If shutdown is rejected, does not respond by the next drain tick, or still appears
+alive after approval, the orchestrator records and surfaces the cleanup failure. The closed seq is no
+longer active work and must not block Loop C self-close solely because cleanup failed.
+
+## Key Decisions
+
+- Replace `TaskStop` reaping guidance with a graceful teammate shutdown request.
+- Record teammate id/name against each seq for in-session liveness and shutdown targeting.
+- Make worker handoff explicit: workers do not self-terminate, but approve shutdown requests for their
+  closed seq.
+- Treat closed-task shutdown failures as cleanup findings, not reasons to reopen/reset tasks or keep
+  Loop C alive forever.
+- Surface `shutdown not attempted for task <seq>: no in-session teammate handle` when another
+  orchestrator closes a task without owning the teammate handle.
+- Run a final cleanup audit before goal-met cancellation or Loop C self-close so shutdown uncertainty
+  from the last tick is surfaced.
+- Bump task-loop plugin manifests and affected Claude skill versions so cached installs refresh.
+
+## Pressure-Test Round 1
+
+Critic: A shutdown request is cooperative and rejectable. If the docs only say to request shutdown,
+Loop C can still deadlock because a closed task's worker may reject, hang, or remain addressable after
+approval.
+
+Disposition: Conceded and revised. The final contract separates active task liveness from closed-task
+cleanup. Shutdown failure is surfaced, but it does not block Loop C once the seq is already closed.
+
+## Pressure-Test Round 2
+
+Critic: The existing reset rule treated a fresh single-orchestrator session as proof that pre-PR
+workers from prior Agent Teams sessions were dead. The evidence does not establish that strongly enough,
+and a blind reset could clobber a still-live teammate.
+
+Disposition: Conceded and revised. Fresh session alone is no longer positive no-live-owner evidence.
+Opaque `working`-no-PR rows are reset only after in-session observed death, human reset, or explicit
+operator assertion that the prior Agent Teams session is terminated and no other orchestrator owns the
+task. Otherwise they are surfaced.
+
+## Pressure-Test Round 3
+
+Critic: If the final PR closes on the same tick that satisfies goal completion or Loop C self-close,
+there may be no next drain tick to detect a rejected, missing, or incomplete shutdown response.
+
+Disposition: Conceded and revised. Before goal-met cancellation or Loop C self-close, the orchestrator
+runs a final closed-teammate cleanup audit. Shutdown is verified only after approval and a
+post-approval addressability check confirms the teammate is no longer reachable. Otherwise it surfaces
+`shutdown unverified for task <seq> teammate <id/name>` as a cleanup finding and then stops.
+
+## Pressure-Test Round 4
+
+Critic: Any orchestrator can integrate a PR, but teammate handles are in-session only. If orchestrator B
+closes a task whose worker was spawned by orchestrator A, B cannot send shutdown and the prior audit did
+not surface that missing handle.
+
+Disposition: Conceded and revised. Closed-task cleanup now branches on handle availability. With a
+handle, the orchestrator requests shutdown and audits it. Without one, it surfaces
+`shutdown not attempted for task <seq>: no in-session teammate handle`. Only the owning live
+orchestrator can later request shutdown if it observes the closed seq.
+
+## Pressure-Test Round 5
+
+Critic: The final cleanup audit treated approval as enough, but the contract also says cleanup fails if
+the teammate remains addressable after approval. A same-tick final shutdown approval could be followed
+by immediate generation cancellation without checking whether the teammate actually exited.
+
+Disposition: Conceded and revised. Shutdown verification now requires approval plus a post-approval
+addressability check confirming the teammate is no longer reachable. If that check has not happened or
+the teammate remains reachable, the audit surfaces `shutdown unverified for task <seq> teammate
+<id/name>` before stopping.
+
+## Pressure-Test Round 6
+
+Critic: The docs still claimed every orchestrator reading the same durable state takes the same action,
+but cleanup now depends on nondurable in-session teammate handles.
+
+Disposition: Conceded and revised. The invariant now says durable task/PR/proposal decisions are
+re-derived and convergent, while liveness and teammate cleanup may differ by in-session handle
+ownership.
+
+## Unresolved Tensions
+
+Claude Agent Teams currently has no documented hard-kill equivalent for a teammate. The best available
+contract is graceful shutdown plus bounded cleanup reporting. Without a durable worker ownership marker,
+fresh-session pre-PR recovery may need an operator reset/assertion, and non-owning orchestrators can
+only report missing teammate handles.
+
+## Ending Condition
+
+Reached round cap after six critic rounds; all substantive objections were handled in the final text.

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development on a hosted Supabase task board: the task-loop CLI, setup/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "skills": "./claude-skills/"
 }

--- a/task-loop/.codex-plugin/plugin.json
+++ b/task-loop/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-loop",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Task-loop setup, preflight, specify-aims, create-cycle scaffolding, and manual run-cycle support for Codex.",
   "author": {
     "name": "Steven",

--- a/task-loop/agents/cycle-worker.md
+++ b/task-loop/agents/cycle-worker.md
@@ -89,8 +89,8 @@ If any is missing, ask the orchestrator before starting. You need nothing else.
 When your cycle reaches an open PR with its study log (per
 `${CLAUDE_PLUGIN_ROOT}/references/pr-findings.md`), send the orchestrator **one line** — the task
 `seq`, the PR number + URL + head SHA, and the declared **outcome** (`success` / `failed` /
-`blocked`) — then **go idle**. You do not self-terminate; the orchestrator validates, merges, and
-reaps you.
+`blocked`) — then **go idle**. Do not self-terminate. If the orchestrator sends a shutdown request for
+that closed `seq`, approve it and exit gracefully.
 
 If the orchestrator messages you for progress mid-task, reply with a **one-line status** (current step
 + whether you're on track) and keep working — that is its liveness check.

--- a/task-loop/claude-skills/create-cycle/SKILL.md
+++ b/task-loop/claude-skills/create-cycle/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-cycle
 description: This skill should be used when the user asks to "create cycle", "create the task loop", "generate the task-loop instructions", "write the per-task playbook", "scaffold task-loop", or to turn a task-loop proposal into the per-project cycle a worker follows. It renders docs/task-loop/task-loop.md — this project's tailored step-by-step worker cycle, its general rules, and its parameters (the cycle-worker agent follows this file) — from auto-detected and interviewed specifics, and scaffolds docs/task-loop/directions.md and a .gitignore entry.
-version: 0.2.0
+version: 0.2.1
 ---
 
 # Create Cycle

--- a/task-loop/claude-skills/create-cycle/assets/task-loop-skeleton.md
+++ b/task-loop/claude-skills/create-cycle/assets/task-loop-skeleton.md
@@ -115,8 +115,8 @@ rigor; fix or rebut each point; re-review until no blocking issues.
 
 ### 9. Report and idle
 Send the orchestrator **one line** — your `seq`, the PR number + URL + head SHA, and the declared
-**Outcome** — then **go idle**. Do not merge and do not self-terminate; the orchestrator validates,
-merges, and reaps you.
+**Outcome** — then **go idle**. Do not merge and do not self-terminate. If the orchestrator sends a
+shutdown request for that closed `seq`, approve it and exit gracefully.
 
 ## Background long jobs (never foreground-block)
 

--- a/task-loop/claude-skills/run-cycle/SKILL.md
+++ b/task-loop/claude-skills/run-cycle/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-cycle
 description: This skill should be used when the user asks to "run cycle", "run the task loop", "start the orchestrator", "drive the autonomous loop", or to begin autonomous, orchestrated execution of a task-loop project. It runs the orchestrator under a fixed-interval loop; each tick honors human steering, merges ready PRs, diagnoses and re-attacks any failed/blocked/stuck attempt with a materially-different AIM-aligned strategy (it never gives up short of the goal or the time bound), reconciles the roadmap, and dispatches the next work. Idempotent — every tick re-derives state from the task DB + GitHub + directions.md.
-version: 0.4.0
+version: 0.4.1
 ---
 
 # Run Cycle
@@ -13,10 +13,11 @@ This skill is the **orchestrator** (the main agent): sole **dispatcher / decider
 sole **editor of `proposal.md`**. It talks to the task DB **only** via the `task-loop` CLI and to
 GitHub via `gh`; `cycle-worker` teammates do the tasks.
 
-**Idempotent & stateless.** All durable state lives in **Supabase** (the board), **GitHub**
-(PRs/issues), and the git-tracked `docs/task-loop/` files. Every tick re-derives from
-`task-loop status` + GitHub + `directions.md` and takes the same action — there is **no** control
-issue, **no** lease, and **no** local runtime files. **Recovery is just the next tick.**
+**Idempotent durable decisions.** All durable state lives in **Supabase** (the board), **GitHub**
+(PRs/issues), and the git-tracked `docs/task-loop/` files. Every tick re-derives task, PR, and proposal
+decisions from `task-loop status` + GitHub + `directions.md` — there is **no** control issue, **no**
+lease, and **no** local runtime files. Liveness and teammate cleanup can depend on in-session teammate
+handles. **Recovery is just the next tick.**
 
 **Relentless (never gives up).** Short of the time bound the orchestrator never abandons the goal. A
 failed / blocked / stuck attempt is **diagnosed** (`dev-skills:discuss-with-codex`) and **re-attacked**
@@ -63,20 +64,21 @@ stale job can never touch a newer run. Loop C is created later by the stop trans
 
 **Stopping after `stop_at` is Loop C's decision:** `stop_at` means "stop starting new work," not
 "abandon work already launched." Loop C cancels the generation's `-A`/`-B`/`-C` schedules and stops
-only when no positively live in-session worker or monitored detached job remains for this generation
-and no PR-present `working` task still needs merge/classification. Opaque `working`-no-PR rows without
-positive live ownership follow the reset rule in the reference and never block Loop C forever. To change
-the bound, re-invoke `/run-cycle` — it mints a new generation, best-effort cancels every
+only when no positively live in-session worker or monitored detached job remains for open/working tasks
+in this generation and no PR-present `working` task still needs merge/classification; before canceling,
+it runs the final closed-teammate cleanup audit from the reference. Opaque `working`-no-PR rows without
+positive live ownership follow the reset rule in the reference and never block Loop C forever. To
+change the bound, re-invoke `/run-cycle` — it mints a new generation, best-effort cancels every
 `task-loop-<project>-*` job, and recreates Loop A + Loop B. No DB cell, no stored handle, no local file.
 
 ## Setup (on invocation)
 
 1. Confirm prerequisites (above). 2. Ask the run duration (default 24h) → compute `stop_at` (UTC); mint
 `run_generation` (`date -u +%s`). 3. Best-effort cancel stale `task-loop-<project>-*` jobs. 4. Ensure
-the cycle-worker **team** exists (recreate on a fresh session — teammates are ephemeral). 5. Create
-Loop A + Loop B only; Loop B's prompt creates Loop C at `stop_at`. Loop A's prompt carries `stop_at` +
-`run_generation` and the instruction to **read `references/orchestrator-loop.md` and work it as a
-`TodoWrite` each tick**. Loop A then runs unattended.
+the cycle-worker **team** exists for this session. 5. Create Loop A + Loop B only; Loop B's prompt
+creates Loop C at `stop_at`. Loop A's prompt carries `stop_at` + `run_generation` and the instruction
+to **read `references/orchestrator-loop.md` and work it as a `TodoWrite` each tick**. Loop A then runs
+unattended.
 
 ## The pass (each Loop A tick)
 
@@ -99,12 +101,12 @@ multi-orchestrator notes.
 - **Never give up short of the goal** — every non-mergeable attempt is diagnosed and re-attacked with a
   materially-different, escalated, AIM-aligned strategy; the run ends only at **goal-met** or **`stop_at`**.
 - **After `stop_at`, no new starts** — Loop B installs Loop C; Loop C drains observable in-flight
-  workers/monitored jobs and PR-present work, then cancels the generation. It does not dispatch or
-  materialize re-attacks.
+  workers/monitored jobs for open/working tasks and PR-present work, runs the final closed-teammate
+  cleanup audit, then cancels the generation. It does not dispatch or materialize re-attacks.
 - **Reset only with positive "no live owner" knowledge** — in-session observed death, a human
-  `task-loop reset <seq>`, or a **single-orchestrator cold start** reclaiming opaque orphans (the
-  default mode — prior-session workers die with their session, so none can be live). Only *declared*
-  multi-orchestrator operation refuses to reclaim a foreign orphan (it **surfaces** it). `directions.md`
+  `task-loop reset <seq>`, or an explicit operator assertion that the prior Agent Teams session is
+  terminated and no other orchestrator owns the task. A fresh session alone is not proof. Opaque
+  `working`-no-PR rows without positive evidence are surfaced, never blindly reset. `directions.md`
   never triggers reset. Full rule in the reference.
 - **Idempotent passes:** proposal updates are reconcile sweeps, never stale patches; task/issue creation
   is idempotent.

--- a/task-loop/claude-skills/run-cycle/references/orchestrator-loop.md
+++ b/task-loop/claude-skills/run-cycle/references/orchestrator-loop.md
@@ -1,12 +1,15 @@
 # Orchestrator loop — the per-tick pass (run-cycle detail)
 
 The orchestrator is the **sole dispatcher, decider, merger, and editor of `proposal.md`**, and it
-holds **no durable state of its own**: every tick re-derives everything from the **task DB** (via the
-`task-loop` CLI), **GitHub** (via `gh`), and the git-tracked **`docs/task-loop/`** files. Two
-orchestrators reading the same DB + GitHub + `directions.md` take the same action. **Recovery is just
-the next tick.** It is also **relentless**: short of the time bound it **never gives up on the goal** —
-every failed / blocked / stuck attempt is *diagnosed* and *re-attacked* with a materially-different,
-AIM-aligned strategy (§3/§5/§7), never surrendered, idled, or redefined into an easier goal.
+holds **no durable state of its own**: durable task/PR/proposal decisions are re-derived each tick from
+the **task DB** (via the `task-loop` CLI), **GitHub** (via `gh`), and the git-tracked
+**`docs/task-loop/`** files. Liveness and teammate cleanup may also use nondurable in-session teammate
+handles. Two orchestrators reading the same durable state converge on the same durable outcome, but can
+differ in liveness/cleanup actions: the owner requests shutdown; a non-owner surfaces the missing
+handle. **Recovery is just the next tick.** It is also **relentless**: short of the time bound it
+**never gives up on the goal** — every failed / blocked / stuck attempt is *diagnosed* and
+*re-attacked* with a materially-different, AIM-aligned strategy (§3/§5/§7), never surrendered, idled,
+or redefined into an easier goal.
 
 ## Where state lives
 
@@ -20,8 +23,8 @@ AIM-aligned strategy (§3/§5/§7), never surrendered, idled, or redefined into 
 - **Git-tracked files.** `proposal.md` (the roadmap the orchestrator reconciles), `directions.md`
   (human steering), `docs/task-loop/logs/<seq>_<task>.md` (merged study-logs = the durable evidence set).
 - **In-session only (not durable).** Which teammate this orchestrator spawned for which task — the
-  basis for *in-session* reset (case (a)). A fresh session has none; it recovers opaque orphans via the
-  cold-start reclaim (case (c)) instead.
+  basis for *in-session* liveness and reset (case (a)). A fresh session has no durable worker ownership
+  proof; opaque pre-PR rows need explicit no-live-owner evidence before reset.
 
 ## Control plane (set up once per invocation)
 
@@ -38,9 +41,9 @@ and Loop B. Loop C is created only when the stop transition fires:
   no-ops/cancels itself. Otherwise it creates or ensures Loop C and may run/wake one drain tick. It
   never dispatches, never materializes re-attacks, and never force-stops live work.
 - **Loop C** — a recurring drain monitor (default ~30 min, `...-<gen>-C`) created by Loop B. It runs the
-  drain subset until no positively live in-session worker/monitored detached job remains for this
-  generation and no PR-present `working` task still needs merge/classification; then it cancels
-  `-A`/`-B`/`-C` for the generation and stops.
+  drain subset until no positively live in-session worker/monitored detached job remains for
+  open/working tasks in this generation and no PR-present `working` task still needs
+  merge/classification; then it cancels `-A`/`-B`/`-C` for the generation and stops.
 
 Because every job is generation-named, a leftover job from an earlier run can only touch its own
 generation. Generation checks use schedule names only — no DB cell, stored handle, or local runtime
@@ -62,6 +65,24 @@ best-effort ensures Loop C if Loop B is clearly absent/stale. Loop C self-closes
 
 Opaque `working`-no-PR tasks without positive live ownership follow the Reset rule. They do not block
 Loop C forever; they are reset, surfaced, or left as recoverable state according to that rule.
+
+Closed-task teammate cleanup is separate from task liveness. Once a seq is closed, if this session has
+the recorded teammate id/name for that seq, send it a graceful shutdown request. If this session has no
+teammate handle, record/surface `shutdown not attempted for task <seq>: no in-session teammate handle`.
+Only the live orchestrator session that owns the handle can request that shutdown later if it observes
+the closed seq. If the request is rejected, no response arrives by the next drain tick, or the teammate
+remains addressable after approval, record/surface the cleanup failure and stop counting that closed
+seq's teammate as an active drain blocker. Do **not** use `TaskStop`, reopen/reset the task, or block
+Loop C solely on cleanup failure.
+
+Before canceling the generation on goal-met or Loop C self-close, run a final cleanup audit for closed
+seqs touched this tick, shutdown requests sent this tick, and shutdown requests still pending. If a
+closed seq has no in-session teammate handle, surface
+`shutdown not attempted for task <seq>: no in-session teammate handle`. Treat shutdown as verified only
+after approval **and** a post-approval addressability check confirms the teammate is no longer
+reachable. If that check has not happened, or the teammate is still reachable, surface
+`shutdown unverified for task <seq> teammate <id/name>` as a cleanup finding, then stop. This audit
+reports uncertainty; it does not keep the run alive by itself.
 
 ### 1. Honor steering (first, before any irreversible action)
 `directions.md` is highest-priority and free-form; interpret it and apply its constraints **this tick,
@@ -89,11 +110,11 @@ Read the study-log **Outcome** *before* deciding — broken work is never merged
   **atomically**: `gh pr merge <N> --squash --match-head-commit <validated head SHA>` (re-checks at the
   bound head; if the head moved or the merge is rejected for a **transient** reason → re-evaluate next
   tick, defeating a green→red flap). Then `gh issue close <issue>`; `task-loop close <seq>` (its
-  **Findings** feed step 5); **reap the idle teammate** (`TaskStop` the worker you spawned for that seq).
+  **Findings** feed step 5); run closed-task teammate cleanup.
 - **`blocked`** (Outcome: blocked) → `task-loop close <seq>`; on an active tick, step 5 recreates the
   remaining work as a `--dep` task. In drain-only mode, defer recreation to the next active run. The
-  issue stays **open**, re-linked there → reap. (Merge the partial PR only if it is independently
-  valuable — your call; otherwise `gh pr close <N>` as the record.)
+  issue stays **open**, re-linked there → run closed-task teammate cleanup. (Merge the partial PR only
+  if it is independently valuable — your call; otherwise `gh pr close <N>` as the record.)
 - **`success` but behind base only** (green, no conflict, just behind a required up-to-date base) → run
   **`gh pr update-branch <N>`** — a *mechanical base-sync the orchestrator owns* (not task code) → CI
   re-runs → merge next tick. The cheapest re-attack: no new task.
@@ -173,8 +194,8 @@ While within your **soft capacity** (you decide; not prescribed):
 - The claimed task already has an `issue` (paired in step 5); pick a branch (e.g. `tl/<seq>`, honoring
   any repo branch-prefix hook).
 - **Spawn one `cycle-worker` teammate** (ask for it by agent type) with: `seq`, `title`, `issue`, and
-  the branch. **Record the teammate id against the seq** — it is the basis for liveness (§2) and reap
-  (§3).
+  the branch. **Record the teammate id/name against the seq** — it is the basis for liveness (§2) and
+  shutdown after closure (§3).
 Stop when `claim` returns `none` or you reach capacity (the rest win a seat on a later tick).
 
 ### 7. Goal check / terminate (close the loop on the GOAL, never on difficulty)
@@ -183,7 +204,8 @@ Evaluate the proposal's **Success criteria** against the repo — **run them** (
 
 - **Criteria met** → **done**: dispatch nothing. If observable in-flight workers or PR-present working
   tasks remain, enter the same drain-only behavior and stop when the Loop C self-close condition holds;
-  otherwise cancel the generation's jobs and stop. (The natural finish.)
+  otherwise run the final closed-teammate cleanup audit, cancel the generation's jobs, and stop. (The
+  natural finish.)
 - **Criteria unmet** → **always continue.** §5 guarantees the board carries the next diagnosed,
   AIM-aligned work (re-attacks, decomposition, blockers), so the loop keeps driving. **There is no
   exhaustion terminal and no idle-on-difficulty** — a non-mergeable attempt is diagnosed and
@@ -200,16 +222,18 @@ never stops *trying*.
 **Drain / `stop_at`:** at `now ≥ stop_at`, the run stops dispatching and re-attacking. Loop B installs
 Loop C, and Loop C keeps the same live session around to process observable in-flight work:
 
-- keep checking positively live workers you spawned this session and any monitored detached jobs they
-  reported;
+- keep checking positively live workers you spawned this session while they still own open/working
+  tasks, and any monitored detached jobs they reported;
 - merge/classify PR-present `working` tasks as they land;
 - run proposal reconciliation for merged findings;
 - skip materialization and dispatch.
 
-Loop C self-closes when no positively live in-flight worker/monitored job remains and no PR-present
-`working` task needs merge/classification. Opaque `working`-no-PR rows without positive live ownership
-never become hidden blockers: apply the Reset rule if you have positive no-live-owner knowledge, surface
-them under declared multi-orchestrator ambiguity, or leave them as recoverable state for the next run.
+Loop C self-closes when no positively live in-flight worker/monitored job remains for open/working
+tasks and no PR-present `working` task needs merge/classification. Before canceling schedules, run the
+final closed-teammate cleanup audit. Opaque `working`-no-PR rows without positive live ownership never
+become hidden blockers: apply the Reset rule if you have positive no-live-owner knowledge, surface them
+for operator reset/assertion, or leave them as recoverable state for the next run. Closed-task shutdown
+failures are cleanup findings, not active work.
 If the session dies during Loop C, recovery is unchanged: the next `/run-cycle` re-derives from DB +
 GitHub and reclaims/surfaces according to the Reset rule.
 
@@ -234,29 +258,20 @@ with positive knowledge that no live worker owns it** — true in three cases:
   finish-without-PR → `task-loop reset <seq>` (claimable again next tick). On the *same* tick, delete
   the stale remote branch (`git push origin --delete <branch>`) so re-dispatch starts clean.
 - **(b) Human direct CLI** — the operator runs `task-loop reset <seq>` out-of-band.
-- **(c) Single-orchestrator cold start** — on a fresh session in **single-orchestrator operation**,
-  **every** opaque `working`-no-PR task is safely reclaimable: each worker from a prior session died
-  **with** that session, so no live worker can own one. Reset and re-attack them (deleting any stale
-  remote branch first). This is the autonomous recovery that keeps the loop from **ever waiting on a
-  human** after a crash / restart. Single-orchestrator is an **operator deployment declaration** (the
-  harness's default mode — the operator controls how many orchestrators run), *not* a runtime
-  detection. Accidental concurrency (running two while declaring single) is operator error and degrades
-  to **bounded waste** — a reset may clobber a peer's `tl/<seq>` branch, so that unit is simply
-  re-attacked — never unrecoverable loss.
+- **(c) Explicit operator no-live assertion** — the operator states the prior Agent Teams session is
+  terminated and no other orchestrator owns the task, then directs this run to reclaim the opaque rows.
+  Delete any stale remote branch first, then reset and re-attack.
 
-**Only under *declared* multi-orchestrator operation** (the operator runs more than one orchestrator —
-declared via `directions.md` / the invocation) does a tick refuse to reclaim an opaque `working`-no-PR
-task it didn't spawn: a concurrent peer's worker may be live **and** share the `tl/<seq>` branch, so an
-erroneous reset would clobber it. It **surfaces** the task instead ("`012` looks orphaned; if no
-orchestrator is live, run `task-loop reset 012`") and moves on (still merging PR-present tasks and
-dispatching claimable). `directions.md` never *triggers* a reset — a stale `reset 012` line would
-re-fire and kill a live worker.
+A fresh session by itself is **not** positive no-live-owner knowledge. If an opaque `working`-no-PR
+task was not spawned by this live session and no explicit operator assertion exists, **surface** it
+instead ("`012` is working with no PR and no observable owner; if no worker/orchestrator is live, run
+`task-loop reset 012`") and move on. Still merge PR-present tasks and dispatch claimable work.
+`directions.md` never *triggers* a reset — a stale `reset 012` line would re-fire and kill a live
+worker.
 
-**Consequence (honest):** the default **single-orchestrator** mode — including sequential cross-machine
-and crash / restart (teammates die with their session) — **always** reclaims pre-PR orphans
-autonomously and never waits on a human. Only **declared concurrent multi-orchestrator** operation
-trades that for a human reset *or* a tolerated duplicate attempt (bounded waste — the issue is the unit
-identity, and at most one attempt merges).
+**Consequence (honest):** crash/restart and cross-machine recovery remain idempotent for PR-present
+work and claimable work, but opaque pre-PR work may require an operator reset or explicit no-live
+assertion. This avoids clobbering a still-live teammate while keeping the DB schema lease-free.
 
 ## Merge gate
 
@@ -286,21 +301,20 @@ succeeds or `stop_at` halts the run. The issue closes **only on success** (or by
 
 ## Recovery = the next tick
 
-There is no resume path. A fresh orchestrator recreates the team, reads `task-loop status` + GitHub +
-`directions.md`, and runs a normal tick: PR-present `working` tasks are integrated; PR-absent orphans
-are **reclaimed and re-attacked** in the default single-orchestrator mode (§Reset case (c)) — held and
-surfaced only under *declared* multi-orchestrator operation. So a crash / restart **self-heals** without
-human intervention.
+There is no durable worker resume path. A fresh orchestrator creates the session's team, reads
+`task-loop status` + GitHub + `directions.md`, and runs a normal tick: PR-present `working` tasks are
+integrated; PR-absent opaque rows are reset only with the positive no-live-owner evidence in §Reset, or
+surfaced for operator reset/assertion. Crash/restart self-heals for durable artifacts and claimable
+work; pre-PR opaque work is not blindly clobbered.
 
 ## Multiple orchestrators
 
-Declared multi-orchestrator operation (one per ecosystem — Claude / Gemini / Codex) runs with **no
-coordination beyond `task-loop claim`**: the atomic claim guarantees single-flight *dispatch*, any
-orchestrator may merge any ready PR, and the proposal reconcile-sweep (§4) is convergent. The two
-surfaces they must respect: a foreign orchestrator never resets an opaque `working` task it doesn't own
-(§Reset), and *materialization* is unlocked, so two peers may create a **duplicate attempt** for one
-unit — bounded waste (the issue is the unit identity; at most one attempt merges). Both are accepted
-costs of lock-free concurrency; the default single-orchestrator mode incurs neither.
+Multiple orchestrators (one per ecosystem — Claude / Gemini / Codex) run with **no coordination beyond
+`task-loop claim`**: the atomic claim guarantees single-flight *dispatch*, any orchestrator may merge
+any ready PR, and the proposal reconcile-sweep (§4) is convergent. The two surfaces they must respect:
+an orchestrator never resets an opaque `working` task without positive no-live-owner evidence (§Reset),
+and *materialization* is unlocked, so two peers may create a **duplicate attempt** for one unit —
+bounded waste (the issue is the unit identity; at most one attempt merges).
 
 ## Deliberate with Codex
 


### PR DESCRIPTION
Updates Claude task-loop run-cycle docs so closed cycle-worker teammates are cleaned up with Agent Teams shutdown requests instead of TaskStop.

Also tightens opaque worker reset rules so fresh sessions do not reset without positive no-live-owner evidence.

Closes #171