### PR TITLE
Extend discuss-with-codex call timeout to 600s

### DIFF
--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-skills",
   "description": "Collection of development workflow skills including systematic problem-solving cycle from brainstorming to PR merge",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }

--- a/dev-skills/skills/discuss-with-codex/SKILL.md
+++ b/dev-skills/skills/discuss-with-codex/SKILL.md
@@ -36,7 +36,7 @@ a single shell script: composing each rebuttal is your job.
 ## Defaults
 
 - `ROUND_CAP=6` (one round = one Claude↔Codex exchange)
-- `CALL_TIMEOUT=180` seconds per codex call; `SMOKE_TIMEOUT=60` for preflight
+- `CALL_TIMEOUT=600` seconds per codex call; `SMOKE_TIMEOUT=60` for preflight
 - Codex sandbox: `read-only`, repo as working dir
 - Conclusion: always saved AND presented
 
@@ -103,7 +103,7 @@ You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is 
 CRITIC
 )"
 
-codex_to 180 codex exec --json -s read-only -C "$REPO" \
+codex_to 600 codex exec --json -s read-only -C "$REPO" \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"
 status=$?
@@ -157,7 +157,7 @@ CRITIC
 # NOTE: do NOT pass -s/-C to `codex exec resume`. Sandbox and cwd are bound to
 # the session at kickoff and `resume` rejects those flags. Always use the
 # explicit THREAD_ID form captured in Step 1.
-codex_to 180 codex exec resume "$THREAD_ID" --json \
+codex_to 600 codex exec resume "$THREAD_ID" --json \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"
 echo "exit=$?"


### PR DESCRIPTION
Bumps the per-call codex timeout from 180s to 600s so deep repo-grounded objections don't get cut off (exit 124). Updates the three references (Defaults, kickoff, resume) and bumps dev-skills to 3.8.1. Smoke-test timeout left at 60s.