### PR TITLE
Add Codex-native creator and step workflow skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -36,6 +36,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "creator-skills",
+      "source": {
+        "source": "local",
+        "path": "./creator-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- creator-skills/dev-skills: add native Codex support for `sci-slides`, `sci-figure-format`, and `step-workflow`.
 - task-loop: replace Claude cycle-worker `TaskStop` reaping guidance with graceful teammate shutdown requests.
 - task-loop: require positive no-live-owner evidence before resetting fresh-session opaque workers.
 - task-loop: document Loop C post-`stop_at` drain monitoring and bump plugin manifests to `0.17.0`.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,17 @@ cc-toolkit/
 │   └── codex-skills/
 │       ├── doc-update/
 │       ├── goal-rubric/
-│       └── pressure-test/
+│       ├── pressure-test/
+│       └── step-workflow/
 ├── creator-skills/                 # Scientific content creation plugin
 │   ├── .claude-plugin/
 │   │   └── plugin.json
-│   └── skills/
+│   ├── .codex-plugin/
+│   │   └── plugin.json
+│   ├── skills/
+│   │   ├── sci-figure-format/
+│   │   └── sci-slides/
+│   └── codex-skills/
 │       ├── sci-figure-format/
 │       └── sci-slides/
 ├── doc-skills/                     # Document processing plugin
@@ -100,6 +106,7 @@ Development workflow automation and systematic problem-solving.
 - **doc-update**
 - **goal-rubric**
 - **pressure-test**
+- **step-workflow**
 
 ### Creator Skills (`creator-skills`)
 Scientific content creation for figures and presentations.
@@ -107,6 +114,10 @@ Scientific content creation for figures and presentations.
 **Skills:**
 - **sci-figure-format**: Publication-quality scientific figure formatting for major journals (Nature, Science, ACS, RSC)
 - **sci-slides**: Academic presentation slide creation for STEM fields
+
+**Codex skills:**
+- **sci-figure-format**
+- **sci-slides**
 
 ### Document Skills (`doc-skills`)
 Document processing and AI-accessible content extraction.

--- a/creator-skills/.codex-plugin/plugin.json
+++ b/creator-skills/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "creator-skills",
+  "version": "1.0.1",
+  "description": "Scientific content creation skills for Codex.",
+  "author": {
+    "name": "Steven",
+    "email": "aeghnnsw@users.noreply.github.com"
+  },
+  "repository": "https://github.com/aeghnnsw/cc-toolkit",
+  "license": "MIT",
+  "keywords": [
+    "science",
+    "scientific",
+    "presentation",
+    "slides",
+    "figures",
+    "visualization",
+    "publication"
+  ],
+  "skills": "./codex-skills/",
+  "interface": {
+    "displayName": "Creator Skills",
+    "shortDescription": "Codex-ready scientific slides and figure guidance.",
+    "longDescription": "Use Creator Skills to design scientific presentations and format publication-quality scientific figures.",
+    "developerName": "Steven",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Design an effective scientific presentation.",
+      "Review these academic slides.",
+      "Format this scientific figure for publication."
+    ]
+  }
+}

--- a/creator-skills/codex-skills/sci-figure-format/SKILL.md
+++ b/creator-skills/codex-skills/sci-figure-format/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: sci-figure-format
+description: Use when creating or reviewing scientific figures for publication, including journal dimensions, resolution, file formats, typography, line weights, colorblind-safe palettes, and Nature, Science, ACS, or RSC requirements.
+---
+
+# Scientific Figure Formatting
+
+Guidelines for creating publication-quality figures that meet standards of Nature, Science, ACS, and RSC journals.
+
+---
+
+## Universal Standards (All Major Journals)
+
+| Element | Requirement |
+|---------|-------------|
+| **Colors** | Okabe-Ito palette (colorblind-safe) |
+| **Font** | Helvetica or Arial, 6-8 pt |
+| **Resolution** | 600 DPI minimum |
+| **Format** | PDF (graphs) or TIFF (images) |
+| **Width** | 3.5" (single column) or 7" (double column) |
+| **Line weight** | ≥0.5 pt |
+
+---
+
+## 1. Color Palettes
+
+### Okabe-Ito (Default - Categorical Data ≤8 groups)
+
+```
+#E69F00
+#56B4E9
+#009E73
+#F0E442
+#0072B2
+#D55E00
+#CC79A7
+#999999
+```
+
+**When to use:** Line plots, bar charts, scatter plots, any categorical data
+
+---
+
+### ColorBrewer Set3 (9-12 categories)
+
+```
+#8DD3C7
+#FFFFB3
+#BEBADA
+#FB8072
+#80B1D3
+#FDB462
+#B3DE69
+#FCCDE5
+#D9D9D9
+#BC80BD
+#CCEBC5
+#FFED6F
+```
+
+**When to use:** More than 8 categories needed
+
+---
+
+### PiYG Diverging (Data with midpoint)
+
+```
+#C51B7D
+#DE77AE
+#F1B6DA
+#FDE0EF
+#E6F5D0
+#B8E186
+#7FBC41
+#4D9221
+```
+
+**When to use:** Correlation matrices, positive vs negative values
+**Why:** Avoids red-green, colorblind-safe
+
+---
+
+### BuRd Diverging (Blue-Red)
+
+```
+#2166AC
+#4393C3
+#92C5DE
+#D1E5F0
+#F7F7F7
+#FDDBC7
+#F4A582
+#D6604D
+#B2182B
+```
+
+**When to use:** Temperature data, classic diverging scale
+
+---
+
+### Two-Color Pairs
+
+- **Blue-Orange:** #0072B2 + #E69F00 (most versatile)
+- **Green-Magenta:** #009E73 + #CC79A7
+- **Cyan-Vermillion:** #56B4E9 + #D55E00
+
+**Avoid:** Red-Green combinations (colorblind issue)
+
+---
+
+## 2. Typography
+
+**Font:** Helvetica or Arial (sans-serif only)
+
+**Sizes:**
+- Axis labels: 8 pt
+- Tick labels: 7 pt
+- Legend: 7 pt
+- Panel labels (a,b,c): 8-10 pt bold
+
+**Minimum:** 5 pt (Nature/ACS requirement)
+**Recommended:** 6-8 pt for readability
+
+---
+
+## 3. Resolution & File Formats
+
+**Resolution:**
+- Default: 600 DPI (exceeds all journal minimums)
+- Color images: 300-600 DPI
+- Line art: 600-1200 DPI
+
+**File Formats:**
+- **Graphs/charts:** PDF (vector, preferred) or EPS
+- **Photos/images:** TIFF or PNG
+- **Avoid:** JPEG (lossy compression)
+
+**Key principle:** Use vector formats (PDF/EPS) for graphs - they scale without quality loss
+
+---
+
+## 4. Figure Dimensions
+
+**Standard widths:**
+- **Single column:** 3.5 inches (9 cm)
+- **Double column:** 7 inches (18 cm)
+- **Height:** ≤10 inches
+
+**Journal-specific widths:**
+- Nature: 90mm / 180mm
+- Science: 3.5-7.3 inches
+- ACS: 3.25" / 7"
+- RSC: 8.3cm / 17.1cm
+
+**Design at final print size** to ensure text legibility and correct proportions.
+
+---
+
+## 5. Design Principles
+
+**Do:**
+- Keep simple and uncluttered
+- Use clear axis labels with units (e.g., "Time (s)")
+- Remove unnecessary gridlines
+- Maintain consistency across all figures
+- Ensure line thickness ≥0.5 pt (prefer 1-1.5 pt)
+
+**Avoid:**
+- Red-green color combinations
+- Rainbow colormaps
+- Font sizes <5 pt
+- 3D effects
+- Serif fonts
+- JPEG for graphs
+
+---
+
+## 6. Pre-Submission Checklist
+
+**Format:**
+- [ ] 600 DPI minimum resolution
+- [ ] Vector format with editable text
+
+**Typography:**
+- [ ] Helvetica or Arial used
+- [ ] Font size ≥6 pt
+- [ ] Consistent font across all figures
+
+**Dimensions:**
+- [ ] Width: 3.5" (single) or 7" (double)
+- [ ] Height ≤10 inches
+- [ ] Designed at final size
+
+**Colors:**
+- [ ] Colorblind-safe palette (Okabe-Ito)
+- [ ] No red-green combinations
+
+**Design:**
+- [ ] Clear axis labels with units
+- [ ] Line thickness ≥0.5 pt
+- [ ] No unnecessary decoration
+- [ ] Consistent style
+---
+
+## Workflow
+
+When helping users format figures:
+
+1. **Select color palette:**
+   - ≤8 categories → Okabe-Ito
+   - 9-12 categories → Set3
+   - Diverging data → PiYG or BuRd
+   - 2 colors → Blue-Orange
+2. **Apply standards:**
+   - Font: Helvetica/Arial, 6-8 pt
+   - Resolution: 600 DPI
+   - Width: 3.5" or 7"
+   - Format: PDF (graphs) or TIFF (images)
+3. **Verify design:**
+   - Simple, clear layout
+   - Labels with units
+   - Line weights ≥0.5 pt
+
+---

--- a/creator-skills/codex-skills/sci-slides/SKILL.md
+++ b/creator-skills/codex-skills/sci-slides/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: sci-slides
+description: Use when creating or reviewing scientific presentations, conference talks, lab meetings, journal clubs, or STEM slides involving content density, visual evidence, equations, figures, typography, or cognitive load.
+---
+
+# Scientific Presentation Slides
+
+Evidence-based guidelines for creating effective academic presentations in STEM that respect cognitive principles and enhance audience comprehension.
+
+---
+
+## Overview
+
+This skill provides research-backed guidance for creating scientific presentation slides that communicate complex STEM content effectively. The guidelines are grounded in cognitive load theory, multimedia learning research, and empirical studies of presentation effectiveness.
+
+**Key insight:** 100% of analyzed academic presentations violated basic cognitive principles. Following evidence-based guidelines provides significant competitive advantage while better serving scientific communication.
+
+**When to use this skill:**
+- Creating new academic presentations
+- Reviewing and improving existing slides
+- Adapting publication figures for presentations
+- Presenting equations or technical content
+- Seeking guidance on slide structure and design
+
+---
+
+## Core Design Principle: Assertion-Evidence
+
+**Replace topic headings with full-sentence assertions that state findings.**
+
+Traditional approach (avoid):
+- Slide title: "Results"
+- Content: Bullet points listing observations
+
+Evidence-based approach:
+- Slide headline: "Catalyst efficiency increases 40% at higher temperatures"
+- Content: Supporting graph or visual evidence
+
+**Why this works:**
+- Forces clarity about the actual message
+- Provides clear takeaways even if audience misses narration
+- Eliminates cognitive conflict between reading and listening
+
+**Rule:** Each slide should communicate ONE clear message supported by visual evidence, not bullet points.
+
+---
+
+## Typography & Readability Standards
+
+### Font Requirements
+
+| Element | Specification |
+|---------|---------------|
+| **Minimum size** | 24 pt (28 pt for challenging conditions) |
+| **Font family** | Sans-serif only (Arial, Helvetica, Calibri) |
+| **Contrast** | Dark gray text on white backgrounds |
+
+**Test:** Every slide must be readable from the farthest seat in the presentation room.
+
+### Text Density Limits
+
+| Element | Maximum |
+|---------|---------|
+| **Lines per slide** | 6-9 lines |
+| **Bulleted items per list** | 5 items |
+| **Lines per bullet** | 2 lines |
+| **Words per bullet** | 2-10 words (not complete sentences) |
+
+**Key principle:** Audiences read faster than speakers talk. Text-heavy slides create unsolvable cognitive conflict.
+
+---
+
+## Visual Evidence Guidelines
+
+### Core Rules
+
+1. **Replace text with visual evidence** whenever possible
+2. **One visual message per slide** (respect 3-4 chunk working memory limit)
+3. **Maximize data-ink ratio** - remove decorative elements
+4. **Large, simple figures** over complex multi-panel figures
+5. **Direct annotation** - use arrows and text boxes to guide interpretation
+
+### Adapting Published Figures
+
+**Critical distinction:** Journal figures can include extensive detail because readers control viewing duration. Presentation figures must communicate key findings in seconds.
+
+**Adaptation workflow:**
+1. Identify the specific point the figure should support
+2. Simplify by reducing data series
+3. Enlarge all labels (minimum 24 pt)
+4. Remove secondary information
+5. Consider creating entirely new visualizations focused on the key message
+6. Add direct annotations (arrows, text boxes) highlighting critical features
+
+**Common error:** Copying complex multi-panel figures directly from papers into slides. Audiences lack time to decipher them.
+
+---
+
+## Presenting Data
+
+### Graphs vs Tables
+
+**Strongly prefer graphs** (processed 60,000x faster than text)
+
+**Use graphs for:**
+- Trends over time (line graphs)
+- Relationships between variables (scatter plots)
+- Comparisons between groups (bar charts)
+- Patterns and distributions
+
+**Reserve tables only for:** Exact numerical lookup requirements
+
+### Data Visualization Rules
+
+**Do:**
+- Remove gridlines unless essential for reading values
+- Eliminate 3D effects (distort perception)
+- Remove shadows, gradients, decorative patterns
+- Choose graph types that match the data story
+
+**Avoid:**
+- Software defaults that serve no scientific purpose
+- Misleading scales or inappropriate graph types
+- Excessive chartjunk
+
+---
+
+## Mathematical Content
+
+### Equation Presentation
+
+**Golden rule:** Only include equations explicitly explained during the presentation.
+
+**Best practices:**
+1. **Decompose** complex equations into components
+2. **Discuss each term separately** while graying out others
+3. **Provide plain-language explanations** alongside equations
+4. **Show graphical behavior** through plots demonstrating how the equation works
+5. **Define all terms** both verbally and visually
+6. **Use LaTeX** for equation formatting (import as high-resolution images)
+
+**For short talks:** Minimize equation density. Displaying complex equations without decomposition and explanation fails to communicate.
+
+---
+
+## Cognitive Science Foundations
+
+### Working Memory Limitations
+
+**Key constraint:** Humans can hold only 3-4 chunks of information simultaneously in working memory.
+
+**Implication:** Text-heavy slides + narration = cognitive overload on the same mental resources.
+
+**Solution:** Employ dual modality by combining visual graphics (processed by visual channel) with auditory narration (processed by verbal channel).
+
+### Retention Research
+
+After three days:
+- **10% retention** from purely verbal presentations
+- **35% retention** from purely visual presentations
+- **65% retention** from combined verbal and visual presentations
+
+**Mayer's Key Principles:**
+1. **Redundancy principle:** Graphics + narration outperform graphics + narration + identical text
+2. **Coherence principle:** Extraneous elements interfere with learning
+3. **Multimedia principle:** Words + pictures significantly outperform words alone
+
+---
+
+## Critical Mistakes to Avoid
+
+### 1. Excessive Text
+
+**Problem:** Creates cognitive conflict - audiences read in 10 seconds, then face boredom or divided attention.
+
+**Solution:** Limit to 6-9 lines maximum, or replace with visual evidence.
+
+### 2. Reading From Slides
+
+**Problem:** Signals poor preparation; written prose sounds pompous when read aloud.
+
+**Solution:** Use conversational language in delivery; slides should support, not script, the talk.
+
+### 3. Unreadable Content
+
+**Problems:**
+- Fonts below 24 pt
+- Insufficient contrast
+- Acknowledging "I know you can't read this"
+
+**Solution:** Test readability from the farthest seat. Never present unreadable content.
+
+### 4. Decorative Elements
+
+**Problem:** "Seductive details" (clip art, background patterns, sound effects) interfere with message retention. Audiences remember decoration instead of findings.
+
+**Solution:** Remove all elements that don't convey scientific information.
+
+### 5. Assuming Specialized Knowledge
+
+**Problem:** Using jargon or acronyms without definition, even at specialized conferences.
+
+**Solution:** Define technical terms on first use. Mixed expertise levels exist in all audiences.
+
+---
+
+## Workflow
+
+When helping users create or review scientific presentations:
+
+### 1. Structure Development
+- Identify 2-5 clear messages audiences should remember
+- Create full-sentence assertion headlines for each message
+- Determine visual evidence that supports each assertion
+
+### 2. Apply Design Standards
+- Font: Sans-serif, minimum 24 pt
+- Text: Maximum 6-9 lines, 5 bullets, 2 lines per bullet
+- Visuals: Simplify published figures, annotate directly
+- Equations: Only include if explicitly explaining; decompose complex ones
+
+### 3. Content Review
+- Remove decorative elements
+- Replace text with visual evidence where possible
+- Verify one message per slide
+- Check readability from back row
+
+### 4. Cognitive Load Check
+- Does the slide respect 3-4 chunk working memory limit?
+- Is there cognitive conflict between reading and listening?
+- Are verbal and visual channels used effectively?
+
+### 5. Mistake Prevention
+- [ ] No text-heavy slides (≤6-9 lines)
+- [ ] No reading from slides (conversational delivery)
+- [ ] All content readable from back row
+- [ ] No decorative elements
+- [ ] All jargon defined
+
+---
+
+## Success Criteria
+
+A well-designed scientific presentation:
+- Has 2-5 clear messages audiences will remember
+- Uses full-sentence assertion headlines
+- Presents visual evidence, not text bullets
+- Respects working memory limitations (3-4 chunks)
+- Is readable from the back row
+- Eliminates decorative elements
+- Adapts published figures for quick comprehension
+- Explains equations explicitly or omits them
+- Maintains engagement through variety and enthusiasm

--- a/dev-skills/.codex-plugin/plugin.json
+++ b/dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Development workflow skills for Codex.",
   "author": {
     "name": "Steven",
@@ -16,13 +16,15 @@
     "pressure-test",
     "critic",
     "review",
-    "workflow"
+    "workflow",
+    "file-naming",
+    "organization"
   ],
   "skills": "./codex-skills/",
   "interface": {
     "displayName": "Dev Skills",
     "shortDescription": "Codex-ready development workflow skills.",
-    "longDescription": "Use Dev Skills for selected development workflows, including measurable goal rubrics, current-truth documentation updates, and independent adversarial pressure tests.",
+    "longDescription": "Use Dev Skills for measurable goal rubrics, current-truth documentation updates, independent adversarial pressure tests, and sequential file organization.",
     "developerName": "Steven",
     "category": "Developer Tools",
     "capabilities": [
@@ -32,7 +34,8 @@
     "defaultPrompt": [
       "Draft a measurable /goal rubric.",
       "Update existing documentation to current truth.",
-      "Pressure-test this plan before implementation."
+      "Pressure-test this plan before implementation.",
+      "Organize this feature with numbered step-based file names."
     ]
   }
 }

--- a/dev-skills/codex-skills/step-workflow/SKILL.md
+++ b/dev-skills/codex-skills/step-workflow/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: step-workflow
+description: Use when the user requests step-based file naming and folder organization for a new feature, including sequential numbered prefixes, sub-step notation, and plan tracking across scripts, outputs, tests, or documentation.
+---
+
+# Step-Based Workflow Organization
+
+## Overview
+
+Organize all work for a feature using step-based file naming with numbered
+prefixes. Apply this convention only when the user requests it and it does not
+conflict with an established repository layout or naming convention.
+
+## File Naming Convention
+
+### Basic Pattern
+
+```text
+<step_number>_<descriptive_name>.<extension>
+```
+
+Examples:
+
+- `01_load_data.py`
+- `02_clean_data.py`
+- `03_analysis.ipynb`
+- `04_results.csv`
+
+### Sub-Steps
+
+When a step has multiple related files:
+
+```text
+<step>_<substep>_<descriptive_name>.<extension>
+```
+
+Examples:
+
+- `01_1_fetch_api.py`
+- `01_2_parse_response.py`
+- `02_1_clean_text.py`
+- `02_2_clean_numbers.py`
+
+### Leading Zeros
+
+Use leading zeros based on the expected number of steps:
+
+- 10–99 steps: `01`, `02`, ..., `99`
+- 100–999 steps: `001`, `002`, ..., `999`
+
+This ensures proper alphabetical sorting.
+
+## Workflow Rules
+
+1. **Respect repository conventions** - Apply step-based names only when the
+   user requests them and they do not conflict with established project layout
+2. **Keep related artifacts together** - Keep files for the feature in its
+   feature folder while preserving the repository's expected subdirectories
+3. **Number files sequentially** - Order prefixes by execution or workflow
+4. **Use underscores, not spaces** - Keep file names shell- and tool-friendly
+5. **Track the numbered work with `update_plan`** - Map each plan item to its
+   corresponding step and keep exactly one item in progress
+6. **Renumber when needed** - Restore a clear sequence after inserting or
+   reordering steps
+
+## Plan Integration
+
+Each plan item corresponds to a numbered step:
+
+```text
+1. [in_progress] Load data (01_load_data.py)
+2. [pending] Clean data (02_clean_data.py)
+3. [pending] Run analysis (03_analysis.py)
+```
+
+Use `update_plan` as the work advances so file order and task state remain
+aligned.

--- a/dev-skills/codex-skills/step-workflow/SKILL.md
+++ b/dev-skills/codex-skills/step-workflow/SKILL.md
@@ -59,7 +59,8 @@ This ensures proper alphabetical sorting.
 3. **Number files sequentially** - Order prefixes by execution or workflow
 4. **Use underscores, not spaces** - Keep file names shell- and tool-friendly
 5. **Track the numbered work with `update_plan`** - Map each plan item to its
-   corresponding step and keep exactly one item in progress
+   corresponding step, keep at most one item in progress, and leave none in
+   progress after completion
 6. **Renumber when needed** - Restore a clear sequence after inserting or
    reordering steps
 

--- a/docs/superpowers/plans/2026-07-18-creator-skills-codex-native.md
+++ b/docs/superpowers/plans/2026-07-18-creator-skills-codex-native.md
@@ -228,9 +228,9 @@ Run:
 jq . creator-skills/.codex-plugin/plugin.json >/dev/null
 jq . dev-skills/.codex-plugin/plugin.json >/dev/null
 jq . .agents/plugins/marketplace.json >/dev/null
-python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py creator-skills/codex-skills/sci-slides
-python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py creator-skills/codex-skills/sci-figure-format
-python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py dev-skills/codex-skills/step-workflow
+python "${CODEX_HOME:-${HOME}/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" creator-skills/codex-skills/sci-slides
+python "${CODEX_HOME:-${HOME}/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" creator-skills/codex-skills/sci-figure-format
+python "${CODEX_HOME:-${HOME}/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" dev-skills/codex-skills/step-workflow
 ```
 
 Expected: all commands exit `0`.

--- a/docs/superpowers/plans/2026-07-18-creator-skills-codex-native.md
+++ b/docs/superpowers/plans/2026-07-18-creator-skills-codex-native.md
@@ -1,0 +1,360 @@
+# Creator Skills and Step Workflow Codex-native Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add native Codex support for `sci-slides`, `sci-figure-format`, and
+`step-workflow`, with registry-level proof that Codex loads all three skills
+from installed plugin caches.
+
+**Architecture:** Keep the Claude and Codex skill surfaces separate. Add a new
+Codex manifest and `codex-skills/` tree to `creator-skills`, extend the existing
+`dev-skills/codex-skills/` tree, and advertise only the new plugin through the
+repository's Codex marketplace. Validate custom skill roots directly and use an
+isolated Codex home plus app-server `skills/list` for native discovery proof.
+
+**Tech Stack:** JSON plugin manifests, Markdown `SKILL.md` files with YAML
+frontmatter, `jq`, the skill-creator validator, Python standard library, Codex
+CLI/app-server.
+
+## Global Constraints
+
+- Work in `trees/feat-175-codex-creator-skills` on branch
+  `feat-175-codex-creator-skills` for issue #175.
+- Do not modify either `.claude-plugin/plugin.json` or any file under
+  `creator-skills/skills/` or `dev-skills/skills/`.
+- Preserve the scientific skill bodies; change only their Codex frontmatter.
+- Adapt `step-workflow` only where Codex requires it: trigger wording,
+  `update_plan`, and repository-convention precedence.
+- Use `creator-skills` version `1.0.1` and bump the Codex `dev-skills` manifest
+  from `1.0.0` to `1.0.1`.
+- Do not use the bundled generic plugin validator; it rejects the repository's
+  supported `./codex-skills/` layout. Use the explicit contract checks below.
+- Keep commits, issue text, and any PR text free of AI attribution. Do not add a
+  test-plan section to a PR description.
+
+---
+
+### Task 1: Establish failing packaging and behavior baselines
+
+**Files:**
+
+- Inspect: `creator-skills/.codex-plugin/plugin.json`
+- Inspect: `creator-skills/codex-skills/`
+- Inspect: `dev-skills/codex-skills/step-workflow/SKILL.md`
+- Inspect: `.agents/plugins/marketplace.json`
+
+**Interfaces:**
+
+- Consumes: the pre-migration branch state.
+- Produces: failing checks and no-skill behavior samples proving the native
+  surface is absent.
+
+- [ ] **Step 1: Run the desired-state packaging assertion**
+
+Run:
+
+```bash
+python - <<'PY'
+import json
+from pathlib import Path
+
+root = Path.cwd()
+assert (root / "creator-skills/.codex-plugin/plugin.json").is_file()
+assert (root / "creator-skills/codex-skills/sci-slides/SKILL.md").is_file()
+assert (root / "creator-skills/codex-skills/sci-figure-format/SKILL.md").is_file()
+assert (root / "dev-skills/codex-skills/step-workflow/SKILL.md").is_file()
+
+marketplace = json.loads((root / ".agents/plugins/marketplace.json").read_text())
+assert sum(plugin["name"] == "creator-skills" for plugin in marketplace["plugins"]) == 1
+PY
+```
+
+Expected: exits nonzero on the missing creator Codex manifest before checking
+the later assertions.
+
+- [ ] **Step 2: Capture no-skill behavior baselines**
+
+Use fresh read-only subagents without loading the source skills. Give them one
+scenario each:
+
+1. Review a dense scientific results slide with 11 lines of 18-point text, a
+   complex six-panel journal figure, and three unexplained equations.
+2. Specify publication formatting for a 10-category Nature single-column
+   scientific figure, including size, palette, font, format, resolution, and
+   line weight.
+3. Organize a new data-analysis feature into sequential scripts, outputs,
+   tests, and documentation with explicit file names.
+
+Record which skill-specific rules are absent or inconsistent. These are
+content baselines only; Task 3 supplies native loader proof.
+
+---
+
+### Task 2: Add the native plugin and three Codex skills
+
+**Files:**
+
+- Create: `creator-skills/.codex-plugin/plugin.json`
+- Create: `creator-skills/codex-skills/sci-slides/SKILL.md`
+- Create: `creator-skills/codex-skills/sci-figure-format/SKILL.md`
+- Create: `dev-skills/codex-skills/step-workflow/SKILL.md`
+- Modify: `dev-skills/.codex-plugin/plugin.json`
+- Modify: `.agents/plugins/marketplace.json`
+
+**Interfaces:**
+
+- Consumes: the approved design and existing Claude skill bodies.
+- Produces: two installable native plugin versions and three Codex-valid skills.
+
+- [ ] **Step 1: Add the creator Codex manifest**
+
+Create `creator-skills/.codex-plugin/plugin.json`:
+
+```json
+{
+  "name": "creator-skills",
+  "version": "1.0.1",
+  "description": "Scientific content creation skills for Codex.",
+  "author": {
+    "name": "Steven",
+    "email": "aeghnnsw@users.noreply.github.com"
+  },
+  "repository": "https://github.com/aeghnnsw/cc-toolkit",
+  "license": "MIT",
+  "keywords": [
+    "science",
+    "scientific",
+    "presentation",
+    "slides",
+    "figures",
+    "visualization",
+    "publication"
+  ],
+  "skills": "./codex-skills/",
+  "interface": {
+    "displayName": "Creator Skills",
+    "shortDescription": "Codex-ready scientific slides and figure guidance.",
+    "longDescription": "Use Creator Skills to design scientific presentations and format publication-quality scientific figures.",
+    "developerName": "Steven",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Design an effective scientific presentation.",
+      "Review these academic slides.",
+      "Format this scientific figure for publication."
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Add the Codex scientific skills**
+
+For `creator-skills/codex-skills/sci-slides/SKILL.md`, preserve the existing
+body from `creator-skills/skills/sci-slides/SKILL.md` byte-for-byte after the
+closing frontmatter delimiter and use exactly:
+
+```yaml
+---
+name: sci-slides
+description: Use when creating or reviewing scientific presentations, conference talks, lab meetings, journal clubs, or STEM slides involving content density, visual evidence, equations, figures, typography, or cognitive load.
+---
+```
+
+For `creator-skills/codex-skills/sci-figure-format/SKILL.md`, preserve the
+existing body after frontmatter and use exactly:
+
+```yaml
+---
+name: sci-figure-format
+description: Use when creating or reviewing scientific figures for publication, including journal dimensions, resolution, file formats, typography, line weights, colorblind-safe palettes, and Nature, Science, ACS, or RSC requirements.
+---
+```
+
+- [ ] **Step 3: Add the Codex step workflow**
+
+Create `dev-skills/codex-skills/step-workflow/SKILL.md`. Preserve the numbered
+file and sub-step patterns from the Claude skill. Use only `name` and a
+`Use when` description in frontmatter. Replace the `TodoWrite` requirement and
+section with `update_plan`, and add this precedence rule:
+
+```markdown
+1. **Respect repository conventions** - Apply step-based names only when the
+   user requests them and they do not conflict with established project layout
+```
+
+The remaining workflow rules must keep files together, number them by workflow
+order, use underscores, track progress with `update_plan`, and renumber when
+needed.
+
+- [ ] **Step 4: Version and advertise the expanded dev plugin**
+
+In `dev-skills/.codex-plugin/plugin.json`:
+
+- change `version` to `1.0.1`;
+- add `file-naming` and `organization` keywords;
+- mention sequential file organization in `interface.longDescription`;
+- append `Organize this feature with numbered step-based file names.` to
+  `interface.defaultPrompt`.
+
+Do not change the plugin identity, paths, category, or capabilities.
+
+- [ ] **Step 5: Add creator-skills to the Codex marketplace**
+
+Append this entry after `task-loop` in `.agents/plugins/marketplace.json`:
+
+```json
+{
+  "name": "creator-skills",
+  "source": {
+    "source": "local",
+    "path": "./creator-skills"
+  },
+  "policy": {
+    "installation": "AVAILABLE",
+    "authentication": "ON_INSTALL"
+  },
+  "category": "Productivity"
+}
+```
+
+- [ ] **Step 6: Run fast structural checks**
+
+Run:
+
+```bash
+jq . creator-skills/.codex-plugin/plugin.json >/dev/null
+jq . dev-skills/.codex-plugin/plugin.json >/dev/null
+jq . .agents/plugins/marketplace.json >/dev/null
+python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py creator-skills/codex-skills/sci-slides
+python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py creator-skills/codex-skills/sci-figure-format
+python /Users/steven/.codex/skills/.system/skill-creator/scripts/quick_validate.py dev-skills/codex-skills/step-workflow
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 7: Commit the native package**
+
+```bash
+git add .agents/plugins/marketplace.json creator-skills/.codex-plugin creator-skills/codex-skills dev-skills/.codex-plugin/plugin.json dev-skills/codex-skills/step-workflow
+git commit -m "Add Codex-native creator and step workflow skills"
+```
+
+---
+
+### Task 3: Prove package contracts and native registry loading
+
+**Files:**
+
+- Verify: all Task 2 files
+- Verify unchanged: `creator-skills/.claude-plugin/`
+- Verify unchanged: `creator-skills/skills/`
+- Verify unchanged: `dev-skills/.claude-plugin/`
+- Verify unchanged: `dev-skills/skills/`
+
+**Interfaces:**
+
+- Consumes: the completed native package.
+- Produces: executable evidence for manifest correctness, installed versions,
+  namespaced skill registration, and skill-specific behavior.
+
+- [ ] **Step 1: Run the explicit package contract**
+
+Run a Python standard-library assertion that loads both Codex manifests and the
+marketplace, resolves each declared skill root relative to its plugin, proves
+the root stays within the plugin, and checks:
+
+- creator root directories equal `sci-figure-format` and `sci-slides`;
+- dev root contains `step-workflow`;
+- each target folder equals its frontmatter `name`;
+- target frontmatter keys equal `name` and `description`;
+- creator marketplace count is one with the approved path, policies, and
+  category;
+- creator version is `1.0.1` and dev version is `1.0.1`;
+- no target Codex skill contains `TodoWrite` or a `version:` frontmatter field.
+
+Expected: exits `0` and prints `package contract passed`.
+
+- [ ] **Step 2: Prove the Claude surfaces are unchanged**
+
+Run:
+
+```bash
+base=$(git merge-base HEAD master)
+git diff --exit-code "$base" -- creator-skills/.claude-plugin creator-skills/skills dev-skills/.claude-plugin dev-skills/skills
+```
+
+Expected: no output, exit `0`.
+
+- [ ] **Step 3: Install into an isolated Codex home**
+
+Use Python `tempfile.TemporaryDirectory` and a subprocess environment containing
+that directory as `CODEX_HOME`. Within that environment:
+
+1. Run `codex plugin marketplace add <worktree> --json`.
+2. Run `codex plugin list --marketplace cc-toolkit --available --json` and
+   assert creator `1.0.1` and dev `1.0.1` are discoverable.
+3. Run `codex plugin add creator-skills@cc-toolkit --json`.
+4. Run `codex plugin add dev-skills@cc-toolkit --json`.
+
+Expected: both installations succeed and the installed metadata reports the
+expected versions.
+
+- [ ] **Step 4: Query native `skills/list` in the same isolated home**
+
+Start `codex app-server --stdio` with the Step 3 environment. Send newline-
+delimited JSON messages in this order:
+
+```json
+{"id":1,"method":"initialize","params":{"clientInfo":{"name":"cc-toolkit-smoke","version":"1.0.0"}}}
+{"method":"initialized"}
+{"id":2,"method":"skills/list","params":{"cwds":["<absolute-worktree>"],"forceReload":true}}
+```
+
+Wait for response `id: 2`, then assert:
+
+- no returned entry contains errors;
+- enabled registry names include exactly the target names
+  `creator-skills:sci-slides`, `creator-skills:sci-figure-format`, and
+  `dev-skills:step-workflow`;
+- creator paths contain
+  `/creator-skills/1.0.1/codex-skills/<skill>/SKILL.md`;
+- the dev path contains
+  `/dev-skills/1.0.1/codex-skills/step-workflow/SKILL.md`;
+- all three paths are inside the isolated Codex home;
+- none resolves under either Claude `skills/` tree.
+
+Terminate the app server in `finally`. Expected: print the three registered
+names and exit `0`.
+
+- [ ] **Step 5: Forward-test each skill's behavior**
+
+Use fresh read-only subagents, explicitly loading one new Codex `SKILL.md` per
+matching Task 1 scenario. Confirm:
+
+- `sci-slides` supplies its concrete density, typography, figure, and equation
+  corrections;
+- `sci-figure-format` supplies journal-aware dimensions, palette, font, format,
+  resolution, and line-weight guidance;
+- `step-workflow` supplies leading-zero step and sub-step names, keeps related
+  artifacts together, uses `update_plan`, and respects existing repo
+  conventions.
+
+Compare each result with its no-skill baseline. Expected: all skill-specific
+requirements are present without Claude-only tool references.
+
+- [ ] **Step 6: Run final repository checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git log --oneline --decorate -3
+```
+
+Expected: no whitespace errors; only intentional plan/spec/package changes are
+present; the design, pressure-test, plan, and implementation commits are at the
+branch tip.

--- a/docs/superpowers/specs/2026-07-18-creator-skills-codex-native-conclusion.md
+++ b/docs/superpowers/specs/2026-07-18-creator-skills-codex-native-conclusion.md
@@ -1,0 +1,60 @@
+# Creator Skills and Step Workflow Pressure-Test Conclusion
+
+## Settled Position
+
+Proceed with a Codex-native `creator-skills` package containing `sci-slides`
+and `sci-figure-format`, and add a Codex-native `step-workflow` to the existing
+`dev-skills` package. Keep the Claude skill trees unchanged, use the established
+`codex-skills/` layout, register `creator-skills` in the Codex marketplace, and
+bump the Codex `dev-skills` manifest from `1.0.0` to `1.0.1`.
+
+Native support is accepted only when an isolated Codex installation registers
+all three namespaced skills through `skills/list` from the installed
+`codex-skills/` trees.
+
+## Decisions
+
+- Use separate Codex skill trees rather than sharing the Claude files.
+- Preserve the existing scientific guidance while normalizing frontmatter.
+- Replace `TodoWrite` with `update_plan` in the Codex step workflow.
+- Do not let `step-workflow` override established repository structure or
+  naming conventions.
+- Exclude the generic plugin validator because it incorrectly hard-codes the
+  default `skills/` root; validate the declared roots directly instead.
+- Verify registry loading, namespacing, installed paths, and loader errors with
+  the app server rather than treating installation or file presence as proof.
+- Version-bump `dev-skills` so existing installations receive a new cache entry.
+
+## Objections and Dispositions
+
+### Round 1: Validator contract mismatch
+
+The generic plugin validator rejects `./codex-skills/`, even though that is the
+working repository pattern. Agreed. The design now uses explicit executable
+checks for relative, contained skill roots, expected directories, and matching
+frontmatter names.
+
+### Round 2: Installation does not prove native discovery
+
+Installing a plugin and observing its files does not prove Codex loaded its
+skills. Agreed. The design now calls `skills/list` in the same isolated Codex
+home and asserts exact namespaced registry entries, installed native paths, and
+the absence of loader errors or Claude-tree paths.
+
+### Round 3: Existing `dev-skills` users could remain on a stale cache
+
+Adding `step-workflow` without changing `dev-skills` version would prove only a
+clean install and could leave existing `1.0.0` caches unchanged. Agreed. The
+Codex manifest advances to `1.0.1`, and validation asserts that installed
+version.
+
+### Round 4: Convergence
+
+The critic returned `NO SUBSTANTIVE OBJECTION`, finding the revised design
+decision-complete across versioned delivery, native discovery, platform
+adaptation, marketplace packaging, validation, and Claude-tree non-regression.
+
+## Ending Condition
+
+Pressure testing ended by convergence after three substantive objections were
+resolved and the next review found no remaining substantive objection.

--- a/docs/superpowers/specs/2026-07-18-creator-skills-codex-native-design.md
+++ b/docs/superpowers/specs/2026-07-18-creator-skills-codex-native-design.md
@@ -1,0 +1,152 @@
+# Creator Skills Codex-native Migration Design
+
+## Goal
+
+Make `creator-skills` installable as a native Codex plugin for issue #175 and
+expose Codex-adjusted versions of both existing scientific-content skills:
+
+- `sci-slides`
+- `sci-figure-format`
+
+The Claude plugin and its existing skill tree remain unchanged.
+
+## Context
+
+`creator-skills` currently has a Claude manifest at
+`creator-skills/.claude-plugin/plugin.json` and two skills under
+`creator-skills/skills/`. Codex-native plugins in this repository use a separate
+`.codex-plugin/plugin.json`, a dedicated `codex-skills/` tree when platform
+instructions may diverge, and a repo marketplace entry in
+`.agents/plugins/marketplace.json`.
+
+`dev-skills` and `task-loop` establish the repository pattern. This migration
+uses that pattern instead of pointing both runtimes at the same skill files.
+
+## Scope
+
+In scope:
+
+- Add `creator-skills/.codex-plugin/plugin.json`.
+- Add Codex-native `sci-slides` and `sci-figure-format` skills under
+  `creator-skills/codex-skills/`.
+- Add `creator-skills` to `.agents/plugins/marketplace.json`.
+- Validate skill frontmatter, plugin metadata, paths, and marketplace metadata.
+- Forward-test each Codex skill on a representative scientific-content task.
+
+Out of scope:
+
+- Changing the Claude manifest or `creator-skills/skills/` content.
+- Rewriting or re-sourcing the scientific guidance.
+- Adding slide-generation scripts, presentation templates, icons, MCP servers,
+  hooks, apps, or other plugin components.
+- Migrating other plugins.
+
+## Alternatives Considered
+
+### Separate Codex skill tree
+
+Add `codex-skills/` and point the Codex manifest at it. This duplicates the two
+skill documents, but it isolates platform-specific frontmatter and future Codex
+workflow changes. This is the selected approach because it matches existing
+native plugins in the repository.
+
+### Shared skill tree
+
+Point both Claude and Codex manifests at `skills/`. This minimizes duplication
+but couples the runtimes and leaves the current Claude-oriented frontmatter in
+the Codex package.
+
+### Platform-neutral rewrite
+
+Rewrite the existing skills as one shared, neutral implementation. This could
+reduce long-term duplication but expands the migration into a Claude behavior
+change and risks unnecessary regressions.
+
+## Package Structure
+
+```text
+creator-skills/
+|-- .claude-plugin/
+|   `-- plugin.json
+|-- .codex-plugin/
+|   `-- plugin.json
+|-- skills/
+|   |-- sci-figure-format/
+|   |   `-- SKILL.md
+|   `-- sci-slides/
+|       `-- SKILL.md
+`-- codex-skills/
+    |-- sci-figure-format/
+    |   `-- SKILL.md
+    `-- sci-slides/
+        `-- SKILL.md
+```
+
+## Codex Plugin Manifest
+
+The native manifest will:
+
+- use the plugin identity `creator-skills`;
+- keep version `1.0.1`, matching the current Claude plugin;
+- point `skills` to `./codex-skills/`;
+- include author, repository, license, discovery keywords, and interface
+  metadata following the `dev-skills` and `task-loop` manifests;
+- use the `Productivity` category and `Read`/`Write` capabilities;
+- offer starter prompts for scientific slide design and figure formatting.
+
+The manifest will not declare components that do not exist.
+
+## Codex Skills
+
+Each Codex skill will preserve the current domain guidance and workflow while
+using Codex-valid skill metadata:
+
+- YAML frontmatter contains only `name` and `description`.
+- Each description begins with `Use when` and names concrete triggering tasks.
+- The unsupported `version` frontmatter field is omitted.
+- Claude-specific wording is not introduced.
+
+The migration will not alter numerical claims, design standards, palettes,
+format recommendations, or other scientific content. Content modernization is
+a separate concern.
+
+## Marketplace Entry
+
+Append `creator-skills` to the existing ordered plugin list in
+`.agents/plugins/marketplace.json` with:
+
+- local source path `./creator-skills`, matching this repository's established
+  marketplace layout;
+- installation policy `AVAILABLE`;
+- authentication policy `ON_INSTALL`;
+- category `Productivity`.
+
+The existing marketplace name and plugin order remain unchanged.
+
+## Validation
+
+Use a red-green validation cycle:
+
+1. Confirm packaging checks fail before the Codex manifest, skill tree, and
+   marketplace entry exist.
+2. Add the minimum native package files.
+3. Run the skill creator validator for both Codex skill directories.
+4. Run the plugin creator validator against `creator-skills`.
+5. Validate all changed JSON with `jq` and verify every manifest path exists.
+6. Confirm the native marketplace contains exactly one `creator-skills` entry.
+7. Forward-test `sci-slides` with a slide-design scenario and
+   `sci-figure-format` with a publication-figure scenario.
+
+Forward tests are read-only and verify that each skill retrieves and applies
+its specific guidance. They do not create durable presentation artifacts.
+
+## Acceptance Criteria
+
+- `creator-skills/.codex-plugin/plugin.json` passes plugin validation and points
+  to `./codex-skills/`.
+- Both Codex skills pass skill validation and contain no unsupported
+  frontmatter fields.
+- `.agents/plugins/marketplace.json` contains one valid `creator-skills` entry.
+- Existing Claude files remain byte-for-byte unchanged.
+- Representative forward tests show that each Codex skill applies its
+  domain-specific guidance.

--- a/docs/superpowers/specs/2026-07-18-creator-skills-codex-native-design.md
+++ b/docs/superpowers/specs/2026-07-18-creator-skills-codex-native-design.md
@@ -1,4 +1,4 @@
-# Creator Skills Codex-native Migration Design
+# Creator Skills and Step Workflow Codex-native Migration Design
 
 ## Goal
 
@@ -8,7 +8,10 @@ expose Codex-adjusted versions of both existing scientific-content skills:
 - `sci-slides`
 - `sci-figure-format`
 
-The Claude plugin and its existing skill tree remain unchanged.
+Also expose the existing `step-workflow` file-naming convention through the
+already-native `dev-skills` plugin.
+
+Both plugins' Claude skill trees remain unchanged.
 
 ## Context
 
@@ -21,6 +24,8 @@ instructions may diverge, and a repo marketplace entry in
 
 `dev-skills` and `task-loop` establish the repository pattern. This migration
 uses that pattern instead of pointing both runtimes at the same skill files.
+`dev-skills` already has a Codex manifest and marketplace entry, but its Codex
+skill tree does not yet contain `step-workflow`.
 
 ## Scope
 
@@ -30,16 +35,17 @@ In scope:
 - Add Codex-native `sci-slides` and `sci-figure-format` skills under
   `creator-skills/codex-skills/`.
 - Add `creator-skills` to `.agents/plugins/marketplace.json`.
+- Add a Codex-adjusted `step-workflow` under `dev-skills/codex-skills/`.
 - Validate skill frontmatter, plugin metadata, paths, and marketplace metadata.
-- Forward-test each Codex skill on a representative scientific-content task.
+- Forward-test all three Codex skills on representative tasks.
 
 Out of scope:
 
-- Changing the Claude manifest or `creator-skills/skills/` content.
+- Changing either Claude manifest or either plugin's `skills/` content.
 - Rewriting or re-sourcing the scientific guidance.
 - Adding slide-generation scripts, presentation templates, icons, MCP servers,
   hooks, apps, or other plugin components.
-- Migrating other plugins.
+- Migrating any other skill or plugin.
 
 ## Alternatives Considered
 
@@ -80,6 +86,14 @@ creator-skills/
     |   `-- SKILL.md
     `-- sci-slides/
         `-- SKILL.md
+
+dev-skills/
+|-- .codex-plugin/
+|   `-- plugin.json
+`-- codex-skills/
+    |-- ...
+    `-- step-workflow/
+        `-- SKILL.md
 ```
 
 ## Codex Plugin Manifest
@@ -110,6 +124,20 @@ The migration will not alter numerical claims, design standards, palettes,
 format recommendations, or other scientific content. Content modernization is
 a separate concern.
 
+## Codex Step Workflow
+
+The Codex version of `step-workflow` will preserve the numbered file and
+sub-step naming conventions while adjusting runtime-specific instructions:
+
+- YAML frontmatter contains only `name` and a `Use when` description.
+- `TodoWrite` references are replaced with Codex's `update_plan` workflow.
+- The skill applies when the user requests sequential, step-based organization;
+  it does not override an existing repository layout or naming convention.
+- `dev-skills/.codex-plugin/plugin.json` is updated so its discovery metadata
+  mentions the newly available workflow.
+- The Codex plugin version advances from `1.0.0` to `1.0.1` so existing native
+  installations receive a new version-keyed cache entry containing the skill.
+
 ## Marketplace Entry
 
 Append `creator-skills` to the existing ordered plugin list in
@@ -122,6 +150,8 @@ Append `creator-skills` to the existing ordered plugin list in
 - category `Productivity`.
 
 The existing marketplace name and plugin order remain unchanged.
+The existing `dev-skills` marketplace entry already covers `step-workflow` and
+does not need a second entry.
 
 ## Validation
 
@@ -130,23 +160,56 @@ Use a red-green validation cycle:
 1. Confirm packaging checks fail before the Codex manifest, skill tree, and
    marketplace entry exist.
 2. Add the minimum native package files.
-3. Run the skill creator validator for both Codex skill directories.
-4. Run the plugin creator validator against `creator-skills`.
-5. Validate all changed JSON with `jq` and verify every manifest path exists.
-6. Confirm the native marketplace contains exactly one `creator-skills` entry.
-7. Forward-test `sci-slides` with a slide-design scenario and
-   `sci-figure-format` with a publication-figure scenario.
+3. Run the skill creator validator for all three Codex skill directories.
+4. Validate all changed JSON with `jq` and run an executable manifest contract
+   check that proves the declared skill root is relative, remains inside the
+   plugin, contains exactly the two expected creator skill directories, and has
+   folder names matching each skill's frontmatter `name`. Separately confirm
+   that the existing `dev-skills` root contains `step-workflow` with matching
+   folder and frontmatter names.
+5. Confirm the native marketplace contains exactly one `creator-skills` entry.
+6. Use an isolated temporary Codex home to add the worktree as a local
+   marketplace, discover `creator-skills` through `codex plugin list`, and
+   install it with `codex plugin add`.
+7. Start `codex app-server --stdio` with that same isolated Codex home and call
+   `skills/list` for the worktree with `forceReload: true`. Assert that the
+   registry contains the enabled namespaced skills
+   `creator-skills:sci-slides` and `creator-skills:sci-figure-format`, that
+   their paths originate under the isolated installed plugin cache and its
+   `codex-skills/` tree, that neither path resolves to the Claude `skills/`
+   tree, and that the response contains no skill-loading errors. In the same
+   isolated home, install `dev-skills` and assert that the registry contains
+   enabled `dev-skills:step-workflow` from its installed `1.0.1` native
+   `codex-skills/` tree.
+8. Forward-test `sci-slides` with a slide-design scenario,
+   `sci-figure-format` with a publication-figure scenario, and `step-workflow`
+   with a request for sequential feature-file naming.
 
 Forward tests are read-only and verify that each skill retrieves and applies
-its specific guidance. They do not create durable presentation artifacts.
+its specific guidance. They do not create durable presentation artifacts and
+do not substitute for the native-loader discovery smoke test.
+
+The bundled plugin-creator validator is not part of this migration's contract:
+its current implementation hard-codes `skills/` and rejects the repository's
+working `./codex-skills/` manifest pattern. The explicit contract check and
+isolated Codex loader test validate the package that this repository actually
+ships.
 
 ## Acceptance Criteria
 
-- `creator-skills/.codex-plugin/plugin.json` passes plugin validation and points
-  to `./codex-skills/`.
-- Both Codex skills pass skill validation and contain no unsupported
+- `creator-skills/.codex-plugin/plugin.json` passes the explicit manifest
+  contract checks and points to `./codex-skills/`.
+- Both creator Codex skills pass skill validation and contain no unsupported
   frontmatter fields.
+- The Codex `step-workflow` passes skill validation, preserves the file-naming
+  convention, uses Codex planning terminology, and is discoverable through the
+  version-bumped `dev-skills` package.
 - `.agents/plugins/marketplace.json` contains one valid `creator-skills` entry.
-- Existing Claude files remain byte-for-byte unchanged.
-- Representative forward tests show that each Codex skill applies its
+- An isolated Codex loader discovers and installs `creator-skills` from the
+  repository marketplace, and `skills/list` registers both namespaced native
+  skills from the installed `codex-skills/` tree without loader errors. The
+  same check registers `dev-skills:step-workflow` from the installed native
+  `dev-skills` `1.0.1` tree.
+- Existing Claude files for both plugins remain byte-for-byte unchanged.
+- Representative forward tests show that all three Codex skills apply their
   domain-specific guidance.


### PR DESCRIPTION
Adds native Codex support for the scientific creator skills and step-based file organization.

- registers `creator-skills` in the Codex marketplace
- adds `sci-slides` and `sci-figure-format` Codex skills
- adds `step-workflow` to `dev-skills` and bumps it to 1.0.1
- keeps the Claude skill trees unchanged

Closes #175