### PR TITLE
Update Codex model to gpt-5.6-sol with xhigh effort

### DIFF
--- a/dev-skills/.claude-plugin/plugin.json
+++ b/dev-skills/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-skills",
   "description": "Collection of development workflow skills including systematic problem-solving cycle from brainstorming to PR merge",
-  "version": "3.8.1"
+  "version": "3.8.2"
 }

--- a/dev-skills/skills/discuss-with-codex/SKILL.md
+++ b/dev-skills/skills/discuss-with-codex/SKILL.md
@@ -37,8 +37,9 @@ a single shell script: composing each rebuttal is your job.
 
 - `ROUND_CAP=6` (one round = one Claude↔Codex exchange)
 - `CALL_TIMEOUT=600` seconds per codex call; `SMOKE_TIMEOUT=60` for preflight
-- Model: `gpt-5.6-sol` with `model_reasoning_effort=xhigh`, pinned per call so the
-  skill does not depend on the ambient `~/.codex/config.toml` default
+- Model: `gpt-5.6-sol`, pinned per call so the skill does not depend on the ambient
+  `~/.codex/config.toml` default. Reasoning effort is `xhigh` on the deliberation
+  calls (kickoff/resume) and `low` on the preflight smoke (a trivial connectivity check)
 - Codex sandbox: `read-only`, repo as working dir
 - Conclusion: always saved AND presented
 
@@ -67,7 +68,7 @@ A real smoke call catches broken Codex environments that `command -v` cannot
 
 ```bash
 command -v codex >/dev/null || { echo "codex CLI not found — install it first"; exit 1; }
-codex_to 60 codex exec --json -m gpt-5.6-sol -c model_reasoning_effort="xhigh" \
+codex_to 60 codex exec --json -m gpt-5.6-sol -c model_reasoning_effort="low" \
   -s read-only -C "$REPO" -o "$DIR/smoke.txt" \
   "Reply with exactly: ok" > "$DIR/smoke.jsonl" 2> "$DIR/smoke.err"
 echo "exit=$?"

--- a/dev-skills/skills/discuss-with-codex/SKILL.md
+++ b/dev-skills/skills/discuss-with-codex/SKILL.md
@@ -37,6 +37,8 @@ a single shell script: composing each rebuttal is your job.
 
 - `ROUND_CAP=6` (one round = one Claude↔Codex exchange)
 - `CALL_TIMEOUT=600` seconds per codex call; `SMOKE_TIMEOUT=60` for preflight
+- Model: `gpt-5.6-sol` with `model_reasoning_effort=xhigh`, pinned per call so the
+  skill does not depend on the ambient `~/.codex/config.toml` default
 - Codex sandbox: `read-only`, repo as working dir
 - Conclusion: always saved AND presented
 
@@ -65,7 +67,8 @@ A real smoke call catches broken Codex environments that `command -v` cannot
 
 ```bash
 command -v codex >/dev/null || { echo "codex CLI not found — install it first"; exit 1; }
-codex_to 60 codex exec --json -s read-only -C "$REPO" -o "$DIR/smoke.txt" \
+codex_to 60 codex exec --json -m gpt-5.6-sol -c model_reasoning_effort="xhigh" \
+  -s read-only -C "$REPO" -o "$DIR/smoke.txt" \
   "Reply with exactly: ok" > "$DIR/smoke.jsonl" 2> "$DIR/smoke.err"
 echo "exit=$?"
 grep -qi "ok" "$DIR/smoke.txt" 2>/dev/null && echo "SMOKE OK" || { echo "SMOKE FAILED"; tail -5 "$DIR/smoke.err"; }
@@ -103,7 +106,8 @@ You are acting as an ADVERSARIAL CRITIC in a structured discussion. Your job is 
 CRITIC
 )"
 
-codex_to 600 codex exec --json -s read-only -C "$REPO" \
+codex_to 600 codex exec --json -m gpt-5.6-sol -c model_reasoning_effort="xhigh" \
+  -s read-only -C "$REPO" \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"
 status=$?
@@ -155,9 +159,11 @@ CRITIC
 )"
 
 # NOTE: do NOT pass -s/-C to `codex exec resume`. Sandbox and cwd are bound to
-# the session at kickoff and `resume` rejects those flags. Always use the
-# explicit THREAD_ID form captured in Step 1.
+# the session at kickoff and `resume` rejects those flags. (-m/-c ARE accepted,
+# so the model pin below is fine.) Always use the explicit THREAD_ID form
+# captured in Step 1.
 codex_to 600 codex exec resume "$THREAD_ID" --json \
+  -m gpt-5.6-sol -c model_reasoning_effort="xhigh" \
   -o "$DIR/msg.txt" "$PROMPT" \
   > "$DIR/events.jsonl" 2> "$DIR/err.log"
 echo "exit=$?"

--- a/task-loop/.claude-plugin/plugin.json
+++ b/task-loop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-loop",
   "description": "Autonomous, orchestrated cycle-driven development on a hosted Supabase task board: the task-loop CLI, setup/specify-aims/create-cycle/run-cycle skills, and the cycle-worker agent.",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "skills": "./claude-skills/"
 }

--- a/task-loop/.codex-plugin/plugin.json
+++ b/task-loop/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-loop",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Task-loop setup, preflight, specify-aims, create-cycle scaffolding, and manual run-cycle support for Codex.",
   "author": {
     "name": "Steven",

--- a/task-loop/codex-agents/task-loop-cycle-worker.toml
+++ b/task-loop/codex-agents/task-loop-cycle-worker.toml
@@ -1,7 +1,7 @@
 name = "task_loop_cycle_worker"
 description = "Runs one task-loop task after the controller supplies seq, title, issue, and branch. Follows docs/task-loop/task-loop.md once, opens a PR with a study log, reports the outcome, and never merges."
-model = "gpt-5.5"
-model_reasoning_effort = "high"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "xhigh"
 nickname_candidates = ["Task Loop Worker", "Cycle Worker", "Task Worker"]
 
 developer_instructions = """


### PR DESCRIPTION
Switches Codex usage to `gpt-5.6-sol` with `xhigh` reasoning effort.

**discuss-with-codex skill** (`dev-skills`)
- Pin `-m gpt-5.6-sol` on all three `codex exec` calls (smoke, kickoff, resume); the skill previously pinned no model and inherited the ambient `~/.codex/config.toml` default.
- Reasoning effort `xhigh` on the deliberation calls; `low` on the preflight smoke (trivial connectivity check, keeps it fast under `SMOKE_TIMEOUT=60`).

**task-loop cycle-worker** (Codex agent manifest)
- `model` gpt-5.5 → gpt-5.6-sol, `model_reasoning_effort` high → xhigh.

**Version bumps** (so marketplace consumers pull the changes)
- `task-loop` `.claude-plugin` and `.codex-plugin` both 0.18.0 → 0.18.1 (kept in lockstep).
- `dev-skills/.claude-plugin` 3.8.1 → 3.8.2.