### PR TITLE
Add native Codex support for productivity-skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -48,6 +48,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity"
+    },
+    {
+      "name": "productivity-skills",
+      "source": {
+        "source": "local",
+        "path": "./productivity-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- productivity-skills: add native Codex support for all seven Calendar, Reminders, and GTD skills.
 - creator-skills/dev-skills: add native Codex support for `sci-slides`, `sci-figure-format`, and `step-workflow`.
 - task-loop: replace Claude cycle-worker `TaskStop` reaping guidance with graceful teammate shutdown requests.
 - task-loop: require positive no-live-owner evidence before resetting fresh-session opaque workers.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ cc-toolkit/
 ├── productivity-skills/            # Personal productivity plugin
 │   ├── .claude-plugin/
 │   │   └── plugin.json
-│   └── skills/
+│   ├── .codex-plugin/
+│   │   └── plugin.json
+│   ├── skills/
+│   │   ├── calendar-manager/
+│   │   └── reminder-manager/
+│   └── codex-skills/
 │       ├── calendar-manager/
 │       └── reminder-manager/
 └── pymol-skills/                   # PyMOL molecular visualization plugin
@@ -168,6 +173,15 @@ Personal productivity automation using macOS Calendar and Reminders.
 - **gtd-project**: Review and manage GTD projects and their actions
 - **gtd-next**: Calendar-aware task selection and time-blocked agendas
 - **gtd-overview**: Read-only listing of all projects with their actions plus standalone actions
+
+**Codex skills:**
+- **calendar-manager**
+- **reminder-manager**
+- **gtd-inbox**
+- **gtd-process**
+- **gtd-project**
+- **gtd-next**
+- **gtd-overview**
 
 ### PyMOL Skills (`pymol-skills`)
 PyMOL molecular visualization control via MCP server.

--- a/productivity-skills/.codex-plugin/plugin.json
+++ b/productivity-skills/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "productivity-skills",
+  "version": "5.2.0",
+  "description": "macOS productivity skills for Codex: Calendar, Reminders, and GTD workflows via EventKit CLI.",
+  "author": {
+    "name": "Steven",
+    "email": "aeghnnsw@users.noreply.github.com"
+  },
+  "repository": "https://github.com/aeghnnsw/cc-toolkit",
+  "license": "MIT",
+  "keywords": [
+    "productivity",
+    "gtd",
+    "calendar",
+    "reminders",
+    "macos",
+    "eventkit",
+    "tasks",
+    "agenda",
+    "inbox"
+  ],
+  "skills": "./codex-skills/",
+  "interface": {
+    "displayName": "Productivity Skills",
+    "shortDescription": "Codex-ready macOS Calendar, Reminders, and GTD workflows.",
+    "longDescription": "Use Productivity Skills to manage macOS Calendar events and Reminders, capture and process GTD inbox items, review projects, and generate calendar-aware agendas.",
+    "developerName": "Steven",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "What's on my calendar today?",
+      "Add a reminder to buy groceries tomorrow.",
+      "Process my GTD inbox.",
+      "What should I work on next?"
+    ]
+  }
+}

--- a/productivity-skills/codex-skills/calendar-manager/SKILL.md
+++ b/productivity-skills/codex-skills/calendar-manager/SKILL.md
@@ -9,7 +9,7 @@ Manage macOS Calendar events using the productivity-cli tool (EventKit-based).
 
 ## CLI Usage
 
-Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/` (two levels above this skill's folder; in a repository checkout it is `productivity-skills/`). Resolve it to an absolute path and substitute it in every command:
 
 ```bash
 swift <plugin-root>/scripts/productivity-cli.swift <command>

--- a/productivity-skills/codex-skills/calendar-manager/SKILL.md
+++ b/productivity-skills/codex-skills/calendar-manager/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: calendar-manager
+description: Use when creating, listing, searching, or deleting macOS Calendar events — scheduling meetings or appointments, checking today's or this week's agenda, or querying date ranges via the bundled EventKit CLI. Requires macOS with Calendar access.
+---
+
+# Calendar Manager
+
+Manage macOS Calendar events using the productivity-cli tool (EventKit-based).
+
+## CLI Usage
+
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift <command>
+```
+
+Requires: macOS 13+ with Xcode command line tools installed.
+
+## Important: Always Ask for Calendar Name
+
+Before any create/delete operation, list calendars and ask the user which one to use:
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars list
+```
+
+## Operations
+
+### List All Calendars
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars list
+```
+
+Returns JSON:
+```json
+{
+  "success": true,
+  "count": 3,
+  "data": [
+    {"name": "Work", "type": "calDAV", "color": "..."},
+    {"name": "Personal", "type": "calDAV", "color": "..."}
+  ]
+}
+```
+
+### Get Today's Events
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars today
+```
+
+### Get This Week's Events
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars week
+```
+
+### Get Events on a Specific Date
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars date 2025-01-15
+swift <plugin-root>/scripts/productivity-cli.swift calendars date 2025-01-15 --calendar Work
+```
+
+### Get Events in a Date Range
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars range 2025-01-01 2025-01-31
+swift <plugin-root>/scripts/productivity-cli.swift calendars range 2025-01-01 2025-01-31 --calendar Work
+```
+
+### Search Events by Title
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars search "meeting"
+```
+
+Searches events in the next 365 days matching the term.
+
+### Create an Event
+
+**Basic event (1 hour duration):**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars create \
+  --title "Team Meeting" \
+  --calendar "Work" \
+  --start "2025-01-15 14:00"
+```
+
+**Event with end time:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars create \
+  --title "Team Meeting" \
+  --calendar "Work" \
+  --start "2025-01-15 14:00" \
+  --end "2025-01-15 15:30"
+```
+
+**Event with location and notes:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars create \
+  --title "Team Meeting" \
+  --calendar "Work" \
+  --start "2025-01-15 14:00" \
+  --end "2025-01-15 15:00" \
+  --location "Conference Room A" \
+  --notes "Weekly sync meeting"
+```
+
+**All-day event:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars create \
+  --title "Company Holiday" \
+  --calendar "Work" \
+  --start "2025-01-20" \
+  --allday
+```
+
+### Create a Recurring Event
+
+**Daily standup:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars create \
+  --title "Daily Standup" \
+  --calendar "Work" \
+  --start "2026-01-20 09:00" \
+  --end "2026-01-20 09:30" \
+  --repeat daily
+```
+
+**Weekly team meeting on Mondays:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars create \
+  --title "Team Meeting" \
+  --calendar "Work" \
+  --start "2026-01-20 14:00" \
+  --repeat weekly \
+  --repeat-days mon \
+  --repeat-until "2026-06-30"
+```
+
+**Monthly review (12 occurrences):**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars create \
+  --title "Monthly Review" \
+  --calendar "Work" \
+  --start "2026-02-01 10:00" \
+  --repeat monthly \
+  --repeat-count 12
+```
+
+**Bi-weekly meeting:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars create \
+  --title "Bi-weekly Sync" \
+  --calendar "Work" \
+  --start "2026-01-20 15:00" \
+  --repeat weekly \
+  --repeat-interval 2
+```
+
+### Delete an Event
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars delete \
+  --title "Team Meeting" \
+  --date "2025-01-15"
+```
+
+With specific calendar:
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars delete \
+  --title "Team Meeting" \
+  --date "2025-01-15" \
+  --calendar "Work"
+```
+
+**Delete recurring event and all future occurrences:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift calendars delete \
+  --title "Daily Standup" \
+  --date "2026-01-25" \
+  --all-future
+```
+
+## Response Format
+
+All commands return JSON. Success responses:
+
+```json
+{
+  "success": true,
+  "count": 2,
+  "data": [...]
+}
+```
+
+Action results:
+```json
+{
+  "success": true,
+  "message": "Event 'Team Meeting' created successfully"
+}
+```
+
+Error responses:
+```json
+{
+  "error": "Calendar 'Unknown' not found"
+}
+```
+
+## Date Formats
+
+| Format | Example | Usage |
+|--------|---------|-------|
+| Date only | `2025-01-15` | For date queries, all-day events |
+| Date and time | `2025-01-15 14:00` | For timed events |
+
+## Event Properties
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--title` | Yes | Event title |
+| `--calendar` | Yes (create) | Calendar name |
+| `--start` | Yes (create) | Start date/time |
+| `--end` | No | End date/time (default: 1 hour after start) |
+| `--location` | No | Event location |
+| `--notes` | No | Event notes/description |
+| `--allday` | No | Make it an all-day event |
+| `--repeat` | No | Recurrence frequency: daily, weekly, monthly, yearly |
+| `--repeat-interval` | No | Every N periods (default: 1) |
+| `--repeat-until` | No | End date for recurrence (yyyy-MM-dd) |
+| `--repeat-count` | No | Number of occurrences |
+| `--repeat-days` | No | Days for weekly recurrence (e.g., mon,wed,fri) |
+| `--all-future` | No | Delete all future occurrences (delete only) |
+
+## Event Output with Recurrence
+
+When reading events, recurring events include additional fields:
+
+```json
+{
+  "title": "Daily Standup",
+  "calendar": "Work",
+  "startDate": "2026-01-20 09:00:00",
+  "endDate": "2026-01-20 09:30:00",
+  "isAllDay": false,
+  "isRecurring": true,
+  "recurrence": {
+    "frequency": "daily",
+    "interval": 1,
+    "endDate": "2026-12-31",
+    "occurrenceCount": null,
+    "daysOfWeek": null
+  }
+}
+```
+
+## Limitations
+
+- Events from subscribed calendars (holidays, etc.) cannot be deleted
+- No support for attendees or invitations
+
+## Notes
+
+- Always list calendars first and confirm with user before create/delete
+- Calendar names are case-insensitive
+- The CLI uses EventKit for fast, native access to Calendar data

--- a/productivity-skills/codex-skills/gtd-inbox/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-inbox/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: gtd-inbox
+description: Use when capturing thoughts or tasks into the GTD inbox, or when listing, counting, removing, or clearing inbox items.
+---
+
+Manage the user's GTD inbox based on their request.
+
+## Step 1: Read Inbox File
+
+1. Read `~/.claude/productivity-skills/inbox.md` (shared with the Claude Code version of this skill — keep this exact path)
+2. If file or directory does not exist:
+   - Create directory: `mkdir -p ~/.claude/productivity-skills`
+   - Create file with format:
+     ```markdown
+     # Inbox
+
+     ```
+
+## Step 2: Interpret Instructions
+
+Determine the user's intent from their message:
+
+| Intent | Example phrases |
+|--------|-----------------|
+| Add item | "add buy milk", "remember to call John", "capture: review docs" |
+| List items | "list", "show", "what's in my inbox", "" (empty = list) |
+| Remove item | "remove buy milk", "delete the call item", "done with groceries" |
+| Count | "count", "how many items" |
+| Clear all | "clear", "empty inbox" |
+
+If unclear, ask the user to clarify.
+
+## Step 3: Execute Action
+
+**Adding Items:**
+1. Check if a semantically similar item already exists
+2. If similar found, ask the user: "Similar item exists: '[item]'. Add anyway?" (yes / no)
+3. **Get current date** if item contains time references:
+   ```bash
+   date "+%Y-%m-%d %A"
+   ```
+   This returns the date and day of week (e.g., "2026-01-13 Monday") for accurate time calculation.
+4. **Convert relative time references to explicit dates** before adding:
+   - "today" → "(YYYY-MM-DD)"
+   - "tomorrow" → "(YYYY-MM-DD)"
+   - "this Monday" → "(Mon YYYY-MM-DD)"
+   - "next week" → "(week of YYYY-MM-DD)"
+   - "end of week" → "(by Fri YYYY-MM-DD)"
+   - "end of month" → "(by YYYY-MM-DD)"
+   - If no time reference, store item as-is
+
+   Examples:
+   - "call John this Monday" → "call John (Mon 2026-01-20)"
+   - "finish report by end of week" → "finish report (by Fri 2026-01-17)"
+   - "buy groceries tomorrow" → "buy groceries (2026-01-14)"
+   - "review docs" → "review docs" (no change)
+5. If confirmed or no duplicate, append the converted item to list
+6. Report: "Added '[converted item]' to inbox (N items pending)"
+
+**Listing Items:**
+1. Display numbered list
+2. If empty: "Inbox is empty"
+3. Format: "# Inbox (N items)" followed by numbered items
+
+**Removing Items:**
+1. Find item matching description semantically
+2. If multiple matches or unclear, ask the user to confirm which
+3. Edit the file to remove the line
+4. Report: "Removed '[item]'. (N items remaining)"
+
+**Counting:**
+Report: "N items pending"
+
+**Clearing:**
+1. Ask the user to confirm: "Clear all N items from inbox?"
+2. If confirmed, write empty inbox format
+3. Report: "Inbox cleared"
+
+## Step 4: Save Changes
+
+- Rewrite the whole file when creating it or clearing all items
+- Edit only the affected lines when adding or removing items
+
+## Guidelines
+
+Follow GTD inbox principles:
+- Capture everything without judgment
+- Keep items atomic (single thought/task each)
+- The inbox is for capture, not organization
+
+Handle errors gracefully:
+- If file malformed, parse what's readable and warn user
+- If item not found, ask the user to clarify
+- Always confirm destructive actions (clear all)

--- a/productivity-skills/codex-skills/gtd-inbox/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-inbox/SKILL.md
@@ -34,7 +34,7 @@ If unclear, ask the user to clarify.
 
 **Adding Items:**
 1. Check if a semantically similar item already exists
-2. If similar found, ask the user: "Similar item exists: '[item]'. Add anyway?" (yes / no)
+2. If similar found, ask the user: "Similar item exists: '[item]'. Add anyway?" with options "Yes, add it" / "No, skip"
 3. **Get current date** if item contains time references:
    ```bash
    date "+%Y-%m-%d %A"

--- a/productivity-skills/codex-skills/gtd-next/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-next/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: gtd-next
+description: Use when deciding what to work on next — calendar-aware task selection, time-blocked agenda generation, and agent task dispatch for the GTD Engage step.
+---
+
+<!--
+CLI: swift <plugin-root>/scripts/productivity-cli.swift
+Human context lists: @quick, @1pomo, @2pomo, @deep
+Agent context list: @agent (no duration, async)
+Projects list: "Projects" in macOS Reminders
+Action reference: #{ProjectName} in notes field
+
+Task durations: @quick=15min, @1pomo=25min, @2pomo=50min, @deep=90min
+Agent tasks: no duration, ranked by priority/due date
+Scheduling: 1 human task (fits time slot) + up to 3 agent tasks (parallel)
+Buffer: ~10 min per hour (available_minutes / 6, min 5, max 20)
+Pomodoro: 25 min work + 5 min break
+-->
+
+Automatically select the next actionable tasks and generate a time-blocked agenda based on calendar context and task priority. The agent decides — no user interaction required.
+
+## CLI Tool
+
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift <command>
+```
+
+## Step 1: Check Calendar
+
+1. Get current date and time:
+   ```bash
+   date "+%Y-%m-%d %H:%M"
+   ```
+
+2. Query today's remaining events:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift calendars today
+   ```
+
+3. Parse the JSON response and find the next event (after current time). Skip all-day events.
+
+4. If a next event exists, calculate available minutes until it starts. This becomes the time constraint. If no events remain today, there is no time constraint — proceed without one.
+
+## Step 2: Query All Actionable Tasks
+
+1. Query actions from all context lists:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete "@quick"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete "@1pomo"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete "@2pomo"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete "@deep"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete "@agent"
+   ```
+
+2. Query overdue reminders:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders overdue
+   ```
+
+3. Parse and combine results, separating into two pools:
+
+   **Human tasks** (from @quick, @1pomo, @2pomo, @deep):
+   - Context list and duration
+   - Project reference from notes field (#{ProjectName})
+   - Priority value, due date, whether overdue
+
+   **Agent tasks** (from @agent):
+   - Project reference from notes field (#{ProjectName})
+   - Priority value, due date, whether overdue
+   - No duration
+
+If no actionable tasks found in either pool, report "No actionable tasks found. Add tasks to @quick, @1pomo, @2pomo, @deep, or @agent lists." and exit.
+
+## Step 3: Rank and Select Tasks
+
+**Ranking order (same for both pools):**
+1. Overdue items first
+2. High priority (priority=1)
+3. Due date approaching (soonest first)
+4. Medium priority (priority=5)
+5. Remaining items
+
+### Human task selection
+
+**If there is a time constraint** (next event found in Step 1):
+
+Select human tasks from the top of the ranked list that fit within the available time. Use task durations based on context (@quick=15min, @1pomo=25min, @2pomo=50min, @deep=90min). Account for buffer time and pomodoro breaks when calculating fit. Skip tasks that exceed remaining time and try the next one.
+
+**If there is no time constraint:**
+
+Select the top 10 human tasks from the ranked list.
+
+### Agent task selection
+
+Select up to 3 agent tasks from the top of the ranked `@agent` list. No time-fitting — agent tasks run asynchronously in the background. If fewer than 3 agent tasks are available, show all of them.
+
+## Step 4: Generate Agenda
+
+**If there is a time constraint:**
+
+1. Calculate buffer time before next event:
+   - Buffer = available_minutes / 6 (roughly 10 min per hour)
+   - Round to nearest 5 minutes
+   - Minimum 5 minutes, maximum 20 minutes
+
+2. Usable work time = Available time - Buffer time
+
+3. Arrange selected human tasks into pomodoro blocks:
+   - Each pomodoro = 25 min work + 5 min break
+   - Multiple short tasks within 25 min: group without breaks
+   - After each 25 min of work, schedule a 5 min break
+   - No break needed before the final buffer
+   - Longer tasks (@2pomo, @deep): treat as single focused blocks, break after completing
+
+4. Present a time-blocked agenda with agent tasks listed separately:
+
+```
+## Your Agenda (until [Event] at [Time])
+
+### Focus Tasks
+[Start Time] - [End Time]  [Task A] (@quick) #[ProjectName]
+[Start Time] - [End Time]  [Task B] (@1pomo)
+[Start Time] - [End Time]  Break
+[Start Time] - [End Time]  [Task C] (@2pomo) #[ProjectName]
+[Start Time] - [End Time]  Buffer before [Event]
+
+### Agent Tasks (dispatch and monitor)
+1. [Task D] #[ProjectName] [High] — due [date]
+2. [Task E] — due [date]
+3. [Task F] #[ProjectName] [Medium] — due [date]
+```
+
+**If there is no time constraint:**
+
+Present human tasks as a ranked list, agent tasks separately:
+
+```
+## Recommended Next Tasks
+
+### Human Tasks
+1. ⚠️ [Action Title] #[ProjectName] [High] @quick (~15 min) - OVERDUE
+2. [Action Title] #[ProjectName] [High] @1pomo (~25 min) - due [date]
+3. [Action Title] [Medium] @2pomo (~50 min)
+...
+
+Total estimated time: ~X hours Y min
+
+### Agent Tasks (dispatch up to 3, monitor progress)
+1. [Action Title] #[ProjectName] [High] — due [date]
+2. [Action Title] [Medium] — due [date]
+3. [Action Title] — due [date]
+```
+
+**Display formatting:**
+- ⚠️ prefix for overdue items (both human and agent)
+- Show project name if linked (from notes field)
+- Map priority values: 1=[High], 5=[Medium], 9=[Low], 0=omit
+- Human tasks: show context list (@quick, @1pomo, @2pomo, @deep) and estimated duration
+- Agent tasks: show priority and due date only, no duration
+- Show due date if set, with "OVERDUE" if past
+
+## Guidelines
+
+- Prioritize overdue items — they always appear first (both human and agent)
+- Link actions to projects when #{ProjectName} is found in notes
+- Show all matching actions even if multiple belong to the same project
+- Handle CLI errors gracefully and report to user
+- The agent decides what to work on — present the result, do not ask for selection
+- Human tasks are sequential — only 1 active focus task at a time
+- Agent tasks are parallel — up to 3 dispatched concurrently, no time-fitting needed
+- If only human tasks exist, show agenda without agent section (and vice versa)

--- a/productivity-skills/codex-skills/gtd-next/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-next/SKILL.md
@@ -21,7 +21,7 @@ Automatically select the next actionable tasks and generate a time-blocked agend
 
 ## CLI Tool
 
-Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/` (two levels above this skill's folder; in a repository checkout it is `productivity-skills/`). Resolve it to an absolute path and substitute it in every command:
 
 ```bash
 swift <plugin-root>/scripts/productivity-cli.swift <command>

--- a/productivity-skills/codex-skills/gtd-overview/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-overview/SKILL.md
@@ -19,7 +19,7 @@ Display a complete read-only overview of the GTD system: every open project with
 
 ## CLI Tool
 
-Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/` (two levels above this skill's folder; in a repository checkout it is `productivity-skills/`). Resolve it to an absolute path and substitute it in every command:
 
 ```bash
 swift <plugin-root>/scripts/productivity-cli.swift <command>

--- a/productivity-skills/codex-skills/gtd-overview/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-overview/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: gtd-overview
+description: Use when listing the whole GTD system read-only — every open project with its actions plus standalone actions not linked to any project.
+---
+
+<!--
+Projects list: "Projects" in macOS Reminders
+Project naming: {CamelCaseSummary}-{YYYYMMDD} (e.g., VacationResearch-20260112)
+Action reference: #{FullProjectName} in notes field
+Project notes: "Goal: [end goal description]"
+Human context lists: @quick, @1pomo, @2pomo, @deep
+Agent context list: @agent (no duration, async)
+CLI: swift <plugin-root>/scripts/productivity-cli.swift
+
+Key principle: Read-only overview. Display projects with nested actions, then standalone actions, then a summary. No modifications, no questions — direct user to the gtd-project or gtd-process skills for changes.
+-->
+
+Display a complete read-only overview of the GTD system: every open project with its linked actions nested underneath, followed by all standalone actions not linked to any project.
+
+## CLI Tool
+
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift <command>
+```
+
+## Step 1: Gather Data
+
+1. Query all incomplete reminders across every list in a single call (omitting the list argument returns all lists):
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete
+   ```
+   Each returned reminder carries a `list` field. Keep only rows from the GTD lists — "Projects" for projects and @quick, @1pomo, @2pomo, @deep, @agent for actions — and ignore rows from any other list. A missing list simply contributes no rows; do not create lists in this read-only skill.
+
+2. Query overdue reminders (uses Apple's datetime-aware overdue detection):
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders overdue
+   ```
+
+## Step 2: Group Actions
+
+Parse the JSON output and classify every action from the context lists:
+
+1. **Project actions**: Notes field contains `#{ProjectName}` matching an open project (case-insensitive). Group under that project.
+2. **Orphaned actions**: Notes field contains a `#{...}` reference that matches no open project (project completed or deleted). Group into an "Orphaned" section.
+3. **Standalone actions**: Notes field contains no `#{...}` reference. Group into the "Standalone Actions" section.
+
+For each project, determine status (evaluated in order of severity):
+- **Overdue** (⚠️): Any linked action OR the project itself appears in the overdue query results
+- **Stalled** (⚠️): Has 0 pending linked actions
+- **Healthy** (✓): Has 1+ pending linked actions, none overdue
+
+Extract each project's end goal from its notes field (format: "Goal: [description]").
+
+## Step 3: Display Overview
+
+Present projects sorted by urgency (overdue first, then stalled, then healthy), followed by standalone actions grouped by context list:
+
+```
+# GTD Overview
+
+## Projects (3)
+
+1. ⚠️ ClientProject-20260110 [Medium] — OVERDUE
+   Goal: Invoice paid and project closed
+   • "Send invoice" (@quick) — OVERDUE (due 2026-01-10)
+
+2. ⚠️ ReviewQ1Roadmap-20260115 [High] — STALLED
+   Goal: Roadmap approved by stakeholders
+   (no pending actions)
+
+3. ✓ VacationResearch-20260112 [High]
+   Goal: Flights and hotel booked for Hawaii trip
+   • "Research flights to Hawaii" (@1pomo)
+   • "Email hotel for rates" (@quick)
+   • "Analyze flight price trends" (@agent) — due 2026-01-20
+
+## Standalone Actions (3)
+
+@quick
+   • "Call dentist to schedule appointment" — due 2026-01-18
+@2pomo
+   • "Write blog post draft" [High]
+@agent
+   • "Summarize meeting notes" — OVERDUE (due 2026-01-12)
+
+## Summary
+
+Projects: 3 (1 overdue, 1 stalled, 1 healthy)
+Project actions: 4 | Standalone actions: 3 | Overdue: 2
+```
+
+If there are orphaned actions, add an `## Orphaned Actions` section after standalone actions, listing each with its dangling `#{ProjectName}` reference.
+
+Empty states:
+- No projects and no actions: "GTD system is empty. Use the gtd-inbox skill to capture items and the gtd-process skill to organize them."
+- No projects but actions exist: skip the Projects section, note "No open projects."
+- Projects exist but no standalone actions: note "No standalone actions."
+
+## Step 4: Suggest Next Steps
+
+After the overview, append one line pointing to follow-up skills based on what was found:
+- Overdue or stalled projects → "Run the gtd-project skill to reschedule overdue actions or add next actions."
+- Orphaned actions → "Orphaned actions reference completed projects — run the gtd-project skill to clean up."
+- Otherwise → "Run the gtd-next skill to pick what to work on."
+
+## Guidelines
+
+- Read-only: never create, complete, edit, or delete reminders or lists
+- No user interaction: gather, group, display — done
+- Match project names case-insensitively when linking actions
+- Sort actions within a project by overdue first, then by due date, then by priority
+- Handle CLI errors gracefully: report which query failed and continue with available data
+
+## Reference: Context Lists
+
+| List | Type | Time Estimate |
+|------|------|---------------|
+| @quick | Human | Quick tasks (< 25 min) |
+| @1pomo | Human | 1 Pomodoro (25 min) |
+| @2pomo | Human | 2 Pomodoros (50 min) |
+| @deep | Human | Deep focus (3+ pomodoros) |
+| @agent | Agent | N/A (async, monitor progress) |
+
+## Reference: Priority Values
+
+| Display | Value |
+|---------|-------|
+| High | 1 |
+| Medium | 5 |
+| Low | 9 |
+| None | 0 |

--- a/productivity-skills/codex-skills/gtd-process/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-process/SKILL.md
@@ -7,7 +7,7 @@ Process GTD inbox items into projects or actions. The agent infers categorizatio
 
 ## CLI Tool
 
-Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/` (two levels above this skill's folder; in a repository checkout it is `productivity-skills/`). Resolve it to an absolute path and substitute it in every command:
 
 ```bash
 swift <plugin-root>/scripts/productivity-cli.swift <command>

--- a/productivity-skills/codex-skills/gtd-process/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-process/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: gtd-process
+description: Use when processing, triaging, or clarifying GTD inbox items into projects and context-list actions following the GTD clarify and organize workflow.
+---
+
+Process GTD inbox items into projects or actions. The agent infers categorization, project assignment, priority, time estimate, and due date for each item — then presents a single confirmation for the user to approve or modify.
+
+## CLI Tool
+
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift <command>
+```
+
+## Step 1: Determine Processing Mode
+
+Default: **process all items** sequentially until the inbox is empty, every item has been presented this session, or the user selects "Stop" on the per-item confirmation.
+
+Only switch to single-item mode if the user explicitly asks for it (e.g. "just one item", "single item", "process the first one" — non-exhaustive). In that case, process the first item and exit via Step 6.
+
+## Step 2: Read Inbox and Gather Context
+
+1. Read `~/.claude/productivity-skills/inbox.md` (shared with the Claude Code version of this skill — keep this exact path)
+2. If file or directory does not exist, create directory and file:
+   ```bash
+   mkdir -p ~/.claude/productivity-skills
+   ```
+   Then write an empty inbox file with header `# Inbox` and a blank line.
+3. If empty, inform user: "Inbox is empty. Nothing to process." and exit.
+4. Display numbered list of items.
+5. Ensure required lists exist, creating any that are missing:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders lists
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "Projects"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@quick"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@1pomo"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@2pomo"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@deep"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@agent"
+   ```
+6. Fetch existing projects for context:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete "Projects"
+   ```
+
+## Step 3: Analyze and Propose
+
+For each inbox item, analyze the text and infer:
+
+1. **Category**: Is this a new project (multi-step outcome), a project action (belongs to an existing project), or a single action (standalone task)?
+   - If existing projects were fetched, check if the item relates to any of them
+2. **Project assignment**: If it's a project action, which project does it belong to?
+3. **Action title**: Clean up the inbox text into a clear action title
+4. **Task type**: Is this human-centric or agent-centric?
+   - **Agent-centric indicators**: "generate", "draft", "analyze", "research", "summarize", "review code", "run tests", "scan", "convert", "process" — tasks that produce an artifact the user monitors and checks later
+   - **Human-centric indicators**: phone calls, meetings, physical tasks, decisions requiring real-time judgment
+   - Default to human-centric when ambiguous
+5. **Time estimate** (human-centric only): Infer from complexity — @quick (< 25 min), @1pomo (25 min), @2pomo (50 min), @deep (90+ min). Skip for agent-centric tasks.
+6. **Priority**: Infer from urgency cues in the text (default: Medium)
+7. **Due date**: Infer from any time references in the text (default: one week from today)
+
+**For new projects**, also infer:
+- Project name: `{CamelCaseSummary}-{YYYYMMDD}`
+- End goal: What "done" looks like based on the item text
+
+Present the proposal and ask the user a single question: "Confirm or modify this processing:"
+
+**Human-centric example:**
+```
+Item: "Call dentist to schedule appointment"
+
+Proposed:
+  Type: Single Action
+  Task type: Human
+  Action: "Call dentist to schedule appointment"
+  List: @quick (~15 min)
+  Priority: Medium
+  Due: 2026-05-04
+
+Confirm or modify?
+```
+
+**Agent-centric example:**
+```
+Item: "Analyze Q1 sales data and generate summary report"
+
+Proposed:
+  Type: Single Action
+  Task type: Agent
+  Action: "Analyze Q1 sales data and generate summary report"
+  List: @agent
+  Priority: Medium
+  Due: 2026-05-04
+
+Confirm or modify?
+```
+
+**New project example:**
+```
+Item: "Research vacation flights by end of month"
+
+Proposed:
+  Type: New Project
+  Project name: VacationResearch-20260324
+  Goal: Flights researched and booked
+  Priority: Medium
+  Due: 2026-03-31
+  First action: "Search flight comparison sites" (@1pomo, Human)
+
+Confirm or modify?
+```
+
+Options: "Confirm", "Modify", "Skip", "Stop"
+
+- **Confirm**: Execute the proposed processing (create project/action via CLI), then continue
+- **Modify**: User provides corrections, then execute with modifications, then continue
+- **Skip**: Leave item in inbox, advance to the next unpresented item
+- **Stop**: Leave current item in inbox and exit the processing loop entirely — unlike Skip, no further items are presented
+
+For Skip and Stop, do not perform Step 4 or Step 5 — proceed directly to Step 6.
+
+## Step 4: Execute Processing
+
+Based on the confirmed or modified proposal:
+
+**For new projects:**
+1. Create project in Projects list:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+     --title "ProjectName-YYYYMMDD" \
+     --list "Projects" \
+     --priority 5 \
+     --notes "Goal: [end goal]" \
+     --due "YYYY-MM-DD 17:00"
+   ```
+2. Create first action in the appropriate context list (use the inferred list from Step 3):
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+     --title "Action title" \
+     --list "<inferred list>" \
+     --notes "#{ProjectName-YYYYMMDD}" \
+     --priority 5
+   ```
+   Use `@agent` if the first action is agent-centric, otherwise use the inferred time-based list (@quick, @1pomo, @2pomo, @deep).
+
+**For project actions (use the inferred list from Step 3):**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Action title" \
+  --list "<inferred list>" \
+  --notes "#{ProjectName-YYYYMMDD}" \
+  --priority 5 \
+  --due "YYYY-MM-DD 17:00"
+```
+
+**For single actions (human-centric — use the inferred time-based list):**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Action title" \
+  --list "<inferred list>" \
+  --priority 5 \
+  --due "YYYY-MM-DD 17:00"
+```
+
+**For single actions (agent-centric):**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Action title" \
+  --list "@agent" \
+  --priority 5 \
+  --due "YYYY-MM-DD 17:00"
+```
+
+Omit `--due` only if user explicitly requests no due date. Omit `--priority` if None (0).
+
+## Step 5: Remove from Inbox
+
+Edit inbox.md to remove the processed item.
+
+## Step 6: Continue or Exit
+
+Track which inbox items have been presented in this session (by their original text). Exit (show summary of processed items) when any of these are true:
+- User selected "Stop" in Step 3
+- Inbox is empty
+- Every item currently in the inbox has already been presented this session (each was either processed or skipped) — this prevents an infinite loop when the user skips every item
+- Single-item mode was requested in Step 1 and the first item is done
+
+Otherwise, return to **Step 2** to refresh the inbox contents and the existing-projects context (Step 4 may have created a new project), then propose the next unpresented item in Step 3. Do **not** ask the user whether to continue.
+
+## Reference
+
+**Context lists (human):** @quick (< 25 min), @1pomo (25 min), @2pomo (50 min), @deep (90+ min)
+
+**Context list (agent):** @agent (no duration — async, monitor progress)
+
+**Priority values:** 1=High, 5=Medium, 9=Low, 0=None
+
+**Date format:** `yyyy-MM-dd HH:mm` (default time 17:00)
+
+**Project naming:** `{CamelCaseSummary}-{YYYYMMDD}`
+
+**Project linking:** `#{ProjectName-YYYYMMDD}` in action notes field
+
+## Guidelines
+
+- Every project must have a clear end goal
+- Create missing reminder lists automatically before creating reminders
+- Project actions inherit priority from the project unless overridden
+- Infer as much as possible from the inbox item text — minimize user interaction
+- Present one confirmation per item, not multiple sequential questions

--- a/productivity-skills/codex-skills/gtd-project/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-project/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: gtd-project
+description: Use when reviewing GTD project status, adding actions or agent tasks to projects, completing or rescheduling actions, or completing projects tracked in macOS Reminders.
+---
+
+<!--
+Projects list: "Projects" in macOS Reminders
+Project naming: {CamelCaseSummary}-{YYYYMMDD} (e.g., VacationResearch-20260112)
+Action reference: #{FullProjectName} in notes field
+Project notes: "Goal: [end goal description]"
+Human context lists: @quick, @1pomo, @2pomo, @deep
+Agent context list: @agent (no duration, async)
+CLI: swift <plugin-root>/scripts/productivity-cli.swift
+
+Key principle: Projects can have multiple parallel actions. Track all actionable tasks that can be worked on independently. Actions are either human-centric (pomodoro-timed) or agent-centric (async, no duration).
+-->
+
+Review and manage GTD projects with infer-and-confirm workflow. The agent analyzes project state, proposes actions, and the user confirms or overrides — minimizing back-and-forth.
+
+## CLI Tool
+
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift <command>
+```
+
+## Step 1: Gather Data
+
+1. Query overdue reminders (uses Apple's datetime-aware overdue detection):
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders overdue
+   ```
+
+2. Ensure required lists exist:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders lists
+   ```
+   If any required lists are missing, create them:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "Projects"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@quick"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@1pomo"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@2pomo"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@deep"
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "@agent"
+   ```
+
+3. Query all open projects:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete "Projects"
+   ```
+
+4. Query all context lists for actions:
+   ```bash
+   for context in "@quick" "@1pomo" "@2pomo" "@deep" "@agent"; do
+     swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete "$context"
+   done
+   ```
+
+5. For each project, find ALL linked actions by matching `#{ProjectName}` in the action's notes field:
+   - Parse the JSON output from context list queries
+   - Match the notes field against pattern `#{ProjectName}`
+   - Collect ALL matching actions (not just one)
+
+6. Extract project end goal from project's notes field (format: "Goal: [description]")
+
+7. Determine project status:
+   - **Healthy** (✓): Has 1+ pending actions, none overdue
+   - **Stalled** (⚠️): Has 0 pending actions linked to this project
+   - **Overdue** (⚠️): Any action OR project appears in the overdue query results
+
+   Statuses evaluated in order of severity: Overdue > Stalled > Healthy.
+
+## Step 2: Display Projects Overview
+
+Present all projects sorted by urgency (overdue first, then stalled, then healthy):
+
+```
+# Projects Overview
+
+1. ⚠️ ClientProject-20260110 [Medium] — OVERDUE
+   - Goal: Invoice paid and project closed
+   - Actions (1):
+     • "Send invoice" (@quick) - OVERDUE (due 2026-01-10)
+   → Suggested: Reschedule overdue action
+
+2. ⚠️ ReviewQ1Roadmap-20260115 [High] — STALLED
+   - Goal: Roadmap approved by stakeholders
+   - No pending actions
+   → Suggested: Add next action
+
+3. ✓ VacationResearch-20260112 [High]
+   - Goal: Flights and hotel booked for Hawaii trip
+   - Actions (3):
+     • "Research flights to Hawaii" (@1pomo)
+     • "Email hotel for rates" (@quick)
+     • "Analyze flight price trends" (@agent) — due 2026-01-20
+
+Which project to work on? [1/2/3/Done]
+```
+
+Ask the user: "Which project to work on?"
+- Options: Numbered list of projects + "Done reviewing"
+- Overdue and stalled projects are listed first with suggested actions shown inline
+
+If no open projects, inform user: "No open projects. Use the gtd-process skill to create projects from inbox items."
+
+## Step 3: Auto-Infer Action
+
+Based on the selected project's state, **infer the most logical action automatically** — do not ask "what would you like to do?":
+
+| Project State | Auto-Inferred Action | Rationale |
+|---------------|---------------------|-----------|
+| Overdue actions | Reschedule the specific overdue action(s) (Step 4c) | Overdue items need immediate attention |
+| Stalled (0 actions) | Add next action (Step 4a) | Stalled projects need a next action to move forward |
+| Healthy with actions | Present brief options | Multiple valid paths — ask user |
+
+**For overdue projects**: Identify the specific overdue action(s) and announce:
+> "Project has overdue action 'Send invoice' (due 2026-01-10). Rescheduling — or would you rather mark the project complete / skip?"
+
+If multiple actions are overdue, process each one sequentially. If the project also has non-overdue actions, only target the overdue ones.
+
+**For stalled projects**: Announce:
+> "Project is stalled with no actions. Let's add the next action — or mark project complete / skip?"
+
+**For healthy projects**: Ask the user: "What would you like to do?"
+- Options: "Add action", "Mark action complete", "Edit action", "Mark project complete", "Skip"
+
+In all cases, the user can override the suggestion by saying "complete project" or "skip".
+
+## Step 4a: Add Action
+
+1. Ask the user: "What's the next action for [ProjectName]?"
+   - User provides action title
+
+2. **Infer all properties from the title text** (same pattern as gtd-process):
+   - **Task type**: Infer human vs agent from text. Agent-centric indicators: "generate", "draft", "analyze", "research", "summarize", "review code", "run tests", "scan", "convert", "process". Default to human-centric when ambiguous.
+   - **Time estimate** (human only): Infer from complexity. "Email..." → @quick, "Research..." → @1pomo, "Write report..." → @2pomo, "Redesign..." → @deep. Skip for agent-centric tasks.
+   - **Priority**: Inherit from project priority by default
+   - **Due date**: No due date unless the title implies urgency ("today", "by Friday", "urgent"). For agent-centric tasks, default to one week from today if no date implied.
+
+3. Present a single proposal for confirmation:
+
+   **Human-centric example:**
+   ```
+   Action: "Email hotel for rates"
+   → Type: Human
+   → List: @quick (~15 min)
+   → Priority: High (inherited from project)
+   → Due: No due date
+
+   Confirm? [Yes / Modify / Skip]
+   ```
+
+   **Agent-centric example:**
+   ```
+   Action: "Analyze flight price trends"
+   → Type: Agent
+   → List: @agent
+   → Priority: High (inherited from project)
+   → Due: 2026-01-20
+
+   Confirm? [Yes / Modify / Skip]
+   ```
+
+   Ask the user: "Confirm this action?"
+   - Options: "Yes", "Modify", "Skip"
+   - If "Modify": ask which property to change (includes "Task type"), then re-confirm
+   - If "Yes": create the action
+   - If "Skip": return to Step 2
+
+4. Create the action:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+     --title "Action title" \
+     --list "@quick" \
+     --notes "#{ProjectName-20260112}" \
+     --priority 1
+   ```
+   Add `--due "2026-01-20 17:00"` only if a due date was inferred or confirmed.
+
+5. Report: "Added action '[title]' to [ProjectName]"
+
+6. Return to Step 2.
+
+## Step 4b: Complete Action
+
+1. If project has multiple actions, ask the user: "Which action to complete?"
+   - Options: List of actions for this project
+   - If only one action, skip this question and complete it directly
+
+2. Mark the selected action complete:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders complete \
+     --title "Action title" \
+     --list "@1pomo"
+   ```
+
+3. Report: "Completed: '[action title]'"
+
+4. Check remaining actions:
+   - **If other actions remain**: Report "Project [ProjectName] has N remaining actions." Return to Step 2.
+   - **If no actions remain**: Auto-suggest adding the next action:
+     > "No remaining actions — project will become stalled. Let's add the next action."
+     Proceed to Step 4a. The user can select "Skip" in Step 4a's confirm prompt to decline and return to Step 2 (project becomes stalled).
+
+## Step 4c: Reschedule / Edit Action
+
+1. If project has multiple actions, ask the user: "Which action to edit?"
+   - If only one action (or arrived here via auto-infer for overdue), skip this question
+
+2. **For overdue reschedule** (arrived from auto-infer):
+   - Show current due date
+   - Infer a reasonable new date (tomorrow if 1 day overdue, next week if more)
+   - Present proposal:
+     ```
+     "Send invoice" is overdue (due 2026-01-10)
+     → Reschedule to: tomorrow 17:00
+     Confirm? [Yes / Pick different date]
+     ```
+   - Ask the user with options: "Yes", "Today", "Tomorrow", "This week", "Custom date"
+
+3. **For general edit** (user selected "Edit action"):
+   - Show current properties
+   - Ask the user: "What to edit?" (multiple selections allowed)
+     - Options: "Title", "Task type", "Time estimate", "Priority", "Due date", "Done editing"
+   - For each selected property, gather the new value:
+     - Title: ask for new title text
+     - Task type: options "Human", "Agent". Switching to agent moves task to @agent and removes time estimate. Switching to human requires selecting a time estimate.
+     - Time estimate (human only): options "Quick", "1 Pomodoro", "2 Pomodoros", "Deep" (maps to @quick, @1pomo, @2pomo, @deep)
+     - Priority: options "High", "Medium", "Low", "None" (maps to 1, 5, 9, 0)
+     - Due date: options "No due date", "Today", "Tomorrow", "This week", "Custom date"
+
+4. To update, delete old action and create new one with updated properties:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders delete \
+     --title "Old title" \
+     --list "@old-list"
+
+   swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+     --title "New title" \
+     --list "@new-list" \
+     --notes "#{ProjectName}" \
+     --priority 5 \
+     --due "2026-01-15 17:00"
+   ```
+   If the create command fails after deletion, immediately retry with the same parameters. Report the original action details to the user so they can manually recover if needed.
+
+5. Report: "Updated action '[title]'"
+
+6. Return to Step 2.
+
+## Step 5: Complete Project
+
+1. Mark the project complete:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders complete \
+     --title "ProjectName-20260112" \
+     --list "Projects"
+   ```
+
+2. Complete any remaining linked actions:
+   ```bash
+   swift <plugin-root>/scripts/productivity-cli.swift reminders complete \
+     --title "Action title" \
+     --list "@1pomo"
+   ```
+
+3. Report: "Project '[ProjectName]' marked complete"
+
+4. Return to Step 2.
+
+## Step 6: Exit
+
+When user selects "Done reviewing" in Step 2:
+
+```
+# Review Complete
+
+Projects reviewed: 3
+Actions completed: 2
+Actions added: 1
+Projects completed: 1
+```
+
+## Guidelines
+
+- Prioritize overdue items — they always appear first in the overview
+- Auto-infer actions for overdue/stalled projects to reduce questions
+- Infer action properties from title text — only ask user to confirm
+- Multiple actions per project: track all actionable tasks independently
+- After completing an action, auto-suggest next action if project becomes stalled
+- Create missing reminder lists automatically before creating reminders
+- Handle CLI errors gracefully and report to user
+- Match project names case-insensitively
+- Use `yyyy-MM-dd HH:mm` for due dates, default time 17:00
+
+## Reference: Context Lists
+
+| List | Type | Time Estimate |
+|------|------|---------------|
+| @quick | Human | Quick tasks (< 25 min) |
+| @1pomo | Human | 1 Pomodoro (25 min) |
+| @2pomo | Human | 2 Pomodoros (50 min) |
+| @deep | Human | Deep focus (3+ pomodoros) |
+| @agent | Agent | N/A (async, monitor progress) |
+
+## Reference: Priority Values
+
+| Display | Value |
+|---------|-------|
+| High | 1 |
+| Medium | 5 |
+| Low | 9 |
+| None | 0 |

--- a/productivity-skills/codex-skills/gtd-project/SKILL.md
+++ b/productivity-skills/codex-skills/gtd-project/SKILL.md
@@ -19,7 +19,7 @@ Review and manage GTD projects with infer-and-confirm workflow. The agent analyz
 
 ## CLI Tool
 
-Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/` (two levels above this skill's folder; in a repository checkout it is `productivity-skills/`). Resolve it to an absolute path and substitute it in every command:
 
 ```bash
 swift <plugin-root>/scripts/productivity-cli.swift <command>

--- a/productivity-skills/codex-skills/reminder-manager/SKILL.md
+++ b/productivity-skills/codex-skills/reminder-manager/SKILL.md
@@ -9,7 +9,7 @@ Manage macOS Reminders using the productivity-cli tool (EventKit-based).
 
 ## CLI Usage
 
-Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/` (two levels above this skill's folder; in a repository checkout it is `productivity-skills/`). Resolve it to an absolute path and substitute it in every command:
 
 ```bash
 swift <plugin-root>/scripts/productivity-cli.swift <command>

--- a/productivity-skills/codex-skills/reminder-manager/SKILL.md
+++ b/productivity-skills/codex-skills/reminder-manager/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: reminder-manager
+description: Use when creating, completing, listing, or deleting macOS Reminders — setting due dates, priorities, notes, or recurrence, checking pending or overdue tasks, or managing reminder lists via the bundled EventKit CLI. Requires macOS with Reminders access.
+---
+
+# Reminder Manager
+
+Manage macOS Reminders using the productivity-cli tool (EventKit-based).
+
+## CLI Usage
+
+Run the Swift source directly (no build step required). `<plugin-root>` is the installed plugin directory — the directory that contains `scripts/` and `codex-skills/`, two levels above this skill file; in a repository checkout it is `productivity-skills/`. Resolve it to an absolute path and substitute it in every command:
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift <command>
+```
+
+Requires: macOS 13+ with Xcode command line tools installed.
+
+## Important: Always Ask for Reminder List
+
+Before any create operation, list reminder lists and ask the user which one to use:
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders lists
+```
+
+## Operations
+
+### List All Reminder Lists
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders lists
+```
+
+Returns JSON:
+```json
+{
+  "success": true,
+  "count": 3,
+  "data": [
+    {"name": "Tasks", "count": 5},
+    {"name": "Work", "count": 2},
+    {"name": "Personal", "count": 0}
+  ]
+}
+```
+
+The `count` field shows incomplete reminders in each list.
+
+### Get Reminders Due Today
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders today
+```
+
+### Get Incomplete Reminders
+
+**All incomplete reminders:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete
+```
+
+**From a specific list:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders incomplete "Tasks"
+```
+
+### Get Overdue Reminders
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders overdue
+```
+
+### Create a Reminder
+
+**Basic reminder:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Buy groceries" \
+  --list "Tasks"
+```
+
+**With due date:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Submit report" \
+  --list "Work" \
+  --due "2025-01-15 17:00"
+```
+
+**With priority:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Urgent task" \
+  --list "Work" \
+  --priority 1
+```
+
+**With notes:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Call John" \
+  --list "Tasks" \
+  --notes "Discuss project timeline and budget"
+```
+
+**Full reminder with all properties:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Team meeting prep" \
+  --list "Work" \
+  --due "2025-01-15 09:00" \
+  --priority 1 \
+  --notes "Prepare slides and agenda"
+```
+
+### Create a Recurring Reminder
+
+**Daily medication reminder:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Take medication" \
+  --list "Health" \
+  --due "2026-01-20 08:00" \
+  --repeat daily
+```
+
+**Weekly grocery shopping:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Grocery shopping" \
+  --list "Personal" \
+  --due "2026-01-25 10:00" \
+  --repeat weekly
+```
+
+**Bi-weekly task:**
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create \
+  --title "Review expenses" \
+  --list "Work" \
+  --due "2026-01-20 17:00" \
+  --repeat weekly \
+  --repeat-interval 2
+```
+
+### Mark Reminder as Complete
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders complete --title "Buy groceries"
+```
+
+With specific list:
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders complete --title "Buy groceries" --list "Tasks"
+```
+
+### Mark Reminder as Incomplete
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders uncomplete --title "Buy groceries"
+```
+
+With specific list:
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders uncomplete --title "Buy groceries" --list "Tasks"
+```
+
+### Delete a Reminder
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders delete --title "Buy groceries"
+```
+
+With specific list:
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders delete --title "Buy groceries" --list "Tasks"
+```
+
+### Create a New Reminder List
+
+```bash
+swift <plugin-root>/scripts/productivity-cli.swift reminders create-list "Shopping"
+```
+
+## Response Format
+
+All commands return JSON. Success responses:
+
+```json
+{
+  "success": true,
+  "count": 5,
+  "data": [
+    {
+      "title": "Buy groceries",
+      "list": "Tasks",
+      "dueDate": "2025-01-15 17:00:00",
+      "priority": 0,
+      "isCompleted": false,
+      "notes": null,
+      "isRecurring": false,
+      "recurrence": null
+    }
+  ]
+}
+```
+
+**Recurring reminder response:**
+```json
+{
+  "title": "Take medication",
+  "list": "Health",
+  "dueDate": "2026-01-20 08:00:00",
+  "priority": 0,
+  "isCompleted": false,
+  "notes": null,
+  "isRecurring": true,
+  "recurrence": {
+    "frequency": "daily",
+    "interval": 1,
+    "endDate": null,
+    "occurrenceCount": null,
+    "daysOfWeek": null
+  }
+}
+```
+
+Action results:
+```json
+{
+  "success": true,
+  "message": "Reminder 'Buy groceries' created successfully"
+}
+```
+
+Error responses:
+```json
+{
+  "error": "Reminder list 'Unknown' not found"
+}
+```
+
+## Priority Values
+
+| Value | Meaning | Display |
+|-------|---------|---------|
+| 0 | No priority | (none) |
+| 1 | High | !!! |
+| 5 | Medium | !! |
+| 9 | Low | ! |
+
+## Date Format
+
+Use `yyyy-MM-dd HH:mm` for due dates:
+- `2025-01-15 17:00` - January 15, 2025 at 5:00 PM
+- `2025-01-15 09:00` - January 15, 2025 at 9:00 AM
+
+## Reminder Properties
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--title` | Yes | Reminder title |
+| `--list` | Yes (create) | Reminder list name |
+| `--due` | No | Due date/time |
+| `--priority` | No | Priority (0, 1, 5, or 9) |
+| `--notes` | No | Notes/description |
+| `--repeat` | No | Recurrence frequency: daily, weekly, monthly, yearly |
+| `--repeat-interval` | No | Every N periods (default: 1) |
+
+## Limitations
+
+- Tags are not supported
+- Location-based reminders cannot be created
+- Subtasks are not accessible
+- Attachments cannot be added
+
+## Notes
+
+- Always list reminder lists first and confirm with user before create
+- List names are case-insensitive
+- The CLI uses EventKit for fast, native access to Reminders data
+- Searching by title finds the first matching reminder


### PR DESCRIPTION
Ports productivity-skills to Codex following the creator-skills/dev-skills pattern (#176):

- `productivity-skills/.codex-plugin/plugin.json` at version 5.2.0 pointing at `./codex-skills/`
- Codex-native copies of all seven skills with `name`/`description`-only frontmatter and "Use when" descriptions
- `${CLAUDE_PLUGIN_ROOT}` replaced with a `<plugin-root>` resolution instruction (task-loop pattern)
- Claude-only tool references (AskUserQuestion, Write/Edit tools, /skill slashes) replaced with runtime-neutral wording
- `productivity-skills` registered in `.agents/plugins/marketplace.json`
- The GTD inbox keeps the shared `~/.claude/productivity-skills/inbox.md` path so both runtimes see one inbox

Claude manifest and skill tree are unchanged. The personal-assistant agent is out of scope.

Verified in an isolated `CODEX_HOME`: marketplace discovery, `codex plugin add productivity-skills@cc-toolkit`, and app-server `skills/list` registering all seven namespaced skills from the installed `codex-skills/` tree with the bundled Swift CLI present in the cache.

Closes #177